### PR TITLE
keep-dev: Deploy 0.6.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -213,21 +213,21 @@ workflows:
       - migrate_contracts:
           filters:
             branches:
-              only: master
+              only: sthompson22/keep-dev/deploy-v0.6.0
           context: keep-dev
           requires:
             - build_client_and_test_go
       - build_initcontainer:
           filters:
             branches:
-              only: master
+              only: sthompson22/keep-dev/deploy-v0.6.0
           context: keep-dev
           requires:
             - migrate_contracts
       - publish_client:
           filters:
             branches:
-              only: master
+              only: sthompson22/keep-dev/deploy-v0.6.0
           context: keep-dev
           requires:
             - build_client_and_test_go
@@ -236,7 +236,7 @@ workflows:
       - publish_contract_data:
           filters:
             branches:
-              only: master
+              only: sthompson22/keep-dev/deploy-v0.6.0
           context: keep-dev
           requires:
             - migrate_contracts


### PR DESCRIPTION
We want to test out this tag against keep-dev.  Master has already
evolved so we need to do this explicitly.

----

Drafting so builds actually fire.