### PR TITLE
Released version of keep-ecdsa contracts 0.1.7

### DIFF
--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "0.1.2",
+  "version": "0.1.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "0.1.2",
+  "version": "0.1.7",
   "description": "Smart contracts for ECDSA Keep",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Set version of `keep-ecdsa` contracts package to match the latest tag version in the repository.
The changes to contracts included in this version are early work on bonding.
The major reason for this change is to start a new prerelease version.
This change should fix problems with auto-publishing of prerelease versions to NPM package repository we're having here: https://github.com/keep-network/keep-tecdsa/actions?query=workflow%3ANPM