### PR TITLE
Updating keep-core dependency to v0.10.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/gogo/protobuf v1.3.1
 	github.com/ipfs/go-log v0.0.1
 	github.com/keep-network/keep-common v0.1.1-0.20200228111656-16dd370ca897 // TODO: update to released version
-	github.com/keep-network/keep-core v0.9.2-0.20200221162942-550bec0a966c
+	github.com/keep-network/keep-core v0.10.0
 	github.com/olekukonko/tablewriter v0.0.4 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/urfave/cli v1.22.1

--- a/go.sum
+++ b/go.sum
@@ -248,6 +248,8 @@ github.com/keep-network/keep-common v0.1.1-0.20200228111656-16dd370ca897 h1:0T9+
 github.com/keep-network/keep-common v0.1.1-0.20200228111656-16dd370ca897/go.mod h1:QPhFeJa7snRCRlqIr+0G7ifgxEYwALIa/UfcMzeyxAk=
 github.com/keep-network/keep-core v0.9.2-0.20200221162942-550bec0a966c h1:R7wNpsCsifhuXNEK98werTW+nTJO+0EYXsOBlxfCCFQ=
 github.com/keep-network/keep-core v0.9.2-0.20200221162942-550bec0a966c/go.mod h1:+bg+0mNutA7iBwL0Id90Cv4UycmmGEwC/z6/9GWYljo=
+github.com/keep-network/keep-core v0.10.0 h1:+aZe5BMwmaGgZdXdGvIHun2PNtJE4L1SPnBtRL8CRVY=
+github.com/keep-network/keep-core v0.10.0/go.mod h1:9ImACmSRMnBLRN3b/RS38OqTstdfy3Y3UHNMmdejLqo=
 github.com/keep-network/toml v0.3.0 h1:G+NJwWR/ZiORqeLBsDXDchYoL29PXHdxOPcCueA7ctE=
 github.com/keep-network/toml v0.3.0/go.mod h1:Zeyd3lxbIlMYLREho3UK1dMP2xjqt2gLkQ5E5vM6K38=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=


### PR DESCRIPTION
Updating `keep-core` Go dependency to the most recent release version, `v0.10.0`.