### PR TITLE
GitHub action for contracts publication

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -3,10 +3,9 @@ name: NPM
 on:
   push:
     branches:
-      # TODO: Change `actions-npm` to `master` across the file when it's ready to be merged.
-      - actions-npm
-    # paths:
-    #   - "solidity/contracts/**"
+      - master
+    paths:
+      - "solidity/contracts/**"
 
 jobs:
   publish-contracts:
@@ -19,11 +18,11 @@ jobs:
         with:
           node-version: "11.x"
           registry-url: "https://npm.pkg.github.com"
-      # - name: Publish package
-      #   working-directory: solidity
-      #   run: npm publish
-      #   env:
-      #     NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish package
+        working-directory: solidity
+        run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Bump version
         working-directory: solidity
         run: |


### PR DESCRIPTION
GitHub actions job to publish contracts package to GitHub Package Registry.

The configuration expects two secrets to be configured for the project:
- `GITHUB_TOKEN` - which is a default token [generated automatically](https://help.github.com/en/articles/virtual-environments-for-github-actions#github_token-secret), we use it to push the package to the GitHub Package Registry,
- `CI_GITHUB_TOKEN` - need to be set to a token used to push commits to the repo; we introduced it because `GITHUB_TOKEN` doesn't have permission to push.

This solution would require Heimdall to be allowed to push commit directly to master.

Tasks:
- [x] publish package to GitHub Package Registry
- [x] bump version of the package and commit updated `package.json` and `package-lock.json` files.
- ~~sign Heimdall's commit - this will be covered in https://github.com/keep-network/keep-tecdsa/issues/84~~