### PR TITLE
Set log level to debug for keep-dev

### DIFF
--- a/infrastructure/kube/keep-dev/keep-tecdsa-statefulset.yaml
+++ b/infrastructure/kube/keep-dev/keep-tecdsa-statefulset.yaml
@@ -36,6 +36,8 @@ spec:
               secretKeyRef:
                 name: eth-account-passphrase
                 key: account-passphrase
+          - name: LOG_LEVEL
+            value: debug
         volumeMounts:
           - name: keep-tecdsa-config
             mountPath: /mnt/keep-tecdsa/config


### PR DESCRIPTION
Set LOG_LEVEL environment variable for keep-tecdsa client run in keep-dev to `debug`. This change is helpful for verification and debugging of the client running in the cluster.