### PR TITLE
ETH-only bonding

### DIFF
--- a/solidity/contracts/AbstractBonding.sol
+++ b/solidity/contracts/AbstractBonding.sol
@@ -1,0 +1,249 @@
+pragma solidity ^0.5.4;
+
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+
+// TODO: This contract is expected to implement functions defined by IBonding
+// interface defined in @keep-network/sortition-pools. After merging the
+// repositories we need to move IBonding definition to sit closer to KeepBonding
+// contract so that sortition pools import it for own needs. It is the bonding
+// module which should define an interface, and sortition pool module should be
+// just importing it.
+
+/// @title Abstract Bonding
+/// @notice Shared code for holding deposits from keeps' operators.
+contract AbstractBonding {
+    using SafeMath for uint256;
+
+    // Unassigned value in wei deposited by operators.
+    mapping(address => uint256) public unbondedValue;
+
+    // References to created bonds. Bond identifier is built from operator's
+    // address, holder's address and reference ID assigned on bond creation.
+    mapping(bytes32 => uint256) internal lockedBonds;
+
+    // Sortition pools authorized by operator's authorizer.
+    // operator -> pool -> boolean
+    mapping(address => mapping (address => bool)) internal authorizedPools;
+
+    /// @notice Returns the amount of wei the operator has made available for
+    /// bonding and that is still unbounded. If the operator doesn't exist or
+    /// bond creator is not authorized as an operator contract or it is not
+    /// authorized by the operator or there is no secondary authorization for
+    /// the provided sortition pool, function returns 0.
+    /// @dev Implements function expected by sortition pools' IBonding interface.
+    /// @param operator Address of the operator.
+    /// @param bondCreator Address authorized to create a bond.
+    /// @param authorizedSortitionPool Address of authorized sortition pool.
+    /// @return Amount of authorized wei deposit available for bonding.
+    function availableUnbondedValue(
+        address operator,
+        address bondCreator,
+        address authorizedSortitionPool
+    ) public view returns (uint256);
+
+    /// @notice Add the provided value to operator's pool available for bonding.
+    /// @param operator Address of the operator.
+    function deposit(address operator) external payable;
+
+    /// @notice Withdraws amount from operator's value available for bonding.
+    /// Can be called only by the operator or by the stake owner.
+    /// @param amount Value to withdraw in wei.
+    /// @param operator Address of the operator.
+    function withdraw(uint256 amount, address operator) public {
+        require(
+            _isWithdrawerOf(msg.sender, operator),
+            "Not authorized to withdraw bond"
+        );
+
+        require(
+            unbondedValue[operator] >= amount,
+            "Insufficient unbonded value"
+        );
+
+        unbondedValue[operator] = unbondedValue[operator].sub(amount);
+
+        (bool success, ) = _beneficiaryOf(operator).call.value(amount)("");
+        require(success, "Transfer failed");
+    }
+
+    /// @notice Create bond for the given operator, holder, reference and amount.
+    /// @dev Function can be executed only by authorized contract. Reference ID
+    /// should be unique for holder and operator.
+    /// @param operator Address of the operator to bond.
+    /// @param holder Address of the holder of the bond.
+    /// @param referenceID Reference ID used to track the bond by holder.
+    /// @param amount Value to bond in wei.
+    /// @param authorizedSortitionPool Address of authorized sortition pool.
+    function createBond(
+        address operator,
+        address holder,
+        uint256 referenceID,
+        uint256 amount,
+        address authorizedSortitionPool
+    ) public {
+        require(
+            availableUnbondedValue(
+                operator,
+                msg.sender,
+                authorizedSortitionPool
+            ) >= amount,
+            "Insufficient unbonded value"
+        );
+
+        bytes32 bondID = keccak256(
+            abi.encodePacked(operator, holder, referenceID)
+        );
+
+        require(
+            lockedBonds[bondID] == 0,
+            "Reference ID not unique for holder and operator"
+        );
+
+        unbondedValue[operator] = unbondedValue[operator].sub(amount);
+        lockedBonds[bondID] = lockedBonds[bondID].add(amount);
+    }
+
+    /// @notice Returns value of wei bonded for the operator.
+    /// @param operator Address of the operator.
+    /// @param holder Address of the holder of the bond.
+    /// @param referenceID Reference ID of the bond.
+    /// @return Amount of wei in the selected bond.
+    function bondAmount(address operator, address holder, uint256 referenceID)
+        public
+        view
+        returns (uint256)
+    {
+        bytes32 bondID = keccak256(
+            abi.encodePacked(operator, holder, referenceID)
+        );
+
+        return lockedBonds[bondID];
+    }
+
+    /// @notice Reassigns a bond to a new holder under a new reference.
+    /// @dev Function requires that a caller is the current holder of the bond
+    /// which is being reassigned.
+    /// @param operator Address of the bonded operator.
+    /// @param referenceID Reference ID of the bond.
+    /// @param newHolder Address of the new holder of the bond.
+    /// @param newReferenceID New reference ID to register the bond.
+    function reassignBond(
+        address operator,
+        uint256 referenceID,
+        address newHolder,
+        uint256 newReferenceID
+    ) public {
+        address holder = msg.sender;
+        bytes32 bondID = keccak256(
+            abi.encodePacked(operator, holder, referenceID)
+        );
+
+        require(lockedBonds[bondID] > 0, "Bond not found");
+
+        bytes32 newBondID = keccak256(
+            abi.encodePacked(operator, newHolder, newReferenceID)
+        );
+
+        require(
+            lockedBonds[newBondID] == 0,
+            "Reference ID not unique for holder and operator"
+        );
+
+        lockedBonds[newBondID] = lockedBonds[bondID];
+        lockedBonds[bondID] = 0;
+    }
+
+    /// @notice Releases the bond and moves the bond value to the operator's
+    /// unbounded value pool.
+    /// @dev Function requires that caller is the holder of the bond which is
+    /// being released.
+    /// @param operator Address of the bonded operator.
+    /// @param referenceID Reference ID of the bond.
+    function freeBond(address operator, uint256 referenceID) public {
+        address holder = msg.sender;
+        bytes32 bondID = keccak256(
+            abi.encodePacked(operator, holder, referenceID)
+        );
+
+        require(lockedBonds[bondID] > 0, "Bond not found");
+
+        uint256 amount = lockedBonds[bondID];
+        lockedBonds[bondID] = 0;
+        unbondedValue[operator] = unbondedValue[operator].add(amount);
+    }
+
+    /// @notice Seizes the bond by moving some or all of the locked bond to the
+    /// provided destination address.
+    /// @dev Function requires that a caller is the holder of the bond which is
+    /// being seized.
+    /// @param operator Address of the bonded operator.
+    /// @param referenceID Reference ID of the bond.
+    /// @param amount Amount to be seized.
+    /// @param destination Address to send the amount to.
+    function seizeBond(
+        address operator,
+        uint256 referenceID,
+        uint256 amount,
+        address payable destination
+    ) public {
+        require(amount > 0, "Requested amount should be greater than zero");
+
+        address payable holder = msg.sender;
+        bytes32 bondID = keccak256(
+            abi.encodePacked(operator, holder, referenceID)
+        );
+
+        require(
+            lockedBonds[bondID] >= amount,
+            "Requested amount is greater than the bond"
+        );
+
+        lockedBonds[bondID] = lockedBonds[bondID].sub(amount);
+
+        (bool success, ) = destination.call.value(amount)("");
+        require(success, "Transfer failed");
+    }
+
+    /// @notice Authorizes sortition pool for the provided operator.
+    /// Operator's authorizers need to authorize individual sortition pools
+    /// per application since they may be interested in participating only in
+    /// a subset of keep types used by the given appliction.
+    /// @dev Only operator's authorizer can call this function.
+    function authorizeSortitionPoolContract(
+        address _operator,
+        address _poolAddress
+    ) public {
+        require(
+            _isAuthorizerOf(msg.sender, _operator),
+            "Not authorized"
+        );
+        authorizedPools[_operator][_poolAddress] = true;
+    }
+
+    /// @notice Checks if the sortition pool has been authorized for the
+    /// provided operator by its authorizer.
+    /// @dev See authorizeSortitionPoolContract.
+    function hasSecondaryAuthorization(
+        address _operator,
+        address _poolAddress
+    ) public view returns (bool) {
+        return authorizedPools[_operator][_poolAddress];
+    }
+
+    /// @notice Return whether _sender may withdraw for _operator.
+    function _isWithdrawerOf(
+        address _sender,
+        address _operator
+    ) internal view returns (bool);
+
+    /// @notice Return whether _sender is the authorizer of _operator.
+    function _isAuthorizerOf(
+        address _sender,
+        address _operator
+    ) internal view returns (bool);
+
+    /// @notice Get the beneficiary of _operator.
+    function _beneficiaryOf(
+        address _operator
+    ) internal view returns (address payable);
+}

--- a/solidity/contracts/EthBonding.sol
+++ b/solidity/contracts/EthBonding.sol
@@ -1,0 +1,113 @@
+pragma solidity ^0.5.4;
+
+import "./AbstractBonding.sol";
+
+import "@keep-network/keep-core/contracts/Registry.sol";
+
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+
+// TODO: This contract is expected to implement functions defined by IBonding
+// interface defined in @keep-network/sortition-pools. After merging the
+// repositories we need to move IBonding definition to sit closer to KeepBonding
+// contract so that sortition pools import it for own needs. It is the bonding
+// module which should define an interface, and sortition pool module should be
+// just importing it.
+
+/// @title Eth Bonding
+/// @notice Contract holding deposits from keeps' operators.
+contract EthBonding is AbstractBonding {
+    using SafeMath for uint256;
+
+    // Registry contract with a list of approved factories (operator contracts).
+    Registry internal registry;
+
+    uint256 internal initializationPeriod;
+
+    mapping(address => uint256) public createdAt;
+
+    // Operator contracts authorized by operators.
+    mapping(address => mapping(address => bool)) internal authorizedOperatorContracts;
+
+    /// @notice Initializes Keep Bonding contract.
+    /// @param registryAddress Keep registry contract address.
+    /// @param _initializationPeriod Initialization period.
+    constructor(address registryAddress, uint256 _initializationPeriod) public {
+        registry = Registry(registryAddress);
+        initializationPeriod = _initializationPeriod;
+    }
+
+    function isInitialized(address operator) public view returns (bool) {
+        return block.number > createdAt[operator].add(initializationPeriod);
+    }
+
+    /// @notice Returns the amount of wei the operator has made available for
+    /// bonding and that is still unbounded. If the operator doesn't exist or
+    /// bond creator is not authorized as an operator contract or it is not
+    /// authorized by the operator or there is no secondary authorization for
+    /// the provided sortition pool, function returns 0.
+    /// @dev Implements function expected by sortition pools' IBonding interface.
+    /// @param operator Address of the operator.
+    /// @param bondCreator Address authorized to create a bond.
+    /// @param authorizedSortitionPool Address of authorized sortition pool.
+    /// @return Amount of authorized wei deposit available for bonding.
+    function availableUnbondedValue(
+        address operator,
+        address bondCreator,
+        address authorizedSortitionPool
+    ) public view returns (uint256) {
+        // Sortition pools check this condition and skips operators that
+        // are no longer eligible. We cannot revert here.
+        if (
+            isInitialized(operator) &&
+            registry.isApprovedOperatorContract(bondCreator) &&
+            authorizedOperatorContracts[operator][bondCreator] &&
+            hasSecondaryAuthorization(operator, authorizedSortitionPool)
+        ) {
+          return unbondedValue[operator];
+        }
+
+        return 0;
+    }
+
+    /// @notice Add the provided value to operator's pool available for bonding.
+    /// @param operator Address of the operator.
+    function deposit(address operator) external payable {
+        require(
+            createdAt[operator] == 0,
+            "Operator already in use"
+        );
+        unbondedValue[operator] = msg.value;
+        createdAt[operator] = block.number;
+    }
+
+    function authorizeOperatorContract(
+        address _operator,
+        address _contract
+    ) public {
+        require(
+            _isAuthorizerOf(msg.sender, _operator),
+            "May not authorize for other addresses"
+        );
+        authorizedOperatorContracts[_operator][_contract] = true;
+    }
+
+    function _isWithdrawerOf(
+        address _sender,
+        address _operator
+    ) internal view returns (bool) {
+        return _sender == _operator;
+    }
+
+    function _isAuthorizerOf(
+        address _sender,
+        address _operator
+    ) internal view returns (bool) {
+        return _sender == _operator;
+    }
+
+    function _beneficiaryOf(
+        address _operator
+    ) internal view returns (address payable) {
+        return address(uint160(_operator));
+    }
+}

--- a/solidity/test/EthBondingTest.js
+++ b/solidity/test/EthBondingTest.js
@@ -1,0 +1,547 @@
+import { createSnapshot, restoreSnapshot } from "./helpers/snapshot";
+import { mineBlocks } from "./helpers/mineBlocks";
+
+const Registry = artifacts.require('./Registry.sol')
+const TokenStaking = artifacts.require('./TokenStakingStub.sol')
+const EthBonding = artifacts.require('./EthBonding.sol')
+const TestEtherReceiver = artifacts.require('./TestEtherReceiver.sol')
+
+const { expectRevert } = require('openzeppelin-test-helpers');
+
+const BN = web3.utils.BN
+
+const chai = require('chai')
+chai.use(require('bn-chai')(BN))
+const expect = chai.expect
+
+contract('EthBonding', (accounts) => {
+    let registry
+    let tokenStaking
+    let ethBonding
+    let etherReceiver
+
+    let operator
+    let authorizer
+    let notOperator
+    let bondCreator
+    let sortitionPool
+
+    const initializationPeriod = 10
+
+    before(async () => {
+        operator = accounts[1]
+        authorizer = operator
+        notOperator = accounts[3]
+        bondCreator = accounts[4]
+        sortitionPool = accounts[5]
+
+        registry = await Registry.new()
+        ethBonding = await EthBonding.new(registry.address, initializationPeriod)
+        etherReceiver = await TestEtherReceiver.new()
+
+        await registry.approveOperatorContract(bondCreator)
+        await ethBonding.authorizeSortitionPoolContract(
+            operator,
+            sortitionPool,
+            { from: operator }
+        )
+
+        await ethBonding.authorizeOperatorContract(
+            operator,
+            bondCreator,
+            { from: operator }
+        )
+    })
+
+    beforeEach(async () => {
+        await createSnapshot()
+    })
+
+    afterEach(async () => {
+        await restoreSnapshot()
+    })
+
+    describe('deposit', async () => {
+        it('registers unbonded value', async () => {
+            const value = new BN(100)
+
+            const expectedUnbonded = value
+
+            await ethBonding.deposit(operator, { value: value })
+            await mineBlocks(initializationPeriod + 1)
+
+            const unbonded = await ethBonding.availableUnbondedValue(operator, bondCreator, sortitionPool)
+
+            expect(unbonded).to.eq.BN(expectedUnbonded, 'invalid unbonded value')
+        })
+    })
+
+    describe('withdraw', async () => {
+        const value = new BN(1000)
+
+        beforeEach(async () => {
+            await ethBonding.deposit(operator, { value: value })
+            await mineBlocks(initializationPeriod + 1)
+        })
+
+        // it('transfers unbonded value to operator', async () => {
+        //     const expectedUnbonded = 0
+        //     const expectedOperatorBalance = web3.utils.toBN(
+        //         await web3.eth.getBalance(operator)
+        //     ).add(value)
+
+        //     await ethBonding.withdraw(value, operator, { from: operator })
+
+        //     const unbonded = await ethBonding.availableUnbondedValue(
+        //         operator,
+        //         bondCreator,
+        //         sortitionPool
+        //     )
+        //     expect(unbonded).to.eq.BN(expectedUnbonded, 'invalid unbonded value')
+
+        //     const actualOperatorBalance = await web3.eth.getBalance(operator)
+        //     expect(actualOperatorBalance).to.eq.BN(
+        //         expectedOperatorBalance,
+        //         'invalid operator balance'
+        //     )
+        // })
+
+        it('reverts if insufficient unbonded value', async () => {
+            const invalidValue = value.add(new BN(1))
+
+            await expectRevert(
+                ethBonding.withdraw(invalidValue, operator, { from: operator }),
+                "Insufficient unbonded value"
+            )
+        })
+
+        it('reverts if transfer fails', async () => {
+            await ethBonding.deposit(etherReceiver.address, { value: value })
+            await mineBlocks(initializationPeriod + 1)
+
+            await etherReceiver.setShouldFail(true)
+
+            await expectRevert(
+                ethBonding.withdraw(
+                    value,
+                    etherReceiver.address,
+                    { from: etherReceiver.address }
+                ),
+                "Transfer failed"
+            )
+        })
+
+        it('reverts if someone else is trying to withdraw bond', async () => {
+            await expectRevert(
+                ethBonding.withdraw(value, operator, { from: notOperator }),
+                "Not authorized to withdraw bond"
+            )
+        })
+    })
+
+    describe('availableUnbondedValue', async () => {
+        const value = new BN(100)
+
+        beforeEach(async () => {
+            await ethBonding.deposit(operator, { value: value })
+            await mineBlocks(initializationPeriod + 1)
+        })
+
+        it('returns zero for operator with no deposit', async () => {
+            const unbondedOperator = "0x0000000000000000000000000000000000000001"
+            const expectedUnbonded = 0
+
+            const unbondedValue = await ethBonding.availableUnbondedValue(
+                unbondedOperator,
+                bondCreator,
+                sortitionPool
+            )
+            expect(unbondedValue).to.eq.BN(expectedUnbonded, 'invalid unbonded value')
+        })
+
+        it('return zero when bond creator is not approved by operator', async () => {
+            const notApprovedBondCreator = "0x0000000000000000000000000000000000000001"
+            const expectedUnbonded = 0
+
+            const unbondedValue = await ethBonding.availableUnbondedValue(
+                operator,
+                notApprovedBondCreator,
+                sortitionPool
+            )
+            expect(unbondedValue).to.eq.BN(expectedUnbonded, 'invalid unbonded value')
+        })
+
+        it('returns zero when sortition pool is not authorized', async () => {
+            const notAuthorizedSortitionPool = "0x0000000000000000000000000000000000000001"
+            const expectedUnbonded = 0
+
+            const unbondedValue = await ethBonding.availableUnbondedValue(
+                operator,
+                bondCreator,
+                notAuthorizedSortitionPool
+            )
+            expect(unbondedValue).to.eq.BN(expectedUnbonded, 'invalid unbonded value')
+        })
+
+        it('returns value of operators deposit', async () => {
+            const expectedUnbonded = value
+
+            const unbonded = await ethBonding.availableUnbondedValue(operator, bondCreator, sortitionPool)
+
+            expect(unbonded).to.eq.BN(expectedUnbonded, 'invalid unbonded value')
+        })
+
+        it('returns 0 when the initialization period is not over', async () => {
+            await ethBonding.deposit(notOperator, { value: value })
+            await mineBlocks(initializationPeriod)
+            const expectedUnbonded = 0
+
+            const unbonded = await ethBonding.availableUnbondedValue(
+                notOperator,
+                bondCreator,
+                sortitionPool
+            )
+
+            expect(unbonded).to.eq.BN(expectedUnbonded, 'invalid unbonded value')
+        })
+    })
+
+    describe('createBond', async () => {
+        const holder = accounts[3]
+        const value = new BN(100)
+
+        beforeEach(async () => {
+            await ethBonding.deposit(operator, { value: value })
+            await mineBlocks(initializationPeriod + 1)
+        })
+
+        it('creates bond', async () => {
+            const reference = 888
+
+            const expectedUnbonded = 0
+
+            await ethBonding.createBond(
+                operator,
+                holder,
+                reference,
+                value,
+                sortitionPool,
+                { from: bondCreator }
+            )
+
+            const unbonded = await ethBonding.availableUnbondedValue(
+                operator,
+                bondCreator,
+                sortitionPool
+            )
+            expect(unbonded).to.eq.BN(expectedUnbonded, 'invalid unbonded value')
+
+            const lockedBonds = await ethBonding.bondAmount(
+                operator,
+                holder,
+                reference
+            )
+            expect(lockedBonds).to.eq.BN(value, 'unexpected bond value')
+        })
+
+        it('creates two bonds with the same reference for different operators', async () => {
+            const operator2 = accounts[2]
+            const bondValue = new BN(10)
+            const reference = 777
+
+            const expectedUnbonded = value.sub(bondValue)
+
+            await ethBonding.deposit(operator2, { value: value })
+            await mineBlocks(initializationPeriod + 1)
+
+            await ethBonding.authorizeOperatorContract(
+                operator2,
+                bondCreator,
+                { from: operator2 }
+            )
+            await ethBonding.authorizeSortitionPoolContract(
+                operator2,
+                sortitionPool,
+                { from: operator2 }
+            )
+            await ethBonding.createBond(
+                operator,
+                holder,
+                reference,
+                bondValue,
+                sortitionPool,
+                { from: bondCreator }
+            )
+            await ethBonding.createBond(
+                operator2,
+                holder,
+                reference,
+                bondValue,
+                sortitionPool,
+                { from: bondCreator }
+            )
+
+            const unbonded1 = await ethBonding.availableUnbondedValue(
+                operator, bondCreator, sortitionPool
+            )
+            expect(unbonded1).to.eq.BN(expectedUnbonded, 'invalid unbonded value 1')
+
+            const unbonded2 = await ethBonding.availableUnbondedValue(
+                operator2, bondCreator, sortitionPool
+            )
+            expect(unbonded2).to.eq.BN(expectedUnbonded, 'invalid unbonded value 2')
+
+            const lockedBonds1 = await ethBonding.bondAmount(
+                operator, holder, reference
+            )
+            expect(lockedBonds1).to.eq.BN(bondValue, 'unexpected bond value 1')
+
+            const lockedBonds2 = await ethBonding.bondAmount(
+                operator2, holder, reference
+            )
+            expect(lockedBonds2).to.eq.BN(bondValue, 'unexpected bond value 2')
+        })
+
+        it('fails to create two bonds with the same reference for the same operator', async () => {
+            const bondValue = new BN(10)
+            const reference = 777
+
+            await ethBonding.createBond(
+                operator, holder,
+                reference, bondValue,
+                sortitionPool,
+                { from: bondCreator }
+            )
+
+            await expectRevert(
+                ethBonding.createBond(
+                    operator, holder,
+                    reference, bondValue,
+                    sortitionPool,
+                    { from: bondCreator }
+                ),
+                "Reference ID not unique for holder and operator"
+            )
+        })
+
+        it('fails if insufficient unbonded value', async () => {
+            const bondValue = value.add(new BN(1))
+
+            await expectRevert(
+                ethBonding.createBond(operator, holder, 0, bondValue, sortitionPool, { from: bondCreator }),
+                "Insufficient unbonded value"
+            )
+        })
+
+        it('fails if not initialized', async () => {
+            const bondValue = value.add(new BN(1))
+            await ethBonding.deposit(notOperator, { value: value })
+            await ethBonding.authorizeSortitionPoolContract(
+                notOperator,
+                sortitionPool,
+                { from: notOperator }
+            )
+
+            await ethBonding.authorizeOperatorContract(
+                notOperator,
+                bondCreator,
+                { from: notOperator }
+            )
+
+            await expectRevert(
+                ethBonding.createBond(notOperator, holder, 0, bondValue, sortitionPool, { from: bondCreator }),
+                "Insufficient unbonded value"
+            )
+        })
+    })
+
+    describe('reassignBond', async () => {
+        const holder = accounts[2]
+        const newHolder = accounts[3]
+        const bondValue = new BN(100)
+        const reference = 777
+        const newReference = 888
+
+        beforeEach(async () => {
+            await ethBonding.deposit(operator, { value: bondValue })
+            await mineBlocks(initializationPeriod + 1)
+            await ethBonding.createBond(operator, holder, reference, bondValue, sortitionPool, { from: bondCreator })
+        })
+
+        it('reassigns bond to a new holder and a new reference', async () => {
+            await ethBonding.reassignBond(operator, reference, newHolder, newReference, { from: holder })
+
+            let lockedBonds = await ethBonding.bondAmount(operator, holder, reference)
+            expect(lockedBonds).to.eq.BN(0, 'invalid locked bonds')
+
+            lockedBonds = await ethBonding.bondAmount(operator, holder, newReference)
+            expect(lockedBonds).to.eq.BN(0, 'invalid locked bonds')
+
+            lockedBonds = await ethBonding.bondAmount(operator, newHolder, reference)
+            expect(lockedBonds).to.eq.BN(0, 'invalid locked bonds')
+
+            lockedBonds = await ethBonding.bondAmount(operator, newHolder, newReference)
+            expect(lockedBonds).to.eq.BN(bondValue, 'invalid locked bonds')
+        })
+
+        it('reassigns bond to the same holder and a new reference', async () => {
+            await ethBonding.reassignBond(operator, reference, holder, newReference, { from: holder })
+
+            let lockedBonds = await ethBonding.bondAmount(operator, holder, reference)
+            expect(lockedBonds).to.eq.BN(0, 'invalid locked bonds')
+
+            lockedBonds = await ethBonding.bondAmount(operator, holder, newReference)
+            expect(lockedBonds).to.eq.BN(bondValue, 'invalid locked bonds')
+        })
+
+        it('reassigns bond to a new holder and the same reference', async () => {
+            await ethBonding.reassignBond(operator, reference, newHolder, reference, { from: holder })
+
+            let lockedBonds = await ethBonding.bondAmount(operator, holder, reference)
+            expect(lockedBonds).to.eq.BN(0, 'invalid locked bonds')
+
+            lockedBonds = await ethBonding.bondAmount(operator, newHolder, reference)
+            expect(lockedBonds).to.eq.BN(bondValue, 'invalid locked bonds')
+        })
+
+        it('fails if sender is not the holder', async () => {
+            await expectRevert(
+                ethBonding.reassignBond(operator, reference, newHolder, newReference, { from: accounts[0] }),
+                "Bond not found"
+            )
+        })
+
+        it('fails if reassigned to the same holder and the same reference', async () => {
+            await expectRevert(
+                ethBonding.reassignBond(operator, reference, holder, reference, { from: holder }),
+                "Reference ID not unique for holder and operator"
+            )
+        })
+    })
+
+    describe('freeBond', async () => {
+        const holder = accounts[2]
+        const initialUnboundedValue = new BN(500)
+        const bondValue = new BN(100)
+        const reference = 777
+
+        beforeEach(async () => {
+            await ethBonding.deposit(operator, { value: initialUnboundedValue })
+            await mineBlocks(initializationPeriod + 1)
+            await ethBonding.createBond(operator, holder, reference, bondValue, sortitionPool, { from: bondCreator })
+        })
+
+        it('releases bond amount to operator\'s available bonding value', async () => {
+            await ethBonding.freeBond(operator, reference, { from: holder })
+
+            const lockedBonds = await ethBonding.bondAmount(operator, holder, reference)
+            expect(lockedBonds).to.eq.BN(0, 'unexpected remaining locked bonds')
+
+            const unbondedValue = await ethBonding.availableUnbondedValue(operator, bondCreator, sortitionPool)
+            expect(unbondedValue).to.eq.BN(initialUnboundedValue, 'unexpected unbonded value')
+        })
+
+        it('fails if sender is not the holder', async () => {
+            await expectRevert(
+                ethBonding.freeBond(operator, reference, { from: accounts[0] }),
+                "Bond not found"
+            )
+        })
+    })
+
+    describe('seizeBond', async () => {
+        const holder = accounts[2]
+        const destination = accounts[3]
+        const bondValue = new BN(1000)
+        const reference = 777
+
+        beforeEach(async () => {
+            await ethBonding.deposit(operator, { value: bondValue })
+            await mineBlocks(initializationPeriod + 1)
+            await ethBonding.createBond(operator, holder, reference, bondValue, sortitionPool, { from: bondCreator })
+        })
+
+        it('transfers whole bond amount to destination account', async () => {
+            const amount = bondValue
+            let expectedBalance = web3.utils.toBN(await web3.eth.getBalance(destination)).add(amount)
+
+            await ethBonding.seizeBond(operator, reference, amount, destination, { from: holder })
+
+            const actualBalance = await web3.eth.getBalance(destination)
+            expect(actualBalance).to.eq.BN(expectedBalance, 'invalid destination account balance')
+
+            const lockedBonds = await ethBonding.bondAmount(operator, holder, reference)
+            expect(lockedBonds).to.eq.BN(0, 'unexpected remaining bond value')
+        })
+
+        it('transfers less than bond amount to destination account', async () => {
+            const remainingBond = new BN(1)
+            const amount = bondValue.sub(remainingBond)
+            let expectedBalance = web3.utils.toBN(await web3.eth.getBalance(destination)).add(amount)
+
+            await ethBonding.seizeBond(operator, reference, amount, destination, { from: holder })
+
+            const actualBalance = await web3.eth.getBalance(destination)
+            expect(actualBalance).to.eq.BN(expectedBalance, 'invalid destination account balance')
+
+            const lockedBonds = await ethBonding.bondAmount(operator, holder, reference)
+            expect(lockedBonds).to.eq.BN(remainingBond, 'unexpected remaining bond value')
+        })
+
+        it('reverts if seized amount equals zero', async () => {
+            const amount = new BN(0)
+            await expectRevert(
+                ethBonding.seizeBond(operator, reference, amount, destination, { from: holder }),
+                "Requested amount should be greater than zero"
+            )
+        })
+
+        it('reverts if seized amount is greater than bond value', async () => {
+            const amount = bondValue.add(new BN(1))
+            await expectRevert(
+                ethBonding.seizeBond(operator, reference, amount, destination, { from: holder }),
+                "Requested amount is greater than the bond"
+            )
+        })
+
+        it('reverts if transfer fails', async () => {
+            await etherReceiver.setShouldFail(true)
+            const destination = etherReceiver.address
+
+            await expectRevert(
+                ethBonding.seizeBond(operator, reference, bondValue, destination, { from: holder }),
+                "Transfer failed"
+            )
+
+            const destinationBalance = await web3.eth.getBalance(destination)
+            expect(destinationBalance).to.eq.BN(0, 'invalid destination account balance')
+
+            const lockedBonds = await ethBonding.bondAmount(operator, holder, reference)
+            expect(lockedBonds).to.eq.BN(bondValue, 'unexpected bond value')
+        })
+    })
+
+    describe("authorizeSortitionPoolContract", async () => {
+        it("reverts when operator is not an authorizer", async () => {
+            let authorizer1 = accounts[2]
+
+            await expectRevert(
+                ethBonding.authorizeSortitionPoolContract(operator, sortitionPool, { from: authorizer1 }),
+                'Not authorized'
+            )
+        })
+
+        it("should authorize sortition pool for provided operator", async () => {
+            await ethBonding.authorizeSortitionPoolContract(
+                operator,
+                sortitionPool,
+                { from: operator }
+            )
+
+            assert.isTrue(
+                await ethBonding.hasSecondaryAuthorization(operator, sortitionPool),
+                "Sortition pool has not beeen authorized for provided operator"
+            )
+        })
+    })
+})

--- a/solidity/test/KeepBondingTest.js
+++ b/solidity/test/KeepBondingTest.js
@@ -118,7 +118,7 @@ contract('KeepBonding', (accounts) => {
 
             await expectRevert(
                 keepBonding.withdraw(value, operator, { from: accounts[3] }),
-                "Only operator or the owner is allowed to withdraw bond"
+                "Not authorized to withdraw bond"
             )
         })
     })


### PR DESCRIPTION
Add a bonding contract which doesn't rely on staking KEEP, but instead permits bonding with ETH only. To reduce sortition pool manipulation, `EthBonding` implements the initialization period and inability to increase the staked amount from `TokenStaking`.