### PR TITLE
keep-tecdsa: Use correct PV claim for keep-tecdsa DataDir

### DIFF
--- a/infrastructure/kube/keep-dev/keep-tecdsa-statefulset.yaml
+++ b/infrastructure/kube/keep-dev/keep-tecdsa-statefulset.yaml
@@ -48,7 +48,7 @@ spec:
           claimName: keep-tecdsa-config
       - name: keep-tecdsa-data
         persistentVolumeClaim:
-          claimName: keep-tecdsa-config
+          claimName: keep-tecdsa-data
       initContainers:
       - name: initcontainer-provision-keep-tecdsa
         image: gcr.io/keep-dev-fe24/initcontainer-provision-keep-tecdsa


### PR DESCRIPTION
We were using the incorrect PV claim for the data dir.  While this
didn't result in an outright failure, the disk size is much smaller and
doesn't follow the convention we established for assigning PV claim to
Volume to VolumeMount.

-----

Copy/Paste bit me.  This is already deployed to `keep-dev`.