### PR TITLE
Automatic chain events resubscriptions

### DIFF
--- a/pkg/chain/eth/ethereum/ecdsa_keep.go
+++ b/pkg/chain/eth/ethereum/ecdsa_keep.go
@@ -3,12 +3,77 @@ package ethereum
 import (
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/keep-network/keep-core/pkg/subscription"
 	"github.com/keep-network/keep-tecdsa/pkg/chain/eth/gen/abi"
 )
 
 func (ec *EthereumChain) watchSignatureRequested(
+	keepContract *abi.ECDSAKeep,
+	success func(event *abi.ECDSAKeepSignatureRequested),
+	fail func(err error) error,
+) (subscription.EventSubscription, error) {
+	errorChan := make(chan error)
+	unsubscribeChan := make(chan struct{})
+
+	// Delay which must be preserved before a new resubscription attempt.
+	// There is no sense to resubscribe immediately after the fail of current
+	// subscription because the publisher must have some time to recover.
+	retryDelay := 5 * time.Second
+
+	watch := func() {
+		failCallback := func(err error) error {
+			fail(err)
+			errorChan <- err // trigger resubscription signal
+			return err
+		}
+
+		subscription, err := ec.subscribeSignatureRequested(
+			keepContract,
+			success,
+			failCallback,
+		)
+		if err != nil {
+			errorChan <- err // trigger resubscription signal
+			return
+		}
+
+		// wait for unsubscription signal
+		<-unsubscribeChan
+		subscription.Unsubscribe()
+	}
+
+	// trigger the resubscriber goroutine
+	go func() {
+		go watch() // trigger first subscription
+
+		for {
+			select {
+			case <-errorChan:
+				logger.Warning(
+					"subscription to event SignatureRequested terminated with error; " +
+						"resubscription attempt will be performed after the retry delay",
+				)
+				time.Sleep(retryDelay)
+				go watch()
+			case <-unsubscribeChan:
+				// shutdown the resubscriber goroutine on unsubscribe signal
+				return
+			}
+		}
+	}()
+
+	// closing the unsubscribeChan will trigger a unsubscribe signal and
+	// run unsubscription for all subscription instances
+	unsubscribeCallback := func() {
+		close(unsubscribeChan)
+	}
+
+	return subscription.NewEventSubscription(unsubscribeCallback), nil
+}
+
+func (ec *EthereumChain) subscribeSignatureRequested(
 	keepContract *abi.ECDSAKeep,
 	success func(event *abi.ECDSAKeepSignatureRequested),
 	fail func(err error) error,

--- a/pkg/chain/eth/ethereum/ecdsa_keep_factory.go
+++ b/pkg/chain/eth/ethereum/ecdsa_keep_factory.go
@@ -3,12 +3,75 @@ package ethereum
 import (
 	"fmt"
 	"sync"
+	"time"
 
 	"github.com/keep-network/keep-core/pkg/subscription"
 	"github.com/keep-network/keep-tecdsa/pkg/chain/eth/gen/abi"
 )
 
 func (ec *EthereumChain) watchECDSAKeepCreated(
+	success func(event *abi.ECDSAKeepFactoryECDSAKeepCreated),
+	fail func(err error) error,
+) (subscription.EventSubscription, error) {
+	errorChan := make(chan error)
+	unsubscribeChan := make(chan struct{})
+
+	// Delay which must be preserved before a new resubscription attempt.
+	// There is no sense to resubscribe immediately after the fail of current
+	// subscription because the publisher must have some time to recover.
+	retryDelay := 5 * time.Second
+
+	watch := func() {
+		failCallback := func(err error) error {
+			fail(err)
+			errorChan <- err // trigger resubscription signal
+			return err
+		}
+
+		subscription, err := ec.subscribeECDSAKeepCreated(
+			success,
+			failCallback,
+		)
+		if err != nil {
+			errorChan <- err // trigger resubscription signal
+			return
+		}
+
+		// wait for unsubscription signal
+		<-unsubscribeChan
+		subscription.Unsubscribe()
+	}
+
+	// trigger the resubscriber goroutine
+	go func() {
+		go watch() // trigger first subscription
+
+		for {
+			select {
+			case <-errorChan:
+				logger.Warning(
+					"subscription to event ECDSAKeepCreated terminated with error; " +
+						"resubscription attempt will be performed after the retry delay",
+				)
+				time.Sleep(retryDelay)
+				go watch()
+			case <-unsubscribeChan:
+				// shutdown the resubscriber goroutine on unsubscribe signal
+				return
+			}
+		}
+	}()
+
+	// closing the unsubscribeChan will trigger a unsubscribe signal and
+	// run unsubscription for all subscription instances
+	unsubscribeCallback := func() {
+		close(unsubscribeChan)
+	}
+
+	return subscription.NewEventSubscription(unsubscribeCallback), nil
+}
+
+func (ec *EthereumChain) subscribeECDSAKeepCreated(
 	success func(event *abi.ECDSAKeepFactoryECDSAKeepCreated),
 	fail func(err error) error,
 ) (subscription.EventSubscription, error) {


### PR DESCRIPTION
Implemented some logic that allows resubscribing to chain events (ECDSAKeepCreated and SignatureRequested) when current subscriptions are interrupted and terminate with an error.

The solution is taken from https://github.com/keep-network/keep-core/pull/1202