### PR TITLE
Seize bond

### DIFF
--- a/solidity/contracts/KeepBonding.sol
+++ b/solidity/contracts/KeepBonding.sol
@@ -76,7 +76,7 @@ contract KeepBonding {
       lockedBonds[bondID] = 0;
    }
 
-   /// @notice Seizes the bond by moving some or all of a locked bond to holder's 
+   /// @notice Seizes the bond by moving some or all of a locked bond to holder's
    /// account.
    /// @dev Function requires that a caller is the holder of the bond which is
    /// being seized.
@@ -84,6 +84,8 @@ contract KeepBonding {
    /// @param referenceID Reference ID of the bond.
    /// @param amount Amount to be seized.
    function seizeBond(address operator, uint256 referenceID, uint256 amount) public {
+      require(amount > 0, "Requested amount should be greater than zero");
+
       address payable holder = msg.sender;
       bytes32 bondID = keccak256(abi.encodePacked(operator, holder, referenceID));
 

--- a/solidity/test/KeepBondingTest.js
+++ b/solidity/test/KeepBondingTest.js
@@ -281,21 +281,12 @@ contract('KeepBonding', (accounts) => {
             expect(lockedBonds).to.eq.BN(remainingBond, 'unexpected remaining bond value')
         })
 
-        it('accepts seized amount equal zero', async () => {
+        it('fails if seized amount equals zero', async () => {
             const amount = new BN(0)
-            let expectedBalance = web3.utils.toBN(await web3.eth.getBalance(holder))
-
-            const tx = await keepBonding.seizeBond(operator, reference, amount, { from: holder })
-
-            const gasPrice = web3.utils.toBN(await web3.eth.getGasPrice())
-            const txCost = gasPrice.mul(web3.utils.toBN(tx.receipt.gasUsed))
-            expectedBalance = expectedBalance.sub(txCost)
-
-            const actualBalance = await web3.eth.getBalance(holder)
-            expect(actualBalance).to.eq.BN(expectedBalance, 'invalid holder\'s account balance')
-
-            const lockedBonds = await keepBonding.getLockedBonds(holder, operator, reference)
-            expect(lockedBonds).to.eq.BN(bondValue, 'unexpected remaining bond value')
+            await expectRevert(
+                keepBonding.seizeBond(operator, reference, amount, { from: holder }),
+                "Requested amount should be greater than zero"
+            )
         })
 
         it('fails if seized amount is greater than bond value', async () => {


### PR DESCRIPTION
This PR implements a function to seize a bond to holder's account.

As per the [spec](https://github.com/keep-network/keep-tecdsa/blob/0436373b4ace31c65c17a98d7509752c6a54899d/docs/selection.adoc#assigned-bonds):
> The holder of a bond can seize some or all of a locked bond by calling seizeBond(operator, reference, amount). The specified amount must be equal or less than the bond at lockedBonds[operator, holder, reference]. The amount is subtracted from the bond and transferred to the holder.

Refs: https://github.com/keep-network/keep-tecdsa/issues/128