### PR TITLE
Circle CI fix migrations config for private npm package

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -211,9 +211,9 @@ workflows:
           requires:
             - setup_github_package_registry
       - migrate_contracts:
-          # filters:
-          #   branches:
-          #     only: master
+          filters:
+            branches:
+              only: master
           context: keep-dev
           requires:
             - build_client_and_test_go


### PR DESCRIPTION
For `migrate_contracts` we require `setup_github_package_registry` job to be executed. The job stores github token in .npmrc file which we persist to a workspace. With this change, we will attach the workspace to the migrations job so packages can be imported from private github's packages for `@keep-network` scope.