### PR TITLE
Fixing fraud proof hashing

### DIFF
--- a/solidity/contracts/ECDSAKeep.sol
+++ b/solidity/contracts/ECDSAKeep.sol
@@ -220,13 +220,13 @@ contract ECDSAKeep is IBondedECDSAKeep, Ownable {
 
     /// @notice Submits a fraud proof for a valid signature from this keep that was
     /// not first approved via a call to sign.
-    /// @dev The function expects the signed digest to be calculated as a double
-    /// sha256 hash (hash256) of the preimage: `sha256(sha256(_preimage))`.
+    /// @dev The function expects the signed digest to be calculated as a sha256 hash
+    /// of the preimage: `sha256(_preimage))`.
     /// @param _v Signature's header byte: `27 + recoveryID`.
     /// @param _r R part of ECDSA signature.
     /// @param _s S part of ECDSA signature.
     /// @param _signedDigest Digest for the provided signature. Result of hashing
-    /// the preimage.
+    /// the preimage with sha256.
     /// @param _preimage Preimage of the hashed message.
     /// @return True if fraud, error otherwise.
     function submitSignatureFraud(

--- a/solidity/test/ECDSAKeepTest.js
+++ b/solidity/test/ECDSAKeepTest.js
@@ -449,7 +449,7 @@ contract('ECDSAKeep', (accounts) => {
 
     const publicKey1 = '0x9a0544440cc47779235ccb76d669590c2cd20c7e431f97e17a1093faf03291c473e661a208a8a565ca1e384059bd2ff7ff6886df081ff1229250099d388c83df'
     const preimage1 = '0xfdaf2feee2e37c24f2f8d15ad5814b49ba04b450e67b859976cbf25c13ea90d8'
-    // hash256Digest1 = sha256(abi.encodePacked(sha256(preimage1)))
+    // hash256Digest1 = sha256(preimage1)
     const hash256Digest1 = '0x8bacaa8f02ef807f2f61ae8e00a5bfa4528148e0ae73b2bd54b71b8abe61268e'
 
     const signature1 = {


### PR DESCRIPTION
In this PR we need to change code around  `_preimage` hash validation. Instead of double hashing, we can hash once and compare it to `_signedDigest`.