### PR TITLE
Dockerfile: cache downloaded dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,13 @@ RUN mkdir -p $APP_DIR
 
 WORKDIR $APP_DIR
 
+# Get dependencies.
+COPY go.mod $APP_DIR/
+COPY go.sum $APP_DIR/
+
+RUN go mod download
+
+# Build the app.
 COPY ./ $APP_DIR/
 
 RUN GOOS=linux go build -a -o $APP_NAME ./ && \


### PR DESCRIPTION
This PR updated Dockerfile to extract dependencies download from the building process.
This way we cache a layer with downloaded libraries.

It also updates go to 1.12.5 version. The previous version had some problems with handling libraries replaced in `go.mod` file (e.g. `btcsuite/btcd`).