### PR TITLE
Bumping up version 0.10.0-rc -> 0.11.0-pre.0

### DIFF
--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "0.10.0-rc",
+  "version": "0.11.0-pre.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "0.10.0-rc",
+  "version": "0.11.0-pre.0",
   "description": "Smart contracts for ECDSA Keep",
   "repository": {
     "type": "git",


### PR DESCRIPTION
With `0.10.0` version [released](https://github.com/keep-network/keep-tecdsa/releases/tag/v0.10.0-rc) we need to bump up version to `0.11.0-*`.