### PR TITLE
Bump up version of contracts package to 0.7.0

### DIFF
--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "0.1.8",
+  "version": "0.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "0.1.8",
+  "version": "0.7.0",
   "description": "Smart contracts for ECDSA Keep",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This version contains updates to interfaces factory and vendor interfaces described in https://github.com/keep-network/keep-tecdsa/pull/154

- openKeep function accepts _bond parameter
- implement proxy pattern for vendor contract
- remove KeepRegistry contract
- ECDSAKeepVendor is now named BondedECDSAKeepVendor
- public interfaces have been renamed accordingly:
  - IECDSAKeepVendor -> IBondedECDSAKeepVendor
  - IECDSAKeep -> IBondedECDSAKeep
  - IECDSAKeepFactory -> IBondedECDSAKeepFactory