### PR TITLE
Disabled publishing of contract and client to keep-dev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,19 +222,19 @@ workflows:
           context: keep-dev
           requires:
             - build_client_and_test_go
-      - publish_client:
-          filters:
-            branches:
-              only: master
-          context: keep-dev
-          requires:
-            - build_client_and_test_go
-            - build_initcontainer
-            - migrate_contracts
-      - publish_contract_data:
-          filters:
-            branches:
-              only: master
-          context: keep-dev
-          requires:
-            - migrate_contracts
+#      - publish_client:
+#          filters:
+#            branches:
+#              only: master
+#          context: keep-dev
+#          requires:
+#            - build_client_and_test_go
+#            - build_initcontainer
+#            - migrate_contracts
+#      - publish_contract_data:
+#          filters:
+#            branches:
+#              only: master
+#          context: keep-dev
+#          requires:
+#            - migrate_contracts


### PR DESCRIPTION
It's a temporary change for the purpose of having a stable demo environment. We'll bring it back later when we figure out how to version-tag our deployments properly.