### PR TITLE
Add function to get address of latest deployed keep

### DIFF
--- a/solidity/contracts/KeepRegistry.sol
+++ b/solidity/contracts/KeepRegistry.sol
@@ -52,4 +52,10 @@ contract KeepRegistry is Ownable {
 
         keeps.push(Keep(msg.sender, keep, KeepTypes.ECDSA));
     }
+
+    //Hacky function to get Keep address of the latest added Keep
+    function getLatestKeepAddress()public view returns (address){
+        require(keeps.length != 0, "There are no recent keeps");
+        return keeps[keeps.length - 1].keepAddress;
+    }
 }


### PR DESCRIPTION
Expose a function to get the address of the most recently deployed `keep` from `keepRegistry`

To be used with [early funding script](https://github.com/keep-network/tbtc/pull/164)