### PR TITLE
Removed eth.KeepAddress alias

### DIFF
--- a/pkg/chain/eth/chain.go
+++ b/pkg/chain/eth/chain.go
@@ -8,9 +8,6 @@ import (
 	"github.com/keep-network/keep-tecdsa/pkg/ecdsa"
 )
 
-// KeepAddress is a keep contract address.
-type KeepAddress = common.Address
-
 // Handle represents a handle to an ethereum blockchain.
 type Handle interface {
 	// Address returns client's ethereum address.
@@ -40,18 +37,18 @@ type ECDSAKeep interface {
 	// OnSignatureRequested is a callback that is invoked when an on-chain
 	// notification of a new signing request for a given keep is seen.
 	OnSignatureRequested(
-		keepAddress KeepAddress,
+		keepAddress common.Address,
 		handler func(event *SignatureRequestedEvent),
 	) (subscription.EventSubscription, error)
 
 	// SubmitKeepPublicKey submits a 64-byte serialized public key to a keep
 	// contract deployed under a given address.
-	SubmitKeepPublicKey(keepAddress KeepAddress, publicKey [64]byte) error // TODO: Add promise *async.KeepPublicKeySubmissionPromise
+	SubmitKeepPublicKey(keepAddress common.Address, publicKey [64]byte) error // TODO: Add promise *async.KeepPublicKeySubmissionPromise
 
 	// SubmitSignature submits a signature to a keep contract deployed under a
 	// given address.
 	SubmitSignature(
-		keepAddress KeepAddress,
+		keepAddress common.Address,
 		digest [32]byte,
 		signature *ecdsa.Signature,
 	) error // TODO: Add promise *async.SignatureSubmissionPromise

--- a/pkg/chain/eth/ethereum/ethereum.go
+++ b/pkg/chain/eth/ethereum/ethereum.go
@@ -56,7 +56,7 @@ func (ec *EthereumChain) OnECDSAKeepCreated(
 // OnSignatureRequested is a callback that is invoked on-chain
 // when a keep's signature is requested.
 func (ec *EthereumChain) OnSignatureRequested(
-	keepAddress eth.KeepAddress,
+	keepAddress common.Address,
 	handler func(event *eth.SignatureRequestedEvent),
 ) (subscription.EventSubscription, error) {
 	keepContract, err := ec.getKeepContract(keepAddress)
@@ -82,7 +82,7 @@ func (ec *EthereumChain) OnSignatureRequested(
 // SubmitKeepPublicKey submits a public key to a keep contract deployed under
 // a given address.
 func (ec *EthereumChain) SubmitKeepPublicKey(
-	keepAddress eth.KeepAddress,
+	keepAddress common.Address,
 	publicKey [64]byte,
 ) error {
 	keepContract, err := ec.getKeepContract(keepAddress)
@@ -112,7 +112,7 @@ func (ec *EthereumChain) getKeepContract(address common.Address) (*abi.ECDSAKeep
 // SubmitSignature submits a signature to a keep contract deployed under a
 // given address.
 func (ec *EthereumChain) SubmitSignature(
-	keepAddress eth.KeepAddress,
+	keepAddress common.Address,
 	digest [32]byte,
 	signature *ecdsa.Signature,
 ) error {

--- a/pkg/chain/eth/local/ecdsa_keep.go
+++ b/pkg/chain/eth/local/ecdsa_keep.go
@@ -3,6 +3,7 @@ package local
 import (
 	"fmt"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/keep-network/keep-tecdsa/pkg/chain/eth"
 )
 
@@ -12,7 +13,7 @@ type localKeep struct {
 	signatureRequestedHandlers map[int]func(event *eth.SignatureRequestedEvent)
 }
 
-func (c *localChain) requestSignature(keepAddress eth.KeepAddress, digest [32]byte) error {
+func (c *localChain) requestSignature(keepAddress common.Address, digest [32]byte) error {
 	c.handlerMutex.Lock()
 	defer c.handlerMutex.Unlock()
 

--- a/pkg/chain/eth/local/ecdsa_keep_factory.go
+++ b/pkg/chain/eth/local/ecdsa_keep_factory.go
@@ -3,10 +3,11 @@ package local
 import (
 	"fmt"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/keep-network/keep-tecdsa/pkg/chain/eth"
 )
 
-func (c *localChain) createKeep(keepAddress eth.KeepAddress) error {
+func (c *localChain) createKeep(keepAddress common.Address) error {
 	c.handlerMutex.Lock()
 	defer c.handlerMutex.Unlock()
 

--- a/pkg/chain/eth/local/ecdsa_keep_factory_test.go
+++ b/pkg/chain/eth/local/ecdsa_keep_factory_test.go
@@ -6,12 +6,12 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/keep-network/keep-tecdsa/pkg/chain/eth"
+	"github.com/ethereum/go-ethereum/common"
 )
 
 func TestCreateKeepDuplicate(t *testing.T) {
 	chain := initializeLocalChain()
-	keepAddress := eth.KeepAddress([20]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1})
+	keepAddress := common.Address([20]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1})
 	expectedError := fmt.Errorf("keep already exists for address [0x0000000000000000000000000000000000000001]")
 
 	err := chain.createKeep(keepAddress)
@@ -31,7 +31,7 @@ func TestCreateKeepDuplicate(t *testing.T) {
 
 func TestCreateKeep(t *testing.T) {
 	chain := initializeLocalChain()
-	keepAddress := eth.KeepAddress([20]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1})
+	keepAddress := common.Address([20]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1})
 	expectedPublicKey := [64]byte{}
 
 	err := chain.createKeep(keepAddress)

--- a/pkg/chain/eth/local/ecdsa_keep_test.go
+++ b/pkg/chain/eth/local/ecdsa_keep_test.go
@@ -8,12 +8,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/keep-network/keep-tecdsa/pkg/chain/eth"
 )
 
 func TestRequestSignatureNonexistentKeep(t *testing.T) {
 	chain := initializeLocalChain()
-	keepAddress := eth.KeepAddress([20]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1})
+	keepAddress := common.Address([20]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1})
 	digest := [32]byte{1}
 	expectedError := fmt.Errorf("failed to find keep with address: [0x0000000000000000000000000000000000000001]")
 
@@ -30,7 +31,7 @@ func TestRequestSignatureNonexistentKeep(t *testing.T) {
 
 func TestRequestSignatureNoHandler(t *testing.T) {
 	chain := initializeLocalChain()
-	keepAddress := eth.KeepAddress([20]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1})
+	keepAddress := common.Address([20]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1})
 	digest := [32]byte{1}
 
 	err := chain.createKeep(keepAddress)
@@ -49,7 +50,7 @@ func TestRequestSignature(t *testing.T) {
 	defer cancel()
 
 	chain := initializeLocalChain()
-	keepAddress := eth.KeepAddress([20]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1})
+	keepAddress := common.Address([20]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1})
 	digest := [32]byte{1}
 	eventEmitted := make(chan *eth.SignatureRequestedEvent)
 	handler := func(event *eth.SignatureRequestedEvent) {

--- a/pkg/chain/eth/local/local.go
+++ b/pkg/chain/eth/local/local.go
@@ -18,7 +18,7 @@ import (
 type localChain struct {
 	handlerMutex sync.Mutex
 
-	keeps map[eth.KeepAddress]*localKeep
+	keeps map[common.Address]*localKeep
 
 	keepCreatedHandlers map[int]func(event *eth.ECDSAKeepCreatedEvent)
 
@@ -29,7 +29,7 @@ type localChain struct {
 // based on provided config.
 func Connect() eth.Handle {
 	return &localChain{
-		keeps:               make(map[eth.KeepAddress]*localKeep),
+		keeps:               make(map[common.Address]*localKeep),
 		keepCreatedHandlers: make(map[int]func(event *eth.ECDSAKeepCreatedEvent)),
 		clientAddress:       common.HexToAddress("6299496199d99941193Fdd2d717ef585F431eA05"),
 	}
@@ -69,7 +69,7 @@ func (lc *localChain) OnECDSAKeepCreated(
 // OnSignatureRequested is a callback that is invoked on-chain
 // when a keep's signature is requested.
 func (lc *localChain) OnSignatureRequested(
-	keepAddress eth.KeepAddress,
+	keepAddress common.Address,
 	handler func(event *eth.SignatureRequestedEvent),
 ) (subscription.EventSubscription, error) {
 	lc.handlerMutex.Lock()
@@ -98,7 +98,7 @@ func (lc *localChain) OnSignatureRequested(
 // SubmitKeepPublicKey checks if public key has been already submitted for given
 // keep address, if not it stores the key in a map.
 func (lc *localChain) SubmitKeepPublicKey(
-	keepAddress eth.KeepAddress,
+	keepAddress common.Address,
 	publicKey [64]byte,
 ) error {
 	keep, ok := lc.keeps[keepAddress]
@@ -124,7 +124,7 @@ func (lc *localChain) SubmitKeepPublicKey(
 // SubmitSignature submits a signature to a keep contract deployed under a
 // given address.
 func (lc *localChain) SubmitSignature(
-	keepAddress eth.KeepAddress,
+	keepAddress common.Address,
 	digest [32]byte,
 	signature *ecdsa.Signature,
 ) error {

--- a/pkg/chain/eth/local/local_test.go
+++ b/pkg/chain/eth/local/local_test.go
@@ -17,7 +17,7 @@ func TestOnECDSAKeepCreated(t *testing.T) {
 
 	chain := initializeLocalChain()
 	eventFired := make(chan *eth.ECDSAKeepCreatedEvent)
-	keepAddress := eth.KeepAddress([20]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1})
+	keepAddress := common.Address([20]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1})
 	expectedEvent := &eth.ECDSAKeepCreatedEvent{
 		KeepAddress: keepAddress,
 	}
@@ -57,7 +57,7 @@ func TestOnSignatureRequested(t *testing.T) {
 
 	chain := initializeLocalChain()
 	eventFired := make(chan *eth.SignatureRequestedEvent)
-	keepAddress := eth.KeepAddress([20]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1})
+	keepAddress := common.Address([20]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1})
 	digest := [32]byte{1}
 
 	err := chain.createKeep(keepAddress)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -98,7 +98,7 @@ func Initialize(
 func registerForSignEvents(
 	ethereumChain eth.Handle,
 	tssNode *node.Node,
-	keepAddress eth.KeepAddress,
+	keepAddress common.Address,
 	signer *tss.ThresholdSigner,
 ) {
 	ethereumChain.OnSignatureRequested(

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -39,7 +39,7 @@ func NewNode(
 // public key is a public key of the signing group. It publishes the public key
 // to the keep. It uses keep address as unique signing group identifier.
 func (n *Node) GenerateSignerForKeep(
-	keepAddress eth.KeepAddress,
+	keepAddress common.Address,
 	keepMembers []common.Address,
 ) (*tss.ThresholdSigner, error) {
 	groupMemberIDs := []tss.MemberID{}

--- a/pkg/registry/keeps.go
+++ b/pkg/registry/keeps.go
@@ -6,14 +6,13 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/keep-network/keep-common/pkg/persistence"
-	"github.com/keep-network/keep-tecdsa/pkg/chain/eth"
 	"github.com/keep-network/keep-tecdsa/pkg/ecdsa/tss"
 )
 
 // Keeps represents a collection of keeps in which the given client is a member.
 type Keeps struct {
 	myKeepsMutex *sync.RWMutex
-	myKeeps      map[eth.KeepAddress][]*tss.ThresholdSigner
+	myKeeps      map[common.Address][]*tss.ThresholdSigner
 
 	storage storage
 }
@@ -22,7 +21,7 @@ type Keeps struct {
 func NewKeepsRegistry(persistence persistence.Handle) *Keeps {
 	return &Keeps{
 		myKeepsMutex: &sync.RWMutex{},
-		myKeeps:      make(map[eth.KeepAddress][]*tss.ThresholdSigner),
+		myKeeps:      make(map[common.Address][]*tss.ThresholdSigner),
 		storage:      newStorage(persistence),
 	}
 }


### PR DESCRIPTION
Removed eth.KeepAddress alias as it was unnecessary. There is no need to use this alias across the implementation. `common.Address` type should be used instead.