### PR TITLE
Bumping up version to 0.10.0-pre.0

### DIFF
--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "0.9.0",
+  "version": "0.10.0-pre.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "0.9.0",
+  "version": "0.10.0-pre.0",
   "description": "Smart contracts for ECDSA Keep",
   "repository": {
     "type": "git",


### PR DESCRIPTION
After `0.9.0` release, we are bumping up version to `0.10.0-pre.0` for snapshot deployments.