### PR TITLE
ECDSAKeep Rewards

### DIFF
--- a/pkg/chain/eth/chain.go
+++ b/pkg/chain/eth/chain.go
@@ -88,11 +88,18 @@ type BondedECDSAKeep interface {
 		signature *ecdsa.Signature,
 	) error // TODO: Add promise *async.SignatureSubmissionPromise
 
-	// OnKeepClosed is a callback that is invoked when a notification is sent
-	// about the closed keep.
+	// OnKeepClosed installs a callback that will be called on closing the
+	// given keep.
 	OnKeepClosed(
 		keepAddress common.Address,
 		handler func(event *KeepClosedEvent),
+	) (subscription.EventSubscription, error)
+
+	// OnKeepTerminated installs a callback that will be called on terminating
+	// the given keep.
+	OnKeepTerminated(
+		keepAddress common.Address,
+		handler func(event *KeepTerminatedEvent),
 	) (subscription.EventSubscription, error)
 
 	// IsAwaitingSignature checks if the keep is waiting for a signature to be

--- a/pkg/chain/eth/ethereum/ethereum.go
+++ b/pkg/chain/eth/ethereum/ethereum.go
@@ -3,8 +3,8 @@ package ethereum
 
 import (
 	"fmt"
-	"time"
 	"math/big"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 
@@ -70,22 +70,38 @@ func (ec *EthereumChain) OnKeepClosed(
 	keepAddress common.Address,
 	handler func(event *eth.KeepClosedEvent),
 ) (subscription.EventSubscription, error) {
-		keepContract, err := ec.getKeepContract(keepAddress)
-		if err != nil {
-			return nil, fmt.Errorf("failed to create contract abi: [%v]", err)
-		}
-		return keepContract.WatchKeepClosed(
-			func(
-				blockNumber uint64,
-			) {
-				handler(&eth.KeepClosedEvent{})
-			},
-			func(err error) error {
-				return fmt.Errorf("keep closed callback failed: [%v]", err)
-			},
+	keepContract, err := ec.getKeepContract(keepAddress)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create contract abi: [%v]", err)
+	}
+	return keepContract.WatchKeepClosed(
+		func(blockNumber uint64) {
+			handler(&eth.KeepClosedEvent{})
+		},
+		func(err error) error {
+			return fmt.Errorf("keep closed callback failed: [%v]", err)
+		},
 	)
 }
-		
+
+// OnKeepTerminated is a callback that is invoked on-chain when keep is terminated.
+func (ec *EthereumChain) OnKeepTerminated(
+	keepAddress common.Address,
+	handler func(event *eth.KeepTerminatedEvent),
+) (subscription.EventSubscription, error) {
+	keepContract, err := ec.getKeepContract(keepAddress)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create contract abi: [%v]", err)
+	}
+	return keepContract.WatchKeepTerminated(
+		func(blockNumber uint64) {
+			handler(&eth.KeepTerminatedEvent{})
+		},
+		func(err error) error {
+			return fmt.Errorf("keep terminated callback failed: [%v]", err)
+		},
+	)
+}
 
 // OnPublicKeyPublished is a callback that is invoked when an on-chain
 // event of a published public key was emitted.
@@ -177,7 +193,7 @@ func (ec *EthereumChain) SubmitKeepPublicKey(
 	if err != nil {
 		return err
 	}
-	
+
 	submitPubKey := func() error {
 		transaction, err := keepContract.SubmitPublicKey(
 			publicKey[:],
@@ -188,11 +204,11 @@ func (ec *EthereumChain) SubmitKeepPublicKey(
 		if err != nil {
 			return err
 		}
-		
+
 		logger.Debugf("submitted SubmitPublicKey transaction with hash: [%x]", transaction.Hash())
 		return nil
 	}
-	
+
 	// There might be a scenario, when a public key submission fails because of
 	// a new cloned contract has not been registered by the ethereum node. Common
 	// case is when Ethereum nodes are behind a load balancer and not fully synced

--- a/pkg/chain/eth/event.go
+++ b/pkg/chain/eth/event.go
@@ -10,8 +10,12 @@ type BondedECDSAKeepCreatedEvent struct {
 	Members     []common.Address // keep members addresses
 }
 
-// KeepClosedEvent is an event emitted on a closing keep.
+// KeepClosedEvent is an event emitted when a keep has been closed.
 type KeepClosedEvent struct {
+}
+
+// KeepTerminatedEvent is an event emitted when a keep has been terminated.
+type KeepTerminatedEvent struct {
 }
 
 // IsMember checks if list of members contains the given address.
@@ -34,7 +38,7 @@ type SignatureRequestedEvent struct {
 // the members of a keep has submitted a key that does not match the keys submitted
 // so far by other members.
 type ConflictingPublicKeySubmittedEvent struct {
-	SubmittingMember common.Address
+	SubmittingMember     common.Address
 	ConflictingPublicKey []byte
 }
 

--- a/pkg/chain/eth/local/local.go
+++ b/pkg/chain/eth/local/local.go
@@ -169,13 +169,19 @@ func (lc *localChain) UpdateStatusForApplication(application common.Address) err
 	panic("implement")
 }
 
-// OnKeepClosed archives key shares and unsubscibes from events.
 func (lc *localChain) OnKeepClosed(
 	keepAddress common.Address,
 	handler func(event *eth.KeepClosedEvent),
 ) (subscription.EventSubscription, error) {
 	panic("implement")
-} 
+}
+
+func (lc *localChain) OnKeepTerminated(
+	keepAddress common.Address,
+	handler func(event *eth.KeepTerminatedEvent),
+) (subscription.EventSubscription, error) {
+	panic("implement")
+}
 
 // OnConflictingPublicKeySubmitted logs mismatched public keys submitted by
 // members of a keep.

--- a/solidity/contracts/BondedECDSAKeep.sol
+++ b/solidity/contracts/BondedECDSAKeep.sol
@@ -101,9 +101,13 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
     // Notification that ERC20 reward has been distributed to keep members.
     event ERC20RewardDistributed();
 
-    // Notification that the keep was closed by the owner. Members no longer need
-    // to support it.
+    // Notification that the keep has been closed by the owner.
+    // Members no longer need to support this keep.
     event KeepClosed();
+
+    // Notification that the keep has been terminated by the owner.
+    // Members no longer need to support this keep.
+    event KeepTerminated();
 
     // Notification that the signature has been calculated. Contains a digest which
     // was used for signature calculation and a signature in a form of r, s and
@@ -507,7 +511,7 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
         );
 
         status = Status.Terminated;
-        emit KeepClosed();
+        emit KeepTerminated();
     }
 
     /// @notice Returns bonds to the keep members.

--- a/solidity/contracts/BondedECDSAKeep.sol
+++ b/solidity/contracts/BondedECDSAKeep.sol
@@ -271,7 +271,7 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
     /// The application may decide to return part of bonds later after they are
     /// processed using returnPartialSignerBonds function.
     function seizeSignerBonds() external onlyOwner onlyWhenActive {
-        markAsTerminated();();
+        markAsTerminated();
 
         for (uint256 i = 0; i < members.length; i++) {
             uint256 amount = keepBonding.bondAmount(
@@ -507,9 +507,6 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
         );
 
         status = Status.Terminated;
-
-        keepFactory.notifyKeepClosed();
-
         emit KeepClosed();
     }
 

--- a/solidity/contracts/BondedECDSAKeepFactory.sol
+++ b/solidity/contracts/BondedECDSAKeepFactory.sol
@@ -478,7 +478,7 @@ contract BondedECDSAKeepFactory is IBondedECDSAKeepFactory, CloneFactory {
 
     /// @notice Slashes keep members' KEEP tokens. For each keep member it slashes
     /// amount equal to the minimum stake configured for this factory.
-    function slashKeepMembers() public onlyKeep {
+    function slashKeepMembers() public onlyActiveKeep {
         BondedECDSAKeep keep = BondedECDSAKeep(msg.sender);
 
         tokenStaking.slash(minimumStake, keep.getMembers());
@@ -486,7 +486,7 @@ contract BondedECDSAKeepFactory is IBondedECDSAKeepFactory, CloneFactory {
 
     /// @notice Checks if the caller is a keep created by this factory.
     /// @dev Throws an error if called by any account other than a keep.
-    modifier onlyKeep() {
+    modifier onlyActiveKeep() {
         require(
             creationTime[msg.sender] != 0 && BondedECDSAKeep(msg.sender).isActive(),
             "Caller is not an active keep created by this factory"

--- a/solidity/contracts/BondedECDSAKeepFactory.sol
+++ b/solidity/contracts/BondedECDSAKeepFactory.sol
@@ -447,7 +447,8 @@ contract BondedECDSAKeepFactory is IBondedECDSAKeepFactory, CloneFactory {
     }
 
     /// @notice Gets the creation timestamp of a given keep.
-    /// @return Timestamp the given keep was created at.
+    /// @return Timestamp the given keep was created at or 0 if this keep
+    /// was not created by this factory.
     function getCreationTime(address _keep) external view returns (uint256) {
         return creationTime[_keep];
     }

--- a/solidity/contracts/BondedECDSAKeepVendorImplV1.sol
+++ b/solidity/contracts/BondedECDSAKeepVendorImplV1.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.5.4;
 
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
-import "@keep-network/keep-core/contracts/Registry.sol";
+import "@keep-network/keep-core/contracts/KeepRegistry.sol";
 import "./api/IBondedECDSAKeepVendor.sol";
 
 /// @title Bonded ECDSA Keep Vendor
@@ -13,7 +13,7 @@ contract BondedECDSAKeepVendorImplV1 is IBondedECDSAKeepVendor, Ownable {
 
     // Registry contract with a list of approved factories (operator contracts)
     // and upgraders.
-    Registry internal registry;
+    KeepRegistry internal registry;
 
     // Address of ECDSA keep factory.
     address payable keepFactory;

--- a/solidity/contracts/ECDSAKeepRewards.sol
+++ b/solidity/contracts/ECDSAKeepRewards.sol
@@ -67,7 +67,7 @@ contract ECDSAKeepRewards {
     // `totalRewards.sub(paidOutRewards)`
     uint256 paidOutRewards;
 
-    // Length of one interval.
+    // Length of one interval in seconds (timestamp diff).
     uint256 termLength;
     // Timestamp of first interval beginning.
     uint256 firstIntervalStart;
@@ -81,15 +81,9 @@ contract ECDSAKeepRewards {
     // Mapping of interval number to tokens allocated for the interval.
     uint256[] intervalAllocations;
 
-    // Total number of intervals. (Implicit in intervalWeights)
-    // uint256 termCount = intervalWeights.length;
-
     // mapping of keeps to booleans.
     // True if the keep has been used to claim a reward.
     mapping(address => bool) claimed;
-
-    // Array of timestamps marking interval's end.
-    uint256[] intervalEndpoints;
 
     // Mapping of interval to number of keeps created in/before the interval
     mapping(uint256 => uint256) keepsByInterval;

--- a/solidity/contracts/ECDSAKeepRewards.sol
+++ b/solidity/contracts/ECDSAKeepRewards.sol
@@ -18,7 +18,7 @@ contract ECDSAKeepRewards {
     uint256 initiated;
 
     // Minimum number of keep submissions for each interval.
-    uint256 minimumSubmissions;
+    uint256 minimumKeepsPerInterval;
 
     // Array representing the percentage of unallocated rewards
     // available for each reward interval.
@@ -49,7 +49,7 @@ contract ECDSAKeepRewards {
         uint256 _termLength,
         uint256 _totalRewards,
         address _keepToken,
-        uint256 _minimumSubmissions,
+        uint256 _minimumKeepsPerInterval,
         address factoryAddress,
         uint256 _initiated,
         uint256[] memory _intervalWeights
@@ -60,7 +60,7 @@ contract ECDSAKeepRewards {
        unallocatedRewards = totalRewards;
        termLength = _termLength;
        initiated = _initiated;
-       minimumSubmissions = _minimumSubmissions;
+       minimumKeepsPerInterval = _minimumKeepsPerInterval;
        factory = IBondedECDSAKeepFactory(factoryAddress);
        intervalWeights = _intervalWeights;
     }
@@ -115,7 +115,7 @@ contract ECDSAKeepRewards {
         newInterval - intervalEndpoints[intervalEndpointsLength - 1];
 
         intervalSubmissions[intervalEndpointsLength] = totalSubmissions;
-        if (totalSubmissions < minimumSubmissions){
+        if (totalSubmissions < minimumKeepsPerInterval){
             if(intervalEndpointsLength >= intervalWeights.length){
                 return newInterval;
             }
@@ -281,6 +281,16 @@ contract ECDSAKeepRewards {
 
    function keepsInInterval(uint256 interval) public returns (uint256) {
        return (getEndpoint(interval) - getPreviousEndpoint(interval));
+   }
+
+   function keepCountAdjustment(uint256 interval) public returns (uint256) {
+       uint256 minimumKeeps = minimumKeepsPerInterval;
+       uint256 keepCount = keepsInInterval(interval);
+       if (keepCount >= minimumKeeps) {
+           return 100;
+       } else {
+           return 100 * keepCount / minimumKeeps;
+       }
    }
 
    function getIntervalWeight(uint256 interval) public view returns (uint256) {

--- a/solidity/contracts/ECDSAKeepRewards.sol
+++ b/solidity/contracts/ECDSAKeepRewards.sol
@@ -35,13 +35,14 @@ contract ECDSAKeepRewards {
         uint256 _totalRewards,
         address _keepToken,
         uint256 _minimumSubmissions,
-        address factoryAddress
+        address factoryAddress,
+        uint256 _initiated
     )
     public {
        keepToken = IERC20(_keepToken);
        totalRewards = _totalRewards;
        termLength = _termLength;
-       initiated = block.timestamp;
+       initiated = _initiated;
        minimumSubmissions = _minimumSubmissions;
        factory = IBondedECDSAKeepFactory(factoryAddress);
     }
@@ -180,6 +181,26 @@ contract ECDSAKeepRewards {
 
    function currentTime() public view returns (uint256) {
        return block.timestamp;
+   }
+
+   /// @notice Return the interval number
+   /// the provided timestamp falls within.
+   /// @dev Reverts if the timestamp is before `initiated`.
+   /// @param timestamp The timestamp whose interval is queried.
+   /// @return The interval of the timestamp.
+   function intervalOf(uint256 timestamp) public view returns (uint256) {
+       uint256 _initiated = initiated;
+       uint256 _termLength = termLength;
+
+       require(
+           timestamp >= _initiated,
+           "Timestamp is before the first interval"
+       );
+
+       uint256 difference = timestamp - _initiated;
+       uint256 interval = difference / _termLength;
+
+       return interval;
    }
 }
 

--- a/solidity/contracts/ECDSAKeepRewards.sol
+++ b/solidity/contracts/ECDSAKeepRewards.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.5.4;
 import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/SafeERC20.sol";
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+import "keep-network/keep-core/contracts/Rewards.sol";
 
 /// @title ECDSAKeepRewards
 /// @dev A contract for distributing KEEP token rewards to ECDSA keeps.
@@ -51,46 +52,9 @@ import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 /// that fact can be reported to the reward contract.
 /// Reporting a terminated keep returns its allocated reward
 /// to the pool of unallocated rewards.
-contract ECDSAKeepRewards {
-    using SafeMath for uint256;
-    using SafeERC20 for IERC20;
-
-    IERC20 token;
+contract ECDSAKeepRewards is Rewards {
+    uint256 constant MAX_UINT20 = 1 << 20 - 1;
     IBondedECDSAKeepFactory factory;
-
-    // Total number of keep tokens to distribute.
-    uint256 totalRewards;
-    // Rewards that haven't been allocated to finished intervals
-    uint256 unallocatedRewards;
-    // Rewards that have been paid out;
-    // `token.balanceOf(address(this))` should always equal
-    // `totalRewards.sub(paidOutRewards)`
-    uint256 paidOutRewards;
-
-    // Length of one interval in seconds (timestamp diff).
-    uint256 termLength;
-    // Timestamp of first interval beginning.
-    uint256 firstIntervalStart;
-
-    // Minimum number of keep submissions for each interval.
-    uint256 minimumKeepsPerInterval;
-
-    // Array representing the percentage of unallocated rewards
-    // available for each reward interval.
-    uint256[] intervalWeights; // percent array
-    // Mapping of interval number to tokens allocated for the interval.
-    uint256[] intervalAllocations;
-
-    // mapping of keeps to booleans.
-    // True if the keep has been used to claim a reward.
-    mapping(address => bool) claimed;
-
-    // Mapping of interval to number of keeps created in/before the interval
-    mapping(uint256 => uint256) keepsByInterval;
-
-    // Mapping of interval to number of keeps whose rewards have been paid out,
-    // or reallocated because the keep closed unhappily
-    mapping(uint256 => uint256) intervalKeepsProcessed;
 
     constructor (
         uint256 _termLength,
@@ -99,416 +63,53 @@ contract ECDSAKeepRewards {
         address factoryAddress,
         uint256 _firstIntervalStart,
         uint256[] memory _intervalWeights
-    )
-    public {
-       token = IERC20(_token);
-       termLength = _termLength;
-       firstIntervalStart = _firstIntervalStart;
-       minimumKeepsPerInterval = _minimumKeepsPerInterval;
+    ) public Rewards(
+        _termLength,
+        _token,
+        _minimumKeepsPerInterval,
+        _firstIntervalStart,
+        _intervalWeights
+    ) {
        factory = IBondedECDSAKeepFactory(factoryAddress);
-       intervalWeights = _intervalWeights;
     }
 
-    /// @notice `approveAndCall` funds the rewards contract.
-    /// @dev Adds the received amount of tokens
-    /// to `totalRewards` and `unallocatedRewards`.
-    /// May be called at any time, even after allocating some intervals.
-    /// Changes to `unallocatedRewards`
-    /// will take effect on subsequent interval allocations.
-    /// If the reward contract has received tokens outside `approveAndCall`,
-    /// this collects them as well.
-    function receiveApproval(
-        address _from,
-        uint256 _value,
-        address _token,
-        bytes memory
-    ) public {
-        require(IERC20(_token) == token, "Unsupported token");
-
-        token.safeTransferFrom(_from, address(this), _value);
-
-        uint256 currentBalance = token.balanceOf(address(this));
-        uint256 beforeBalance = _unpaidRewards();
-        require(
-            currentBalance >= beforeBalance,
-            "Reward contract has lost tokens"
-        );
-
-        uint256 addedBalance = currentBalance.sub(beforeBalance);
-
-        totalRewards += addedBalance;
-        unallocatedRewards += addedBalance;
-    }
-
-    /// @notice Sends the reward for a keep to the keep members.
-    /// @param keepAddress ECDSA keep factory address.
-    function receiveReward(address keepAddress)
-        factoryMustRecognize(keepAddress)
-        rewardsNotClaimed(keepAddress)
-        mustBeClosed(keepAddress)
-        public
-    {
-        _processKeep(true, keepAddress);
-    }
-
-    function reportTermination(address keepAddress)
-        factoryMustRecognize(keepAddress)
-        rewardsNotClaimed(keepAddress)
-        mustBeTerminated(keepAddress)
-        public
-    {
-        _processKeep(false, keepAddress);
-    }
-
-    /// @notice Checks if a keep is eligible to receive rewards.
-    /// @dev Keeps that close dishonorably or early are not eligible for rewards.
-    /// @param _keep The keep to check.
-    /// @return True if the keep is eligible, false otherwise
-    function eligibleForReward(address _keep) public view returns (bool){
-        bool _claimed = _rewardClaimed(_keep);
-        bool closed = _isClosed(_keep);
-        bool recognized = _recognizedByFactory(_keep);
-        return !_claimed && closed && recognized;
-    }
-
-    /// @notice Checks if a keep is terminated
-    /// and thus its rewards can be returned to the unallocated pool.
-    /// @param _keep The keep to check.
-    /// @return True if the keep is terminated, false otherwise
-    function eligibleButTerminated(address _keep) public view returns (bool) {
-        bool _claimed = _rewardClaimed(_keep);
-        bool terminated = _isTerminated(_keep);
-        bool recognized = _recognizedByFactory(_keep);
-        return !_claimed && terminated && recognized;
-    }
-
-    /// @notice Return the interval number
-    /// the provided timestamp falls within.
-    /// @dev If the timestamp is before `firstIntervalStart`,
-    /// the interval is 0.
-    /// @param timestamp The timestamp whose interval is queried.
-    /// @return The interval of the timestamp.
-    function intervalOf(uint256 timestamp) public view returns (uint256) {
-        uint256 _firstIntervalStart = firstIntervalStart;
-        uint256 _termLength = termLength;
-
-        if (timestamp < _firstIntervalStart) {
-            return 0;
-        }
-
-        uint256 difference = timestamp - _firstIntervalStart;
-        uint256 interval = difference / _termLength;
-
-        return interval;
-    }
-
-    /// @notice Return the timestamp corresponding to the start of the interval.
-    /// @dev The start of an interval is inclusive;
-    /// a keep created at the timestamp `startOf(i)` is in interval `i`.
-    function startOf(uint256 interval) public view returns (uint256) {
-        return firstIntervalStart + (interval * termLength);
-    }
-
-    /// @notice Return the timestamp corresponding to the end of the interval.
-    /// @dev The end of an interval is exclusive;
-    /// a keep created at the timestamp `endOf(i)` is in interval `i+1`.
-    function endOf(uint256 interval) public view returns (uint256) {
-        return startOf(interval + 1);
-    }
-
-    /// @notice Return the number of keeps created before `intervalEndpoint`
-    /// @dev Wraps the binary search of `_find`
-    /// with a number of checks for edge cases.
-    function _findEndpoint(uint256 intervalEndpoint) public view returns (uint256) {
-        require(
-            intervalEndpoint <= block.timestamp,
-            "interval hasn't ended yet"
-        );
-        uint256 keepCount = factory.getKeepCount();
-        // no keeps created yet -> return 0
-        if (keepCount == 0) {
-            return 0;
-        }
-
-        uint256 lb = 0; // lower bound, inclusive
-        uint256 timestampLB = factory.getCreationTime(factory.getKeepAtIndex(lb));
-        // all keeps created after the interval -> return 0
-        if (timestampLB >= intervalEndpoint) {
-            return 0;
-        }
-
-        uint256 ub = keepCount - 1; // upper bound, inclusive
-        uint256 timestampUB = factory.getCreationTime(factory.getKeepAtIndex(ub));
-        // all keeps created in or before the interval -> return keep count
-        if (timestampUB < intervalEndpoint) {
-            return keepCount;
-        }
-
-        // The above cases also cover the case
-        // where only 1 keep has been created;
-        // lb == ub
-        // if it was created after the interval, return 0
-        // otherwise, return 1
-
-        return _find(lb, timestampLB, ub, timestampUB, intervalEndpoint);
-    }
-
-    /// @notice Return the number of keeps created before `targetTime`,
-    /// with specified upper and lower bounds.
-    /// @dev Binary search assumes the following invariants:
-    ///   lb >= 0, lbTime < targetTime
-    ///   ub < keepCount, ubTime >= targetTime
-    /// @param lb The lower bound of the search (inclusive)
-    /// @param lbTime The creation time of keep number `lb`
-    /// @param ub The upper bound of the search (inclusive)
-    /// @param ubTime The creation time of keep number `ub`
-    /// @param targetTime The target time
-    function _find(
-        uint256 lb,
-        uint256 lbTime,
-        uint256 ub,
-        uint256 ubTime,
-        uint256 targetTime
-    ) internal view returns (uint256) {
-        uint256 len = ub - lb;
-        while (len > 1) {
-            // ub >= lb + 2
-            // mid > lb
-            uint256 mid = lb + (len / 2);
-            uint256 midTime = factory.getCreationTime(factory.getKeepAtIndex(mid));
-
-            if (midTime >= targetTime) {
-                ub = mid;
-                ubTime = midTime;
-            } else {
-                lb = mid;
-                lbTime = midTime;
-            }
-            len = ub - lb;
-        }
-        return ub;
-    }
-
-   /// @notice Return the endpoint index of the interval,
-   /// i.e. the number of keeps created in and before the interval.
-   /// The interval must have ended;
-   /// otherwise the endpoint might still change.
-   /// @dev Uses a locally cached result,
-   /// and stores the result if it isn't cached yet.
-   /// All keeps created before the initiation fall in interval 0.
-   /// @param interval The number of the interval.
-   /// @return endpoint The number of keeps the factory had created
-   /// before the end of the interval.
-   function _getEndpoint(uint256 interval)
-       mustBeFinished(interval)
-       internal
-       returns (uint256 endpoint)
-   {
-       // Get the endpoint from local cache;
-       // might not be recorded yet
-       uint256 maybeEndpoint = keepsByInterval[interval];
-
-       // Either the endpoint is zero
-       // (no keeps created by the end of the interval)
-       // or the endpoint isn't cached yet
-       if (maybeEndpoint == 0) {
-           // Check what the real endpoint is
-           // if the actual value is 0, this call short-circuits
-           // so we don't need to special-case the zero
-           uint256 realEndpoint = _findEndpoint(endOf(interval));
-           // We didn't have the correct value cached,
-           // so store it
-           if (realEndpoint != 0) {
-               keepsByInterval[interval] = realEndpoint;
-           }
-           endpoint = realEndpoint;
-       } else {
-           endpoint = maybeEndpoint;
-       }
-       return endpoint;
+   function _getKeepCount() internal view returns (uint256) {
+       return factory.getKeepCount();
    }
 
-   function _getPreviousEndpoint(uint256 interval) internal returns (uint256) {
-       if (interval == 0) {
-           return 0;
-       } else {
-           return _getEndpoint(interval - 1);
-       }
+   function _getKeepAtIndex(uint256 index) internal view returns (bytes32) {
+       return bytes32(factory.getKeepAtIndex(index));
    }
 
-   function _keepsInInterval(uint256 interval) internal returns (uint256) {
-       return (_getEndpoint(interval) - _getPreviousEndpoint(interval));
+   function _getCreationTime(bytes32 _keep) isAddress(_keep) internal view returns (uint256) {
+       return factory.getCreationTime(address(bytes20(_keep)));
    }
 
-   /// @notice Calculate the reward allocation adjustment percentage
-   /// when an interval has an insufficient number of keeps.
-   /// @dev An interval with at least `minimumKeepsPerInterval` keeps
-   /// will have the full reward allocated to it.
-   /// An interval with fewer keeps will only be allocated
-   /// a fraction of the base reward
-   /// equaling the fraction of the quota that was met.
-   function _keepCountAdjustment(uint256 interval) internal returns (uint256) {
-       uint256 minimumKeeps = minimumKeepsPerInterval;
-       uint256 keepCount = _keepsInInterval(interval);
-       if (keepCount >= minimumKeeps) {
-           return 100;
-       } else {
-           return keepCount.mul(100).div(minimumKeeps);
-       }
+   function _isClosed(bytes32 _keep) isAddress(_keep) internal view returns (bool) {
+       return IBondedECDSAKeep(address(bytes20(_keep))).isClosed();
    }
 
-   /// @notice Return the percentage of remaining unallocated rewards
-   /// that is to be allocated to the specified `interval`
-   function _getIntervalWeight(uint256 interval) internal view returns (uint256) {
-       if (interval < _getIntervalCount()) {
-           return intervalWeights[interval];
-       } else {
-           return 100;
-       }
+   function _isTerminated(bytes32 _keep) isAddress(_keep) internal view returns (bool) {
+       return IBondedECDSAKeep(address(bytes20(_keep))).isTerminated();
    }
 
-   function _getIntervalCount() internal view returns (uint256) {
-       return intervalWeights.length;
+   function _recognizedByFactory(bytes32 _keep) isAddress(_keep) internal view returns (bool) {
+       return factory.getCreationTime(address(bytes20(_keep))) != 0;
    }
 
-   function _baseAllocation(uint256 interval) internal view returns (uint256) {
-       uint256 _unallocatedRewards = unallocatedRewards;
-       uint256 weightPercentage = _getIntervalWeight(interval);
-       return _unallocatedRewards.mul(weightPercentage).div(100);
-   }
-
-   function _adjustedAllocation(uint256 interval) internal returns (uint256) {
-       uint256 __baseAllocation = _baseAllocation(interval);
-       uint256 adjustmentPercentage = _keepCountAdjustment(interval);
-       return __baseAllocation.mul(adjustmentPercentage).div(100);
-   }
-
-   function _rewardPerKeep(uint256 interval) internal returns (uint256) {
-       uint256 __adjustedAllocation = _adjustedAllocation(interval);
-       if (__adjustedAllocation == 0) {
-           return 0;
-       }
-       uint256 keepCount = _keepsInInterval(interval);
-       // Adjusted allocation would be zero if keep count was zero
-       assert(keepCount > 0);
-       return __adjustedAllocation.div(keepCount);
-   }
-
-   function _allocateRewards(uint256 interval)
-       mustBeFinished(interval)
-       internal
-   {
-       uint256 allocatedIntervals = intervalAllocations.length;
-       require(
-           !(interval < allocatedIntervals),
-           "Interval already allocated"
+   function _distributeReward(bytes32 _keep, uint256 amount) isAddress(_keep) internal {
+       token.approve(address(_keep), amount);
+       IBondedECDSAKeep(address(_keep)).distributeERC20Reward(
+           address(token),
+           amount
        );
-       // Allocate previous intervals first
-       if (interval > allocatedIntervals) {
-           _allocateRewards(interval - 1);
-       }
-       uint256 keepCount = _keepsInInterval(interval);
-       uint256 perKeepAllocation = _rewardPerKeep(interval);
-       // Calculate like this so rewards divide equally among keeps
-       uint256 totalAllocation = keepCount * perKeepAllocation;
-       unallocatedRewards -= totalAllocation;
-       intervalAllocations.push(totalAllocation);
    }
 
-   function _getAllocatedRewards(uint256 interval) internal view returns (uint256) {
+   modifier isAddress(bytes32 _keep) {
        require(
-           interval < intervalAllocations.length,
-           "Interval not allocated yet"
+           _keep == (_keep & bytes32(MAX_UINT20)),
+           "Invalid keep address"
        );
-       return intervalAllocations[interval];
-   }
-
-   function _isAllocated(uint256 interval) internal view returns (bool) {
-       uint256 allocatedIntervals = intervalAllocations.length;
-       return (interval < allocatedIntervals);
-   }
-
-   function _processKeep(
-       bool eligible,
-       address keepAddress
-   ) internal {
-       uint256 creationTime = factory.getCreationTime(keepAddress);
-       uint256 interval = intervalOf(creationTime);
-       if (!_isAllocated(interval)) {
-           _allocateRewards(interval);
-       }
-       uint256 allocation = intervalAllocations[interval];
-       uint256 __keepsInInterval = _keepsInInterval(interval);
-       uint256 perKeepReward = allocation.div(__keepsInInterval);
-       uint256 processedKeeps = intervalKeepsProcessed[interval];
-       claimed[keepAddress] = true;
-       intervalKeepsProcessed[interval] = processedKeeps + 1;
-
-       if (eligible) {
-           paidOutRewards += perKeepReward;
-           token.approve(keepAddress, perKeepReward);
-           IBondedECDSAKeep(keepAddress).distributeERC20Reward(
-               address(token),
-               perKeepReward
-           );
-       } else {
-           // Return the reward to the unallocated pool
-           unallocatedRewards += perKeepReward;
-       }
-   }
-
-   function _unpaidRewards() internal view returns (uint256) {
-       return totalRewards.sub(paidOutRewards);
-   }
-
-   function _rewardClaimed(address _keep) internal view returns (bool) {
-       return claimed[_keep];
-   }
-   function _isClosed(address _keep) internal view returns (bool) {
-       return IBondedECDSAKeep(_keep).isClosed();
-   }
-   function _isTerminated(address _keep) internal view returns (bool) {
-       return IBondedECDSAKeep(_keep).isTerminated();
-   }
-   function _recognizedByFactory(address _keep) internal view returns (bool) {
-       return factory.getCreationTime(_keep) != 0;
-   }
-   function _isFinished(uint256 interval) internal view returns (bool) {
-       return block.timestamp >= endOf(interval);
-   }
-
-   modifier rewardsNotClaimed(address _keep) {
-       require(
-           !_rewardClaimed(_keep),
-           "Rewards already claimed");
-       _;
-   }
-
-   modifier mustBeFinished(uint256 interval) {
-       require(
-           _isFinished(interval),
-           "Interval hasn't ended yet");
-       _;
-   }
-
-   modifier mustBeClosed(address _keep) {
-       require(
-           _isClosed(_keep),
-           "Keep is not closed");
-       _;
-   }
-
-   modifier mustBeTerminated(address _keep) {
-       require(
-           _isTerminated(_keep),
-           "Keep is not terminated");
-       _;
-   }
-
-   modifier factoryMustRecognize(address _keep) {
-       require(
-           _recognizedByFactory(_keep),
-           "Keep address not recognized by factory");
        _;
    }
 }

--- a/solidity/contracts/ECDSAKeepRewards.sol
+++ b/solidity/contracts/ECDSAKeepRewards.sol
@@ -316,6 +316,17 @@ contract ECDSAKeepRewards {
        uint256 adjustmentPercentage = keepCountAdjustment(interval);
        return (_baseAllocation * adjustmentPercentage) / 100;
    }
+
+   function rewardPerKeep(uint256 interval) public returns (uint256) {
+       uint256 _adjustedAllocation = adjustedAllocation(interval);
+       if (_adjustedAllocation == 0) {
+           return 0;
+       }
+       uint256 keepCount = keepsInInterval(interval);
+       // Adjusted allocation would be zero if keep count was zero
+       assert(keepCount > 0);
+       return _adjustedAllocation / keepCount;
+   }
 }
 
 interface IBondedECDSAKeep {

--- a/solidity/contracts/ECDSAKeepRewards.sol
+++ b/solidity/contracts/ECDSAKeepRewards.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.4;
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 
 contract ECDSAKeepRewards {

--- a/solidity/contracts/ECDSAKeepRewards.sol
+++ b/solidity/contracts/ECDSAKeepRewards.sol
@@ -310,6 +310,12 @@ contract ECDSAKeepRewards {
        uint256 weightPercentage = getIntervalWeight(interval);
        return (_unallocatedRewards * weightPercentage) / 100;
    }
+
+   function adjustedAllocation(uint256 interval) public returns (uint256) {
+       uint256 _baseAllocation = baseAllocation(interval);
+       uint256 adjustmentPercentage = keepCountAdjustment(interval);
+       return (_baseAllocation * adjustmentPercentage) / 100;
+   }
 }
 
 interface IBondedECDSAKeep {

--- a/solidity/contracts/ECDSAKeepRewards.sol
+++ b/solidity/contracts/ECDSAKeepRewards.sol
@@ -4,6 +4,53 @@ import "openzeppelin-solidity/contracts/token/ERC20/IERC20.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/SafeERC20.sol";
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 
+/// @title ECDSAKeepRewards
+/// @dev A contract for distributing KEEP token rewards to ECDSA keeps.
+/// When a reward contract is created,
+/// the creator defines a reward schedule
+/// consisting of one or more reward intervals and their interval weights,
+/// the length of reward intervals,
+/// and the quota of how many keeps must be created in an interval
+/// for the full reward for that interval to be paid out.
+///
+/// The amount of KEEP to be distributed is determined by funding the contract,
+/// and additional KEEP can be added at any time.
+/// The reward contract is funded with `approveAndCall` with no extra data,
+/// but it also collects any KEEP mistakenly sent to it in any other way.
+///
+/// An interval is defined by the timestamps [startOf, endOf);
+/// a keep created at the time `startOf(i)` belongs to interval `i`
+/// and one created at `endOf(i)` belongs to `i+1`.
+///
+/// When an interval is over,
+/// it will be allocated a percentage of the remaining unallocated rewards
+/// based on its weight,
+/// and adjusted by the number of keeps created in the interval
+/// if the quota is not met.
+/// The adjustment for not meeting the keep quota is a percentage
+/// that equals the percentage of the quota that was met;
+/// if the number of keeps created is 80% of the quota
+/// then 80% of the base reward will be allocated for the interval.
+///
+/// Any unallocated rewards will stay in the unallocated rewards pool,
+/// to be allocated for future intervals.
+/// Intervals past the initially defined schedule have a weight of 100%,
+/// meaning that all remaining unallocated rewards
+/// will be allocated to the interval.
+///
+/// ECDSA keeps created by the defined `factory` can receive rewards
+/// once the interval they were created in is over,
+/// and the keep has closed happily.
+/// There is no time limit to receiving rewards,
+/// nor is there need to wait for all keeps from the interval to close.
+/// Calling `receiveReward` automatically allocates the rewards
+/// for the interval the specified keep was created in
+/// and all previous intervals.
+///
+/// If a keep is terminated,
+/// that fact can be reported to the reward contract.
+/// Reporting a terminated keep returns its allocated reward
+/// to the pool of unallocated rewards.
 contract ECDSAKeepRewards {
     using SafeMath for uint256;
     using SafeERC20 for IERC20;

--- a/solidity/contracts/ECDSAKeepRewards.sol
+++ b/solidity/contracts/ECDSAKeepRewards.sol
@@ -90,9 +90,6 @@ contract ECDSAKeepRewards {
         );
         uint256 intervalEndpointsLength = intervalEndpoints.length;
         uint256 newInterval = findEndpoint(_timestamp);
-        // uint256 newInterval = intervalEndpointsLength > 0 ?
-        // find(0, factory.getKeepCount(), _timestamp):
-        // find(intervalEndpoints[intervalEndpointsLength - 1], factory.getKeepCount(), _timestamp);
 
         uint256 totalSubmissions = intervalEndpointsLength > 0 ?
         newInterval:
@@ -181,9 +178,6 @@ contract ECDSAKeepRewards {
         return ub;
     }
 
-   function tt(uint256 ind) public view returns (uint256) {
-    return factory.getKeepCount();
-}
    function currentTime() public view returns (uint256) {
        return block.timestamp;
    }

--- a/solidity/contracts/ECDSAKeepRewards.sol
+++ b/solidity/contracts/ECDSAKeepRewards.sol
@@ -347,7 +347,7 @@ contract ECDSAKeepRewards {
 
        if (eligible) {
            keepToken.approve(keepAddress, perKeepReward);
-           IBondedECDSAKeep(keepAddress).distributeERC20ToMembers(
+           IBondedECDSAKeep(keepAddress).distributeERC20Reward(
                address(keepToken),
                perKeepReward
            );
@@ -415,7 +415,7 @@ interface IBondedECDSAKeep {
     function isClosed() external view returns (bool);
     function isTerminated() external view returns (bool);
     function isActive() external view returns (bool);
-    function distributeERC20ToMembers(address _erc20, uint256 amount) external;
+    function distributeERC20Reward(address _erc20, uint256 amount) external;
 }
 
 interface IBondedECDSAKeepFactory {

--- a/solidity/contracts/ECDSAKeepRewards.sol
+++ b/solidity/contracts/ECDSAKeepRewards.sol
@@ -384,10 +384,13 @@ contract ECDSAKeepRewards {
        uint256 _keepsInInterval = keepsInInterval(interval);
        uint256 perKeepReward = allocation / _keepsInInterval;
        uint256 processedKeeps = intervalKeepsProcessed[interval];
-
-       // TODO: send rewards here
-
        claimed[keepAddress] = true;
+
+       IBondedECDSAKeep(keepAddress).distributeERC20ToMembers(
+           address(keepToken),
+           perKeepReward
+       );
+
        intervalKeepsProcessed[interval] = processedKeeps + 1;
    }
 
@@ -457,6 +460,7 @@ interface IBondedECDSAKeep {
     function isClosed() external view returns (bool);
     function isTerminated() external view returns (bool);
     function isActive() external view returns (bool);
+    function distributeERC20ToMembers(address _erc20, uint256 amount) external;
 }
 
 interface IBondedECDSAKeepFactory {

--- a/solidity/contracts/ECDSAKeepRewards.sol
+++ b/solidity/contracts/ECDSAKeepRewards.sol
@@ -124,7 +124,7 @@ contract ECDSAKeepRewards {
     /// @return True if the keep is eligible, false otherwise
     function eligibleForReward(address _keep) public view returns (bool){
         // check that keep closed properly
-        return true;
+        return IBondedECDSAKeep(_keep).isClosed();
     }
 
     function findEndpoint(uint256 intervalEndpoint) public view returns (uint256) {
@@ -276,6 +276,9 @@ contract ECDSAKeepRewards {
 interface IBondedECDSAKeep {
     function getOwner() external view returns (address);
     function getTimestamp() external view returns (uint256);
+    function isClosed() external view returns (bool);
+    function isTerminated() external view returns (bool);
+    function isActive() external view returns (bool);
 }
 
 interface IBondedECDSAKeepFactory {

--- a/solidity/contracts/ECDSAKeepRewards.sol
+++ b/solidity/contracts/ECDSAKeepRewards.sol
@@ -33,6 +33,13 @@ contract ECDSAKeepRewards {
     // Mapping of interval to number of keeps created in/before the interval
     mapping(uint256 => uint256) keepsByInterval;
 
+    // Mapping of interval to number of keeps whose rewards have been paid out,
+    // or reallocated because the keep closed unhappily
+    mapping(uint256 => uint256) intervalKeepsProcessed;
+
+    // Rewards that haven't been allocated to finished intervals
+    uint256 unallocatedRewards;
+
     constructor (
         uint256 _termLength,
         uint256 _totalRewards,
@@ -44,6 +51,7 @@ contract ECDSAKeepRewards {
     public {
        keepToken = IERC20(_keepToken);
        totalRewards = _totalRewards;
+       unallocatedRewards = totalRewards;
        termLength = _termLength;
        initiated = _initiated;
        minimumSubmissions = _minimumSubmissions;

--- a/solidity/contracts/ECDSAKeepRewards.sol
+++ b/solidity/contracts/ECDSAKeepRewards.sol
@@ -1,8 +1,10 @@
 pragma solidity ^0.5.4;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 
 contract ECDSAKeepRewards {
+    using SafeMath for uint256;
 
     IERC20 keepToken;
     IBondedECDSAKeepFactory factory;
@@ -296,7 +298,7 @@ contract ECDSAKeepRewards {
        if (keepCount >= minimumKeeps) {
            return 100;
        } else {
-           return 100 * keepCount / minimumKeeps;
+           return keepCount.mul(100).div(minimumKeeps);
        }
    }
 
@@ -315,13 +317,13 @@ contract ECDSAKeepRewards {
    function baseAllocation(uint256 interval) public view returns (uint256) {
        uint256 _unallocatedRewards = unallocatedRewards;
        uint256 weightPercentage = getIntervalWeight(interval);
-       return (_unallocatedRewards * weightPercentage) / 100;
+       return _unallocatedRewards.mul(weightPercentage).div(100);
    }
 
    function adjustedAllocation(uint256 interval) public returns (uint256) {
        uint256 _baseAllocation = baseAllocation(interval);
        uint256 adjustmentPercentage = keepCountAdjustment(interval);
-       return (_baseAllocation * adjustmentPercentage) / 100;
+       return _baseAllocation.mul(adjustmentPercentage).div(100);
    }
 
    function rewardPerKeep(uint256 interval) public returns (uint256) {
@@ -332,7 +334,7 @@ contract ECDSAKeepRewards {
        uint256 keepCount = keepsInInterval(interval);
        // Adjusted allocation would be zero if keep count was zero
        assert(keepCount > 0);
-       return _adjustedAllocation / keepCount;
+       return _adjustedAllocation.div(keepCount);
    }
 
    function allocateRewards(uint256 interval)
@@ -382,7 +384,7 @@ contract ECDSAKeepRewards {
        }
        uint256 allocation = intervalAllocations[interval];
        uint256 _keepsInInterval = keepsInInterval(interval);
-       uint256 perKeepReward = allocation / _keepsInInterval;
+       uint256 perKeepReward = allocation.div(_keepsInInterval);
        uint256 processedKeeps = intervalKeepsProcessed[interval];
        claimed[keepAddress] = true;
 
@@ -408,7 +410,7 @@ contract ECDSAKeepRewards {
        }
        uint256 allocation = intervalAllocations[interval];
        uint256 _keepsInInterval = keepsInInterval(interval);
-       uint256 perKeepReward = allocation / _keepsInInterval;
+       uint256 perKeepReward = allocation.div(_keepsInInterval);
        uint256 processedKeeps = intervalKeepsProcessed[interval];
        uint256 _unallocatedRewards = unallocatedRewards;
 

--- a/solidity/contracts/ECDSAKeepRewards.sol
+++ b/solidity/contracts/ECDSAKeepRewards.sol
@@ -357,6 +357,71 @@ contract ECDSAKeepRewards {
        );
        return intervalAllocations[interval];
    }
+
+   function isAllocated(uint256 interval) public view returns (bool) {
+       uint256 allocatedIntervals = intervalAllocations.length;
+       return (interval < allocatedIntervals);
+   }
+
+   function claimRewards(address keepAddress) public {
+       require(
+           IBondedECDSAKeep(keepAddress).isClosed(),
+           "Keep is not closed"
+       );
+       require(
+           !claimed[keepAddress],
+           "Rewards already claimed"
+       );
+       uint256 creationTime = factory.getCreationTime(keepAddress);
+       require(
+           creationTime != 0,
+           "Keep address not recognized by factory"
+       );
+       uint256 interval = intervalOf(creationTime);
+       if (!isAllocated(interval)) {
+           allocateRewards(interval);
+       }
+       uint256 allocation = intervalAllocations[interval];
+       uint256 _keepsInInterval = keepsInInterval(interval);
+       uint256 perKeepReward = allocation / _keepsInInterval;
+       uint256 processedKeeps = intervalKeepsProcessed[interval];
+
+       // TODO: send rewards here
+
+       claimed[keepAddress] = true;
+       intervalKeepsProcessed[interval] = processedKeeps + 1;
+   }
+
+   function reportTermination(address keepAddress) public {
+       require(
+           IBondedECDSAKeep(keepAddress).isTerminated(),
+           "Keep is not terminated"
+       );
+       require(
+           !claimed[keepAddress],
+           "Rewards already claimed"
+       );
+       uint256 creationTime = factory.getCreationTime(keepAddress);
+       require(
+           creationTime != 0,
+           "Keep address not recognized by factory"
+       );
+       uint256 interval = intervalOf(creationTime);
+       if (!isAllocated(interval)) {
+           allocateRewards(interval);
+       }
+       uint256 allocation = intervalAllocations[interval];
+       uint256 _keepsInInterval = keepsInInterval(interval);
+       uint256 perKeepReward = allocation / _keepsInInterval;
+       uint256 processedKeeps = intervalKeepsProcessed[interval];
+       uint256 _unallocatedRewards = unallocatedRewards;
+
+       // Return the reward to the unallocated pool
+       unallocatedRewards = _unallocatedRewards + perKeepReward;
+
+       claimed[keepAddress] = true;
+       intervalKeepsProcessed[interval] = processedKeeps + 1;
+   }
 }
 
 interface IBondedECDSAKeep {

--- a/solidity/contracts/ECDSAKeepRewards.sol
+++ b/solidity/contracts/ECDSAKeepRewards.sol
@@ -386,6 +386,7 @@ contract ECDSAKeepRewards {
        uint256 processedKeeps = intervalKeepsProcessed[interval];
        claimed[keepAddress] = true;
 
+       keepToken.approve(keepAddress, perKeepReward);
        IBondedECDSAKeep(keepAddress).distributeERC20ToMembers(
            address(keepToken),
            perKeepReward

--- a/solidity/contracts/ECDSAKeepRewards.sol
+++ b/solidity/contracts/ECDSAKeepRewards.sol
@@ -222,6 +222,7 @@ contract ECDSAKeepRewards {
    /// otherwise the endpoint might still change.
    /// @dev Uses a locally cached result,
    /// and stores the result if it isn't cached yet.
+   /// All keeps created before the initiation fall in interval 0.
    /// @param interval The number of the interval.
    /// @return endpoint The number of keeps the factory had created
    /// before the end of the interval.
@@ -253,6 +254,14 @@ contract ECDSAKeepRewards {
            endpoint = maybeEndpoint;
        }
        return endpoint;
+   }
+
+   function getPreviousEndpoint(uint256 interval) public returns (uint256) {
+       if (interval == 0) {
+           return 0;
+       } else {
+           return getEndpoint(interval - 1);
+       }
    }
 }
 

--- a/solidity/contracts/ECDSAKeepRewards.sol
+++ b/solidity/contracts/ECDSAKeepRewards.sol
@@ -106,35 +106,35 @@ contract ECDSAKeepRewards {
         return !claimed && terminated && recognized;
     }
 
-   /// @notice Return the interval number
-   /// the provided timestamp falls within.
-   /// @dev Reverts if the timestamp is before `initiated`.
-   /// @param timestamp The timestamp whose interval is queried.
-   /// @return The interval of the timestamp.
-   function intervalOf(uint256 timestamp) public view returns (uint256) {
-       uint256 _initiated = initiated;
-       uint256 _termLength = termLength;
+    /// @notice Return the interval number
+    /// the provided timestamp falls within.
+    /// @dev If the timestamp is before `initiated`,
+    /// the interval is 0.
+    /// @param timestamp The timestamp whose interval is queried.
+    /// @return The interval of the timestamp.
+    function intervalOf(uint256 timestamp) public view returns (uint256) {
+        uint256 _initiated = initiated;
+        uint256 _termLength = termLength;
 
-       require(
-           timestamp >= _initiated,
-           "Timestamp is before the first interval"
-       );
+        if (timestamp < _initiated) {
+            return 0;
+        }
 
-       uint256 difference = timestamp - _initiated;
-       uint256 interval = difference / _termLength;
+        uint256 difference = timestamp - _initiated;
+        uint256 interval = difference / _termLength;
 
-       return interval;
-   }
+        return interval;
+    }
 
-   /// @notice Return the timestamp corresponding to the start of the interval.
-   function startOf(uint256 interval) public view returns (uint256) {
-       return initiated + (interval * termLength);
-   }
+    /// @notice Return the timestamp corresponding to the start of the interval.
+    function startOf(uint256 interval) public view returns (uint256) {
+        return initiated + (interval * termLength);
+    }
 
-   /// @notice Return the timestamp corresponding to the end of the interval.
-   function endOf(uint256 interval) public view returns (uint256) {
-       return startOf(interval + 1);
-   }
+    /// @notice Return the timestamp corresponding to the end of the interval.
+    function endOf(uint256 interval) public view returns (uint256) {
+        return startOf(interval + 1);
+    }
 
     function _findEndpoint(uint256 intervalEndpoint) public view returns (uint256) {
         require(

--- a/solidity/contracts/ECDSAKeepRewards.sol
+++ b/solidity/contracts/ECDSAKeepRewards.sol
@@ -123,10 +123,10 @@ contract ECDSAKeepRewards {
     /// @param _keep The keep to check.
     /// @return True if the keep is eligible, false otherwise
     function eligibleForReward(address _keep) public view returns (bool){
-        bool claimed = _rewardClaimed(_keep);
+        bool _claimed = _rewardClaimed(_keep);
         bool closed = _isClosed(_keep);
         bool recognized = _recognizedByFactory(_keep);
-        return !claimed && closed && recognized;
+        return !_claimed && closed && recognized;
     }
 
     /// @notice Checks if a keep is terminated
@@ -134,10 +134,10 @@ contract ECDSAKeepRewards {
     /// @param _keep The keep to check.
     /// @return True if the keep is terminated, false otherwise
     function eligibleButTerminated(address _keep) public view returns (bool) {
-        bool claimed = _rewardClaimed(_keep);
+        bool _claimed = _rewardClaimed(_keep);
         bool terminated = _isTerminated(_keep);
         bool recognized = _recognizedByFactory(_keep);
-        return !claimed && terminated && recognized;
+        return !_claimed && terminated && recognized;
     }
 
     /// @notice Return the interval number
@@ -313,20 +313,20 @@ contract ECDSAKeepRewards {
    }
 
    function _adjustedAllocation(uint256 interval) internal returns (uint256) {
-       uint256 _baseAllocation = _baseAllocation(interval);
+       uint256 __baseAllocation = _baseAllocation(interval);
        uint256 adjustmentPercentage = _keepCountAdjustment(interval);
-       return _baseAllocation.mul(adjustmentPercentage).div(100);
+       return __baseAllocation.mul(adjustmentPercentage).div(100);
    }
 
    function _rewardPerKeep(uint256 interval) internal returns (uint256) {
-       uint256 _adjustedAllocation = _adjustedAllocation(interval);
-       if (_adjustedAllocation == 0) {
+       uint256 __adjustedAllocation = _adjustedAllocation(interval);
+       if (__adjustedAllocation == 0) {
            return 0;
        }
        uint256 keepCount = _keepsInInterval(interval);
        // Adjusted allocation would be zero if keep count was zero
        assert(keepCount > 0);
-       return _adjustedAllocation.div(keepCount);
+       return __adjustedAllocation.div(keepCount);
    }
 
    function _allocateRewards(uint256 interval)
@@ -373,8 +373,8 @@ contract ECDSAKeepRewards {
            _allocateRewards(interval);
        }
        uint256 allocation = intervalAllocations[interval];
-       uint256 _keepsInInterval = _keepsInInterval(interval);
-       uint256 perKeepReward = allocation.div(_keepsInInterval);
+       uint256 __keepsInInterval = _keepsInInterval(interval);
+       uint256 perKeepReward = allocation.div(__keepsInInterval);
        uint256 processedKeeps = intervalKeepsProcessed[interval];
        claimed[keepAddress] = true;
        intervalKeepsProcessed[interval] = processedKeeps + 1;

--- a/solidity/contracts/ECDSAKeepRewards.sol
+++ b/solidity/contracts/ECDSAKeepRewards.sol
@@ -279,6 +279,10 @@ contract ECDSAKeepRewards {
        }
    }
 
+   function keepsInInterval(uint256 interval) public returns (uint256) {
+       return (getEndpoint(interval) - getPreviousEndpoint(interval));
+   }
+
    function getIntervalWeight(uint256 interval) public view returns (uint256) {
        if (interval < getIntervalCount()) {
            return intervalWeights[interval];
@@ -289,6 +293,12 @@ contract ECDSAKeepRewards {
 
    function getIntervalCount() public view returns (uint256) {
        return intervalWeights.length;
+   }
+
+   function baseAllocation(uint256 interval) public view returns (uint256) {
+       uint256 _unallocatedRewards = unallocatedRewards;
+       uint256 weightPercentage = getIntervalWeight(interval);
+       return (_unallocatedRewards * weightPercentage) / 100;
    }
 }
 

--- a/solidity/contracts/ECDSAKeepRewards.sol
+++ b/solidity/contracts/ECDSAKeepRewards.sol
@@ -102,18 +102,18 @@ contract ECDSAKeepRewards {
     /// @notice Sends the reward for a keep to the keep members.
     /// @param keepAddress ECDSA keep factory address.
     function receiveReward(address keepAddress)
+        factoryMustRecognize(keepAddress)
         rewardsNotClaimed(keepAddress)
         mustBeClosed(keepAddress)
-        factoryMustRecognize(keepAddress)
         public
     {
         _processKeep(true, keepAddress);
     }
 
     function reportTermination(address keepAddress)
+        factoryMustRecognize(keepAddress)
         rewardsNotClaimed(keepAddress)
         mustBeTerminated(keepAddress)
-        factoryMustRecognize(keepAddress)
         public
     {
         _processKeep(false, keepAddress);

--- a/solidity/contracts/api/IBondedECDSAKeep.sol
+++ b/solidity/contracts/api/IBondedECDSAKeep.sol
@@ -33,7 +33,7 @@ contract IBondedECDSAKeep {
         external;
 
     /// @notice Seizes the signers' ETH bonds. After seizing bonds keep is
-    /// closed so it will no longer respond to signing requests. Bonds can be
+    /// terminated so it will no longer respond to signing requests. Bonds can be
     /// seized only when there is no signing in progress or requested signing
     /// process has timed out. This function seizes all of signers' bonds.
     /// The application may decide to return part of bonds later after they are

--- a/solidity/test/BondedECDSAKeepFactoryTest.js
+++ b/solidity/test/BondedECDSAKeepFactoryTest.js
@@ -22,7 +22,7 @@ const chai = require('chai')
 chai.use(require('bn-chai')(BN))
 const expect = chai.expect
 
-contract.only("BondedECDSAKeepFactory", async accounts => {
+contract("BondedECDSAKeepFactory", async accounts => {
     let registry
     let tokenStaking
     let keepFactory

--- a/solidity/test/BondedECDSAKeepFactoryTest.js
+++ b/solidity/test/BondedECDSAKeepFactoryTest.js
@@ -1210,55 +1210,6 @@ contract("BondedECDSAKeepFactory", async accounts => {
         })
     })
 
-    describe("notifyKeepClosed", async () => {
-        const keepOwner = accounts[5]
-        let keep
-
-        before(async () => {
-            await initializeNewFactory()
-            await initializeMemberCandidates()
-            await registerMemberCandidates()
-
-
-            keep = await openKeep()
-        })
-
-        beforeEach(async () => {
-            await createSnapshot()
-        })
-
-        afterEach(async () => {
-            await restoreSnapshot()
-        })
-
-        it("reverts if called not by keep", async () => {
-            await expectRevert(
-                keepFactory.notifyKeepClosed(),
-                "Caller is not an active keep created by this factory"
-            )
-        })
-
-        it("reverts if called by not active keep", async () => {
-            // The keep is removed from the list of keeps created by the factory
-            // or it's already marked as inactive.
-            await keepFactory.removeKeep(keep.address)
-
-            await expectRevert(
-                keep.closeKeep({ from: keepOwner }),
-                "Caller is not an active keep created by this factory"
-            )
-        })
-
-        it("marks keep closed", async () => {
-            // Add keep to the list of keeps created by the factory.
-            await keepFactory.addKeep(keep.address)
-
-            await keep.closeKeep({ from: keepOwner })
-
-            assert.isFalse(await keepFactory.hasKeep(keep.address))
-        })
-    })
-
     describe("newGroupSelectionSeedFee", async () => {
         let newEntryFee;
 

--- a/solidity/test/BondedECDSAKeepFactoryTest.js
+++ b/solidity/test/BondedECDSAKeepFactoryTest.js
@@ -1083,6 +1083,28 @@ contract("BondedECDSAKeepFactory", async accounts => {
             )
         })
 
+        it("produces active keeps", async () => {
+            let keepAddress = await keepFactory.openKeep.call(
+                groupSize,
+                threshold,
+                keepOwner,
+                bond,
+                { from: application, value: feeEstimate }
+            )
+
+            await keepFactory.openKeep(
+                groupSize,
+                threshold,
+                keepOwner,
+                bond,
+                { from: application, value: feeEstimate }
+            )     
+
+            let keep = await BondedECDSAKeep.at(keepAddress)
+
+            assert.isTrue(await keep.isActive(), "keep should be active")
+        })
+
         async function createDepositAndRegisterMembers(memberCount, unbondedAmount) {
             const stakeBalance = await keepFactory.minimumStake.call()
 

--- a/solidity/test/BondedECDSAKeepTest.js
+++ b/solidity/test/BondedECDSAKeepTest.js
@@ -26,7 +26,7 @@ const chai = require('chai')
 chai.use(require('bn-chai')(BN))
 const expect = chai.expect
 
-contract.only('BondedECDSAKeep', (accounts) => {
+contract('BondedECDSAKeep', (accounts) => {
   const bondCreator = accounts[0]
   const owner = accounts[1]
   const nonOwner = accounts[2]

--- a/solidity/test/BondedECDSAKeepTest.js
+++ b/solidity/test/BondedECDSAKeepTest.js
@@ -26,7 +26,7 @@ const chai = require('chai')
 chai.use(require('bn-chai')(BN))
 const expect = chai.expect
 
-contract('BondedECDSAKeep', (accounts) => {
+contract.only('BondedECDSAKeep', (accounts) => {
   const bondCreator = accounts[0]
   const owner = accounts[1]
   const nonOwner = accounts[2]

--- a/solidity/test/BondedECDSAKeepTest.js
+++ b/solidity/test/BondedECDSAKeepTest.js
@@ -953,12 +953,6 @@ contract('BondedECDSAKeep', (accounts) => {
       assert.isFalse(await keep.isActive(), 'keep should no longer be active');
     })
 
-    it('notifies factory', async () => {
-      await keep.closeKeep({ from: owner })
-
-      assert.isTrue(await factoryStub.notifiedKeepClosed(), 'factory was not notified about keep closure');
-    })
-
     it('frees members bonds', async () => {
       await keep.closeKeep({ from: owner })
 

--- a/solidity/test/BondedECDSAKeepTest.js
+++ b/solidity/test/BondedECDSAKeepTest.js
@@ -514,9 +514,18 @@ contract('BondedECDSAKeep', (accounts) => {
       ).to.eq.BN(0, 'should zero all the bonds');
     })
 
-    it('should close a keep', async () => {
+    it('terminates keep', async () => {
       await keep.seizeSignerBonds({ from: owner })
-      assert.isFalse(await keep.isActive(), 'keep should not be active')
+      assert.isTrue(await keep.isTerminated(), 'keep should be terminated')
+      assert.isFalse(await keep.isActive(), 'keep should no longer be active')
+      assert.isFalse(await keep.isClosed(), 'keep should not be closed')
+    })
+
+    it('emits an event', async () => {
+      truffleAssert.eventEmitted(
+        await keep.seizeSignerBonds({ from: owner }),
+        'KeepTerminated'
+      )
     })
 
     it('can be called only by owner', async () => {
@@ -947,10 +956,11 @@ contract('BondedECDSAKeep', (accounts) => {
       )
     })
 
-    it('makes the keep no longer active', async () => {
-      assert.isTrue(await keep.isActive(), 'keep should be active');
+    it('marks keep as closed', async () => {
       await keep.closeKeep({ from: owner })
-      assert.isFalse(await keep.isActive(), 'keep should no longer be active');
+      assert.isTrue(await keep.isClosed(), 'keep should be closed')
+      assert.isFalse(await keep.isActive(), 'keep should no longer be active')
+      assert.isFalse(await keep.isTerminated(), 'keep should not be terminated')
     })
 
     it('frees members bonds', async () => {

--- a/solidity/test/RewardsTest.js
+++ b/solidity/test/RewardsTest.js
@@ -20,7 +20,6 @@ contract.only('ECDSAKeepRewards', (accounts) => {
     const aliceBeneficiary = accounts[2]
     const bobBeneficiary = accounts[3]
 
-    let masterKeep
     let factory
     let registry
     let rewards
@@ -159,8 +158,6 @@ contract.only('ECDSAKeepRewards', (accounts) => {
             initiationTime,
             intervalWeights
         )
-
-        token.mint(rewards.address, totalRewards)
     })
 
     beforeEach(async () => {
@@ -173,6 +170,7 @@ contract.only('ECDSAKeepRewards', (accounts) => {
 
     describe("TestToken", async () => {
         it("is set up correctly", async () => {
+            token.mint(rewards.address, totalRewards)
             let rewardsTokens = await token.balanceOf(rewards.address)
             expect(rewardsTokens.toNumber()).to.equal(totalRewards)
         })
@@ -460,6 +458,8 @@ contract.only('ECDSAKeepRewards', (accounts) => {
 
     describe("claimRewards", async () => {
         it("lets closed keeps claim the reward correctly", async () => {
+            token.mint(rewards.address, totalRewards)
+
             let timestamps = rewardTimestamps
             await createKeeps(timestamps)
             let keepAddress = await keepFactory.getKeepAtIndex(0)

--- a/solidity/test/RewardsTest.js
+++ b/solidity/test/RewardsTest.js
@@ -171,6 +171,13 @@ contract.only('ECDSAKeepRewards', (accounts) => {
         await restoreSnapshot()
     })
 
+    describe("TestToken", async () => {
+        it("is set up correctly", async () => {
+            let rewardsTokens = await token.balanceOf(rewards.address)
+            expect(rewardsTokens.toNumber()).to.equal(totalRewards)
+        })
+    })
+
     describe("eligibleForReward", async () => {
         it("returns true for happily closed keeps", async () => {
             await createKeeps([1000])

--- a/solidity/test/RewardsTest.js
+++ b/solidity/test/RewardsTest.js
@@ -205,6 +205,8 @@ contract.only('ECDSAKeepRewards', (accounts) => {
 
     describe("intervalOf", async () => {
         it("returns the correct interval", async () => {
+            let interval999 = await rewards.intervalOf(999)
+            expect(interval999.toNumber()).to.equal(0)
             let interval1000 = await rewards.intervalOf(1000)
             expect(interval1000.toNumber()).to.equal(0)
             let interval1001 = await rewards.intervalOf(1001)
@@ -217,13 +219,6 @@ contract.only('ECDSAKeepRewards', (accounts) => {
             expect(interval1101.toNumber()).to.equal(1)
             let interval1000000 = await rewards.intervalOf(1000000)
             expect(interval1000000.toNumber()).to.equal(9990)
-        })
-
-        it("reverts on timestamps before initiation", async () => {
-            await expectRevert(
-                rewards.intervalOf(999),
-                "Timestamp is before the first interval"
-            )
         })
     })
 

--- a/solidity/test/RewardsTest.js
+++ b/solidity/test/RewardsTest.js
@@ -529,6 +529,19 @@ contract.only('ECDSAKeepRewards', (accounts) => {
                 "Keep address not recognized by factory"
             )
         })
+
+        it("requires that the interval is over", async () => {
+            let recentTimestamp = await rewards.currentTime()
+            let targetTimestamp = recentTimestamp + 1000
+            await createKeeps([targetTimestamp])
+            let keepAddress = await keepFactory.getKeepAtIndex(0)
+            let keep = await RewardsKeepStub.at(keepAddress)
+            await keep.close()
+            await expectRevert(
+                rewards.receiveReward(keepAddress),
+                "Interval hasn't ended yet"
+            )
+        })
     })
 
     describe("reportTermination", async () => {
@@ -591,6 +604,19 @@ contract.only('ECDSAKeepRewards', (accounts) => {
             await expectRevert(
                 rewards.reportTermination(fakeKeepAddress),
                 "Keep address not recognized by factory"
+            )
+        })
+
+        it("requires that the interval is over", async () => {
+            let recentTimestamp = await rewards.currentTime()
+            let targetTimestamp = recentTimestamp + 1000
+            await createKeeps([targetTimestamp])
+            let keepAddress = await keepFactory.getKeepAtIndex(0)
+            let keep = await RewardsKeepStub.at(keepAddress)
+            await keep.terminate()
+            await expectRevert(
+                rewards.reportTermination(keepAddress),
+                "Interval hasn't ended yet"
             )
         })
     })

--- a/solidity/test/RewardsTest.js
+++ b/solidity/test/RewardsTest.js
@@ -46,6 +46,9 @@ contract.only('ECDSAKeepRewards', (accounts) => {
         1015,
     ]
 
+    const initiationTime = 1000
+    const termLength = 100
+
     async function initializeNewFactory() {
         registry = await Registry.new()
         bondedSortitionPoolFactory = await BondedSortitionPoolFactory.new()
@@ -74,7 +77,14 @@ contract.only('ECDSAKeepRewards', (accounts) => {
     before(async () => {
         await initializeNewFactory()
 
-        rewards = await ECDSAKeepRewards.new(0, 0, accounts[0], 0, keepFactory.address)
+        rewards = await ECDSAKeepRewards.new(
+            termLength,
+            0,
+            accounts[0],
+            0,
+            keepFactory.address,
+            initiationTime
+        )
     })
 
     beforeEach(async () => {
@@ -83,6 +93,23 @@ contract.only('ECDSAKeepRewards', (accounts) => {
 
     afterEach(async () => {
         await restoreSnapshot()
+    })
+
+    describe("intervalOf", async () => {
+        it("returns the correct interval", async () => {
+            let interval1000 = await rewards.intervalOf(1000)
+            expect(interval1000.toNumber()).to.equal(0)
+            let interval1001 = await rewards.intervalOf(1001)
+            expect(interval1001.toNumber()).to.equal(0)
+            let interval1099 = await rewards.intervalOf(1099)
+            expect(interval1099.toNumber()).to.equal(0)
+            let interval1100 = await rewards.intervalOf(1100)
+            expect(interval1100.toNumber()).to.equal(1)
+            let interval1101 = await rewards.intervalOf(1101)
+            expect(interval1101.toNumber()).to.equal(1)
+            let interval1000000 = await rewards.intervalOf(1000000)
+            expect(interval1000000.toNumber()).to.equal(9990)
+        })
     })
 
     describe("findEndpoint", async () => {

--- a/solidity/test/RewardsTest.js
+++ b/solidity/test/RewardsTest.js
@@ -289,6 +289,18 @@ contract.only('ECDSAKeepRewards', (accounts) => {
         })
     })
 
+    describe("keepCountAdjustment", async () => {
+        it("returns the adjustment percentage of the interval", async () => {
+            let timestamps = rewardTimestamps
+            let expectedPercentages = [100, 100, 50, 100, 0, 50, 100, 0]
+            await createKeeps(timestamps)
+            for (let i = 0; i < expectedPercentages.length; i++) {
+                let keepCount = await rewards.keepCountAdjustment.call(i)
+                expect(keepCount.toNumber()).to.equal(expectedPercentages[i])
+            }
+        })
+    })
+
     describe("getIntervalWeight", async () => {
         it("returns the weight of a defined interval", async () => {
             let weight0 = await rewards.getIntervalWeight(0)

--- a/solidity/test/RewardsTest.js
+++ b/solidity/test/RewardsTest.js
@@ -14,7 +14,7 @@ const TestToken = artifacts.require('TestToken')
 const RewardsKeepStub = artifacts.require('RewardsKeepStub');
 const ECDSAKeepRewardsStub = artifacts.require('ECDSAKeepRewardsStub');
 
-contract.only('ECDSAKeepRewards', (accounts) => {
+contract('ECDSAKeepRewards', (accounts) => {
     const alice = accounts[0]
     const bob = accounts[1]
     const aliceBeneficiary = accounts[2]

--- a/solidity/test/RewardsTest.js
+++ b/solidity/test/RewardsTest.js
@@ -456,7 +456,7 @@ contract.only('ECDSAKeepRewards', (accounts) => {
         })
     })
 
-    describe("claimRewards", async () => {
+    describe("receiveReward", async () => {
         it("lets closed keeps claim the reward correctly", async () => {
             token.mint(rewards.address, totalRewards)
 
@@ -465,7 +465,7 @@ contract.only('ECDSAKeepRewards', (accounts) => {
             let keepAddress = await keepFactory.getKeepAtIndex(0)
             let keep = await RewardsKeepStub.at(keepAddress)
             await keep.close()
-            await rewards.claimRewards(keepAddress)
+            await rewards.receiveReward(keepAddress)
             let aliceBalance = await token.balanceOf(aliceBeneficiary)
             expect(aliceBalance.toNumber()).to.equal(33333)
         })

--- a/solidity/test/RewardsTest.js
+++ b/solidity/test/RewardsTest.js
@@ -145,7 +145,7 @@ contract.only('ECDSAKeepRewards', (accounts) => {
         rewards = await ECDSAKeepRewards.new(
             termLength,
             totalRewards,
-            token,
+            token.address,
             minimumIntervalKeeps,
             keepFactory.address,
             initiationTime,

--- a/solidity/test/RewardsTest.js
+++ b/solidity/test/RewardsTest.js
@@ -119,6 +119,28 @@ contract.only('ECDSAKeepRewards', (accounts) => {
         })
     })
 
+    describe("startOf", async () => {
+        it("returns the start of the interval", async () => {
+            let end0 = await rewards.startOf(0)
+            expect(end0.toNumber()).to.equal(1000)
+            let end1 = await rewards.startOf(1)
+            expect(end1.toNumber()).to.equal(1100)
+            let end9990 = await rewards.startOf(9990)
+            expect(end9990.toNumber()).to.equal(1000000)
+        })
+    })
+
+    describe("endOf", async () => {
+        it("returns the end of the interval", async () => {
+            let end0 = await rewards.endOf(0)
+            expect(end0.toNumber()).to.equal(1100)
+            let end1 = await rewards.endOf(1)
+            expect(end1.toNumber()).to.equal(1200)
+            let end9990 = await rewards.endOf(9990)
+            expect(end9990.toNumber()).to.equal(1000100)
+        })
+    })
+
     describe("findEndpoint", async () => {
         let increment = 1000
 

--- a/solidity/test/RewardsTest.js
+++ b/solidity/test/RewardsTest.js
@@ -409,5 +409,16 @@ contract.only('ECDSAKeepRewards', (accounts) => {
                 expect(allocation.toNumber()).to.equal(expectedAllocations[i])
             }
         })
+
+        it("allocates the rewards recursively", async () => {
+            let timestamps = rewardTimestamps
+            let expectedAllocations = actualAllocations
+            await createKeeps(timestamps)
+            await rewards.allocateRewards(expectedAllocations.length - 1)
+            for (let i = 0; i < expectedAllocations.length; i++) {
+                let allocation = await rewards.getAllocatedRewards(i)
+                expect(allocation.toNumber()).to.equal(expectedAllocations[i])
+            }
+        })
     })
 })

--- a/solidity/test/RewardsTest.js
+++ b/solidity/test/RewardsTest.js
@@ -100,6 +100,15 @@ contract.only('ECDSAKeepRewards', (accounts) => {
         500000,
         500000,
     ]
+    const actualAllocations = [
+        199998, // 800002 remaining
+        400000, // 400002 remaining
+        50000,  // 350002 remaining
+        175000, // 175002 remaining
+        0,
+        87501, // 87501 remaining
+        87500, // 1 remaining
+    ]
 
     async function initializeNewFactory() {
         registry = await Registry.new()
@@ -384,6 +393,19 @@ contract.only('ECDSAKeepRewards', (accounts) => {
             await createKeeps(timestamps)
             for (let i = 0; i < expectedAllocations.length; i++) {
                 let allocation = await rewards.rewardPerKeep.call(i)
+                expect(allocation.toNumber()).to.equal(expectedAllocations[i])
+            }
+        })
+    })
+
+    describe("allocateRewards", async () => {
+        it("allocates the reward for each interval", async () => {
+            let timestamps = rewardTimestamps
+            let expectedAllocations = actualAllocations
+            await createKeeps(timestamps)
+            for (let i = 0; i < expectedAllocations.length; i++) {
+                await rewards.allocateRewards(i)
+                let allocation = await rewards.getAllocatedRewards(i)
                 expect(allocation.toNumber()).to.equal(expectedAllocations[i])
             }
         })

--- a/solidity/test/RewardsTest.js
+++ b/solidity/test/RewardsTest.js
@@ -95,6 +95,33 @@ contract.only('ECDSAKeepRewards', (accounts) => {
         await restoreSnapshot()
     })
 
+    describe("eligibleForReward", async () => {
+        it("returns true for happily closed keeps", async () => {
+            await createKeeps([1000])
+            let keepAddress = await keepFactory.getKeepAtIndex(0)
+            let keep = await RewardsKeepStub.at(keepAddress)
+            await keep.close()
+            let eligible = await rewards.eligibleForReward(keepAddress)
+            expect(eligible).to.equal(true)
+        })
+
+        it("returns false for terminated keeps", async () => {
+            await createKeeps([1000])
+            let keepAddress = await keepFactory.getKeepAtIndex(0)
+            let keep = await RewardsKeepStub.at(keepAddress)
+            await keep.terminate()
+            let eligible = await rewards.eligibleForReward(keepAddress)
+            expect(eligible).to.equal(false)
+        })
+
+        it("returns false for active keeps", async () => {
+            await createKeeps([1000])
+            let keepAddress = await keepFactory.getKeepAtIndex(0)
+            let eligible = await rewards.eligibleForReward(keepAddress)
+            expect(eligible).to.equal(false)
+        })
+    })
+
     describe("intervalOf", async () => {
         it("returns the correct interval", async () => {
             let interval1000 = await rewards.intervalOf(1000)

--- a/solidity/test/RewardsTest.js
+++ b/solidity/test/RewardsTest.js
@@ -110,6 +110,13 @@ contract.only('ECDSAKeepRewards', (accounts) => {
             let interval1000000 = await rewards.intervalOf(1000000)
             expect(interval1000000.toNumber()).to.equal(9990)
         })
+
+        it("reverts on timestamps before initiation", async () => {
+            await expectRevert(
+                rewards.intervalOf(999),
+                "Timestamp is before the first interval"
+            )
+        })
     })
 
     describe("findEndpoint", async () => {

--- a/solidity/test/RewardsTest.js
+++ b/solidity/test/RewardsTest.js
@@ -203,4 +203,16 @@ contract.only('ECDSAKeepRewards', (accounts) => {
             expect(index.toNumber()).to.equal(expectedIndex)
         })
     })
+
+    describe("getEndpoint", async () => {
+        it("reverts if the interval hasn't ended", async () => {
+            let recentTimestamp = await rewards.currentTime()
+            let targetTimestamp = recentTimestamp + termLength
+            let targetInterval = await rewards.intervalOf(targetTimestamp)
+            await expectRevert(
+                rewards.findEndpoint(targetTimestamp),
+                "interval hasn't ended yet"
+            )
+        })
+    })
 })

--- a/solidity/test/RewardsTest.js
+++ b/solidity/test/RewardsTest.js
@@ -15,6 +15,11 @@ const RewardsKeepStub = artifacts.require('RewardsKeepStub');
 const ECDSAKeepRewards = artifacts.require('ECDSAKeepRewards');
 
 contract.only('ECDSAKeepRewards', (accounts) => {
+    const alice = accounts[0]
+    const bob = accounts[1]
+    const aliceBeneficiary = accounts[2]
+    const bobBeneficiary = accounts[3]
+
     let masterKeep
     let factory
     let registry
@@ -126,10 +131,13 @@ contract.only('ECDSAKeepRewards', (accounts) => {
             keepBonding.address,
             randomBeacon.address
         )
+
+        await tokenStaking.setMagpie(alice, aliceBeneficiary)
+        await tokenStaking.setMagpie(bob, bobBeneficiary)
     }
 
     async function createKeeps(timestamps) {
-        await keepFactory.openSyntheticKeeps(timestamps)
+        await keepFactory.openSyntheticKeeps([alice, bob], timestamps)
         for (let i = 0; i < timestamps.length; i++) {
             let keepAddress = await keepFactory.getKeepAtIndex(i)
             let keep = await RewardsKeepStub.at(keepAddress)

--- a/solidity/test/RewardsTest.js
+++ b/solidity/test/RewardsTest.js
@@ -8,6 +8,7 @@ const KeepBonding = artifacts.require('KeepBonding');
 const TokenStakingStub = artifacts.require("TokenStakingStub")
 const BondedSortitionPoolFactory = artifacts.require('BondedSortitionPoolFactory');
 const RandomBeaconStub = artifacts.require('RandomBeaconStub')
+const TestToken = artifacts.require('TestToken')
 
 
 const RewardsKeepStub = artifacts.require('RewardsKeepStub');
@@ -18,6 +19,7 @@ contract.only('ECDSAKeepRewards', (accounts) => {
     let factory
     let registry
     let rewards
+    let token
 
     let tokenStaking
     let keepFactory
@@ -138,15 +140,19 @@ contract.only('ECDSAKeepRewards', (accounts) => {
     before(async () => {
         await initializeNewFactory()
 
+        token = await TestToken.new()
+
         rewards = await ECDSAKeepRewards.new(
             termLength,
             totalRewards,
-            accounts[0],
+            token,
             minimumIntervalKeeps,
             keepFactory.address,
             initiationTime,
             intervalWeights
         )
+
+        token.mint(rewards.address, totalRewards)
     })
 
     beforeEach(async () => {

--- a/solidity/test/RewardsTest.js
+++ b/solidity/test/RewardsTest.js
@@ -214,5 +214,19 @@ contract.only('ECDSAKeepRewards', (accounts) => {
                 "interval hasn't ended yet"
             )
         })
+
+        it("returns the correct number of keeps for the interval", async () => {
+            let timestamps = defaultTimestamps
+            await createKeeps(timestamps)
+            let keepCount = await rewards.getEndpoint.call(0)
+            expect(keepCount.toNumber()).to.equal(timestamps.length)
+        })
+
+        it("returns 0 for intervals with no keeps", async () => {
+            let timestamps = [1200, 1201]
+            await createKeeps(timestamps)
+            let keepCount = await rewards.getEndpoint.call(1)
+            expect(keepCount.toNumber()).to.equal(0)
+        })
     })
 })

--- a/solidity/test/RewardsTest.js
+++ b/solidity/test/RewardsTest.js
@@ -435,4 +435,32 @@ contract.only('ECDSAKeepRewards', (accounts) => {
             }
         })
     })
+
+    describe("isAllocated", async () => {
+        it("returns false before allocation and true after allocation", async () => {
+            let timestamps = rewardTimestamps
+            let expectedAllocations = actualAllocations
+            await createKeeps(timestamps)
+            for (let i = 0; i < expectedAllocations.length; i++) {
+                let preAllocated = await rewards.isAllocated(i)
+                expect(preAllocated).to.equal(false)
+                await rewards.allocateRewards(i)
+                let postAllocated = await rewards.isAllocated(i)
+                expect(postAllocated).to.equal(true)
+            }
+        })
+    })
+
+    describe("claimRewards", async () => {
+        it("lets closed keeps claim the reward correctly", async () => {
+            let timestamps = rewardTimestamps
+            await createKeeps(timestamps)
+            let keepAddress = await keepFactory.getKeepAtIndex(0)
+            let keep = await RewardsKeepStub.at(keepAddress)
+            await keep.close()
+            await rewards.claimRewards(keepAddress)
+            let aliceBalance = await token.balanceOf(aliceBeneficiary)
+            expect(aliceBalance.toNumber()).to.equal(33333)
+        })
+    })
 })

--- a/solidity/test/RewardsTest.js
+++ b/solidity/test/RewardsTest.js
@@ -49,6 +49,14 @@ contract.only('ECDSAKeepRewards', (accounts) => {
     const initiationTime = 1000
     const termLength = 100
 
+    const intervalWeights = [
+        // percentage of unallocated rewards, allocated : remaining
+        20, // 20:80
+        50, // 40:40
+        25, // 10:30
+        50, // 15:15
+    ]
+
     async function initializeNewFactory() {
         registry = await Registry.new()
         bondedSortitionPoolFactory = await BondedSortitionPoolFactory.new()
@@ -83,7 +91,8 @@ contract.only('ECDSAKeepRewards', (accounts) => {
             accounts[0],
             0,
             keepFactory.address,
-            initiationTime
+            initiationTime,
+            intervalWeights
         )
     })
 
@@ -254,6 +263,27 @@ contract.only('ECDSAKeepRewards', (accounts) => {
             await createKeeps(timestamps)
             let keepCount = await rewards.getEndpoint.call(1)
             expect(keepCount.toNumber()).to.equal(0)
+        })
+    })
+
+    describe("getIntervalWeight", async () => {
+        it("returns the weight of a defined interval", async () => {
+            let weight0 = await rewards.getIntervalWeight(0)
+            expect(weight0.toNumber()).to.equal(20)
+            let weight3 = await rewards.getIntervalWeight(3)
+            expect(weight3.toNumber()).to.equal(50)
+        })
+
+        it("returns 100% after the defined intervals", async () => {
+            let weight4 = await rewards.getIntervalWeight(4)
+            expect(weight4.toNumber()).to.equal(100)
+        })
+    })
+
+    describe("getIntervalCount", async () => {
+        it("returns the number of defined intervals", async () => {
+            let intervalCount = await rewards.getIntervalCount()
+            expect(intervalCount.toNumber()).to.equal(4)
         })
     })
 })

--- a/solidity/test/RewardsTest.js
+++ b/solidity/test/RewardsTest.js
@@ -12,7 +12,7 @@ const TestToken = artifacts.require('TestToken')
 
 
 const RewardsKeepStub = artifacts.require('RewardsKeepStub');
-const ECDSAKeepRewards = artifacts.require('ECDSAKeepRewards');
+const ECDSAKeepRewardsStub = artifacts.require('ECDSAKeepRewardsStub');
 
 contract.only('ECDSAKeepRewards', (accounts) => {
     const alice = accounts[0]
@@ -149,7 +149,7 @@ contract.only('ECDSAKeepRewards', (accounts) => {
 
         token = await TestToken.new()
 
-        rewards = await ECDSAKeepRewards.new(
+        rewards = await ECDSAKeepRewardsStub.new(
             termLength,
             totalRewards,
             token.address,

--- a/solidity/test/RewardsTest.js
+++ b/solidity/test/RewardsTest.js
@@ -210,8 +210,8 @@ contract.only('ECDSAKeepRewards', (accounts) => {
             let targetTimestamp = recentTimestamp + termLength
             let targetInterval = await rewards.intervalOf(targetTimestamp)
             await expectRevert(
-                rewards.findEndpoint(targetTimestamp),
-                "interval hasn't ended yet"
+                rewards.getEndpoint(targetInterval),
+                "Interval hasn't ended yet"
             )
         })
 

--- a/solidity/test/RewardsTest.js
+++ b/solidity/test/RewardsTest.js
@@ -91,6 +91,15 @@ contract.only('ECDSAKeepRewards', (accounts) => {
         500000,
         1000000,
     ]
+    const inVacuumPerKeepRewards = [
+        66666,
+        125000,
+        125000,
+        250000,
+        0,
+        500000,
+        500000,
+    ]
 
     async function initializeNewFactory() {
         registry = await Registry.new()
@@ -363,6 +372,18 @@ contract.only('ECDSAKeepRewards', (accounts) => {
             await createKeeps(timestamps)
             for (let i = 0; i < expectedAllocations.length; i++) {
                 let allocation = await rewards.adjustedAllocation.call(i)
+                expect(allocation.toNumber()).to.equal(expectedAllocations[i])
+            }
+        })
+    })
+
+    describe("rewardPerKeep", async () => {
+        it("returns the per keep allocation of the interval", async () => {
+            let timestamps = rewardTimestamps
+            let expectedAllocations = inVacuumPerKeepRewards
+            await createKeeps(timestamps)
+            for (let i = 0; i < expectedAllocations.length; i++) {
+                let allocation = await rewards.rewardPerKeep.call(i)
                 expect(allocation.toNumber()).to.equal(expectedAllocations[i])
             }
         })

--- a/solidity/test/RewardsTest.js
+++ b/solidity/test/RewardsTest.js
@@ -21,7 +21,6 @@ contract.only('ECDSAKeepRewards', (accounts) => {
     const bobBeneficiary = accounts[3]
     const funder = accounts[9]
 
-    let factory
     let registry
     let rewards
     let token
@@ -31,7 +30,6 @@ contract.only('ECDSAKeepRewards', (accounts) => {
     let bondedSortitionPoolFactory
     let keepBonding
     let randomBeacon
-    let signerPool
 
     // defaultTimestamps[i] == 1000 + i
     const defaultTimestamps = [

--- a/solidity/test/RewardsTest.js
+++ b/solidity/test/RewardsTest.js
@@ -251,12 +251,12 @@ contract.only('ECDSAKeepRewards', (accounts) => {
 
     describe("startOf", async () => {
         it("returns the start of the interval", async () => {
-            let end0 = await rewards.startOf(0)
-            expect(end0.toNumber()).to.equal(1000)
-            let end1 = await rewards.startOf(1)
-            expect(end1.toNumber()).to.equal(1100)
-            let end9990 = await rewards.startOf(9990)
-            expect(end9990.toNumber()).to.equal(1000000)
+            let start0 = await rewards.startOf(0)
+            expect(start0.toNumber()).to.equal(1000)
+            let start1 = await rewards.startOf(1)
+            expect(start1.toNumber()).to.equal(1100)
+            let start9990 = await rewards.startOf(9990)
+            expect(start9990.toNumber()).to.equal(1000000)
         })
     })
 

--- a/solidity/test/contracts/BondedECDSAKeepCloneFactoryStub.sol
+++ b/solidity/test/contracts/BondedECDSAKeepCloneFactoryStub.sol
@@ -8,7 +8,6 @@ import "../../contracts/CloneFactory.sol";
 contract BondedECDSAKeepCloneFactory is CloneFactory {
     address public masterBondedECDSAKeepAddress;
     bool public membersSlashed;
-    bool public notifiedKeepClosed;
 
     constructor(address _masterBondedECDSAKeepAddress) public {
         masterBondedECDSAKeepAddress = _masterBondedECDSAKeepAddress;
@@ -42,9 +41,5 @@ contract BondedECDSAKeepCloneFactory is CloneFactory {
 
     function slashKeepMembers() public {
         membersSlashed = true;
-    }
-
-    function notifyKeepClosed() public {
-        notifiedKeepClosed = true;
     }
 }

--- a/solidity/test/contracts/BondedECDSAKeepFactoryStub.sol
+++ b/solidity/test/contracts/BondedECDSAKeepFactoryStub.sol
@@ -31,14 +31,8 @@ contract BondedECDSAKeepFactoryStub is BondedECDSAKeepFactory {
     }
 
     function addKeep(address keep) public {
-        keeps[keep] = true;
-    }
-
-    function removeKeep(address keep) public {
-        keeps[keep] = false;
-    }
-
-    function hasKeep(address _keepAddress) public view returns (bool) {
-        return keeps[_keepAddress];
+        keeps.push(keep);
+        /* solium-disable-next-line security/no-block-members*/
+        creationTime[keep] = block.timestamp;
     }
 }

--- a/solidity/test/contracts/ECDSAKeepRewardsStub.sol
+++ b/solidity/test/contracts/ECDSAKeepRewardsStub.sol
@@ -5,7 +5,6 @@ import "../../contracts/ECDSAKeepRewards.sol";
 contract ECDSAKeepRewardsStub is ECDSAKeepRewards {
     constructor (
         uint256 _termLength,
-        uint256 _totalRewards,
         address _keepToken,
         uint256 _minimumKeepsPerInterval,
         address factoryAddress,
@@ -15,7 +14,6 @@ contract ECDSAKeepRewardsStub is ECDSAKeepRewards {
         public
         ECDSAKeepRewards(
             _termLength,
-            _totalRewards,
             _keepToken,
             _minimumKeepsPerInterval,
             factoryAddress,
@@ -23,6 +21,18 @@ contract ECDSAKeepRewardsStub is ECDSAKeepRewards {
             _intervalWeights
         )
     {}
+
+    function getTotalRewards() public view returns (uint256) {
+        return totalRewards;
+    }
+
+    function getUnallocatedRewards() public view returns (uint256) {
+        return unallocatedRewards;
+    }
+
+    function getPaidOutRewards() public view returns (uint256) {
+        return paidOutRewards;
+    }
 
     function currentTime() public view returns (uint256) {
         return block.timestamp;

--- a/solidity/test/contracts/ECDSAKeepRewardsStub.sol
+++ b/solidity/test/contracts/ECDSAKeepRewardsStub.sol
@@ -1,0 +1,67 @@
+pragma solidity ^0.5.4;
+
+import "../../contracts/ECDSAKeepRewards.sol";
+
+contract ECDSAKeepRewardsStub is ECDSAKeepRewards {
+    constructor (
+        uint256 _termLength,
+        uint256 _totalRewards,
+        address _keepToken,
+        uint256 _minimumKeepsPerInterval,
+        address factoryAddress,
+        uint256 _initiated,
+        uint256[] memory _intervalWeights
+    )
+        public
+        ECDSAKeepRewards(
+            _termLength,
+            _totalRewards,
+            _keepToken,
+            _minimumKeepsPerInterval,
+            factoryAddress,
+            _initiated,
+            _intervalWeights
+        )
+    {}
+
+    function currentTime() public view returns (uint256) {
+        return block.timestamp;
+    }
+
+    function findEndpoint(uint256 intervalEndpoint) public view returns (uint256) {
+        return _findEndpoint(intervalEndpoint);
+    }
+    function getEndpoint(uint256 interval) public returns (uint256) {
+        return _getEndpoint(interval);
+    }
+    function keepsInInterval(uint256 interval) public returns (uint256) {
+        return _keepsInInterval(interval);
+    }
+    function keepCountAdjustment(uint256 interval) public returns (uint256) {
+        return _keepCountAdjustment(interval);
+    }
+    function getIntervalWeight(uint256 interval) public view returns (uint256) {
+        return _getIntervalWeight(interval);
+    }
+    function getIntervalCount() public view returns (uint256) {
+        return _getIntervalCount();
+    }
+    function baseAllocation(uint256 interval) public view returns (uint256) {
+        return _baseAllocation(interval);
+    }
+    function adjustedAllocation(uint256 interval) public returns (uint256) {
+        return _adjustedAllocation(interval);
+    }
+    function rewardPerKeep(uint256 interval) public returns (uint256) {
+        return _rewardPerKeep(interval);
+    }
+    function allocateRewards(uint256 interval) public {
+        _allocateRewards(interval);
+    }
+    function getAllocatedRewards(uint256 interval) public view returns (uint256) {
+        return _getAllocatedRewards(interval);
+    }
+    function isAllocated(uint256 interval) public view returns (bool) {
+        return _isAllocated(interval);
+    }
+}

--- a/solidity/test/contracts/RewardsFactoryStub.sol
+++ b/solidity/test/contracts/RewardsFactoryStub.sol
@@ -40,7 +40,8 @@ contract RewardsFactoryStub is BondedECDSAKeepFactory {
                 members,
                 members.length,
                 address(tokenStaking),
-                address(keepBonding)
+                address(keepBonding),
+                address(this)
             );
             keeps.push(keepAddress);
             creationTime[keepAddress] = timestamps[i];
@@ -61,6 +62,7 @@ contract RewardsFactoryStub is BondedECDSAKeepFactory {
             _owner,
             members,
             0,
+            address(0),
             address(0),
             address(0)
         );

--- a/solidity/test/contracts/RewardsFactoryStub.sol
+++ b/solidity/test/contracts/RewardsFactoryStub.sol
@@ -24,7 +24,10 @@ contract RewardsFactoryStub is BondedECDSAKeepFactory {
 
     /// @notice Opens new keeps with the provided arbitrary timestamps.
     /// @param timestamps Arbitrary timestamps, in ascending order.
-    function openSyntheticKeeps(uint256[] calldata timestamps) external {
+    function openSyntheticKeeps(
+        address[] calldata members,
+        uint256[] calldata timestamps
+    ) external {
         for (uint256 i = 0; i < timestamps.length; i++) {
             require(
                 i == 0 || timestamps[i] >= timestamps[i-1],
@@ -32,6 +35,13 @@ contract RewardsFactoryStub is BondedECDSAKeepFactory {
             );
             address keepAddress = createClone(masterBondedECDSAKeepAddress);
             BondedECDSAKeep keep = BondedECDSAKeep(keepAddress);
+            keep.initialize(
+                msg.sender,
+                members,
+                members.length,
+                address(tokenStaking),
+                address(keepBonding)
+            );
             keeps.push(keepAddress);
             creationTime[keepAddress] = timestamps[i];
         }

--- a/solidity/test/contracts/RewardsKeepStub.sol
+++ b/solidity/test/contracts/RewardsKeepStub.sol
@@ -6,4 +6,12 @@ contract RewardsKeepStub is BondedECDSAKeep {
     function setTimestamp(uint256 time) external {
         keyGenerationStartTimestamp = time;
     }
+
+    function close() external {
+        markAsClosed();
+    }
+
+    function terminate() external {
+        markAsTerminated();
+    }
 }

--- a/solidity/test/contracts/RewardsKeepStub.sol
+++ b/solidity/test/contracts/RewardsKeepStub.sol
@@ -1,0 +1,9 @@
+pragma solidity ^0.5.4;
+
+import "../../contracts/BondedECDSAKeep.sol";
+
+contract RewardsKeepStub is BondedECDSAKeep {
+    function setTimestamp(uint256 time) external {
+        keyGenerationStartTimestamp = time;
+    }
+}

--- a/solidity/test/contracts/TestToken.sol
+++ b/solidity/test/contracts/TestToken.sol
@@ -2,6 +2,14 @@ pragma solidity ^0.5.4;
 
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 
+interface tokenRecipient {
+    function receiveApproval(
+        address _from,
+        uint256 _value,
+        address _token,
+        bytes calldata _extraData) external;
+}
+
 contract TestToken is ERC20 {
 
     /// @dev             Mints an amount of the token and assigns it to an account.
@@ -12,5 +20,13 @@ contract TestToken is ERC20 {
         // NOTE: this is a public function with unchecked minting.
         _mint(_account, _amount);
         return true;
+    }
+
+    function approveAndCall(address _spender, uint256 _value, bytes memory _extraData) public returns (bool success) {
+        tokenRecipient spender = tokenRecipient(_spender);
+        if (approve(_spender, _value)) {
+            spender.receiveApproval(msg.sender, _value, address(this), _extraData);
+            return true;
+        }
     }
 }


### PR DESCRIPTION
Refs: #446
ECDSAKeep Rewards to distribute KEEP tokens to keep owners based on a predetermined curve separated by intervals. 

Draft until:
- [ ] fully tested
- [ ] documented
- [ ] cleaned up
- [ ] optimized


