### PR TITLE
Added stub implementation of IBondedECDSAKeep functions to ECDSAKeep

### DIFF
--- a/solidity/contracts/ECDSAKeep.sol
+++ b/solidity/contracts/ECDSAKeep.sol
@@ -77,6 +77,12 @@ contract ECDSAKeep is IBondedECDSAKeep, Ownable {
        return publicKey;
     }
 
+    /// @notice Returns the amount of the keep's ETH bond in wei.
+    /// @return The amount of the keep's ETH bond in wei.
+    function checkBondAmount() external view returns (uint256) {
+        // TODO: Implement
+    }
+
     /// @notice Calculates a signature over provided digest by the keep.
     /// @dev Only one signing process can be in progress at a time.
     /// @param _digest Digest to be signed.
@@ -181,5 +187,29 @@ contract ECDSAKeep is IBondedECDSAKeep, Ownable {
         for(uint16 i = 0; i < memberCount; i++){
             token.transferFrom(msg.sender, members[i], dividend);
         }
+    }
+
+    // @notice Seizes the signer's ETH bond.
+    function seizeSignerBonds() external returns (bool) {
+        // TODO: Implement
+        // onlyKeepOwner
+        // msg.sender.transfer(bondAmount)
+    }
+
+    // @notice Submits a fraud proof for a valid signature from this keep that was
+    //         not first approved via a call to sign.
+    // @return Error if not fraud, true if fraud.
+    function submitSignatureFraud(
+        uint8 _v,
+        bytes32 _r,
+        bytes32 _s,
+        bytes32 _signedDigest,
+        bytes calldata _preimage
+    ) external returns (bool _isFraud) {
+        // TODO: Implement
+        // Expected behavior:
+        // Error if not fraud
+        // Return true if fraud
+        // This means if the signature is valid, but was not approved via sign.
     }
 }


### PR DESCRIPTION
We added new functions to the `IBondedECDASKeep` interface (https://github.com/keep-network/keep-tecdsa/pull/165). Here we add stub implementations of the functions to ECDSAKeep so compilation and tests pass.