### PR TITLE
Two-step proxy initialization call moved to the second step

### DIFF
--- a/solidity/contracts/BondedECDSAKeepFactory.sol
+++ b/solidity/contracts/BondedECDSAKeepFactory.sol
@@ -390,19 +390,19 @@ contract BondedECDSAKeepFactory is IBondedECDSAKeepFactory, CloneFactory {
 
     /// @notice Requests for a relay entry using the beacon payment provided as
     /// the parameter. Sets `setGroupSelectionSeed(uint256)` as beacon callback.
-    function requestRelayEntry(
-        uint256 payment
-    ) internal returns (bool, bytes memory) {
-        return address(randomBeacon).call.value(
-            payment
-        )(
-            abi.encodeWithSignature(
-                "requestRelayEntry(address,string,uint256)",
-                address(this),
-                "setGroupSelectionSeed(uint256)",
-                callbackGas
-            )
-        );
+    function requestRelayEntry(uint256 payment)
+        internal
+        returns (bool, bytes memory)
+    {
+        return
+            address(randomBeacon).call.value(payment)(
+                abi.encodeWithSignature(
+                    "requestRelayEntry(address,string,uint256)",
+                    address(this),
+                    "setGroupSelectionSeed(uint256)",
+                    callbackGas
+                )
+            );
     }
 
     /// @notice Sets a new group selection seed value.

--- a/solidity/contracts/BondedECDSAKeepVendor.sol
+++ b/solidity/contracts/BondedECDSAKeepVendor.sol
@@ -39,16 +39,23 @@ contract BondedECDSAKeepVendor is Proxy, UpgradableProxyStorage {
     event UpgradeStarted(address implementation, uint256 timestamp);
     event UpgradeCompleted(address implementation);
 
-    constructor(address _implementation, bytes memory _data) public {
-        assertSlot(IMPLEMENTATION_SLOT, "eip1967.proxy.implementation");
+    constructor(
+        string memory _version,
+        address _implementation,
+        bytes memory _data
+    ) public {
         assertSlot(ADMIN_SLOT, "eip1967.proxy.admin");
         assertSlot(
             UPGRADE_TIME_DELAY_SLOT,
             "network.keep.bondedecdsavendor.proxy.upgradeTimeDelay"
         );
         assertSlot(
-            UPGRADE_IMPLEMENTATION_SLOT,
-            "network.keep.bondedecdsavendor.proxy.upgradeImplementation"
+            CURRENT_IMPL_ID_SLOT,
+            "network.keep.proxy.currentimplementationid"
+        );
+        assertSlot(
+            UPGRADE_IMPL_ID_SLOT,
+            "network.keep.proxy.upgradeimplementationid"
         );
         assertSlot(
             UPGRADE_INIT_TIMESTAMP_SLOT,
@@ -60,11 +67,15 @@ contract BondedECDSAKeepVendor is Proxy, UpgradableProxyStorage {
             "Implementation address can't be zero."
         );
 
+        setCurrentImplementationID(
+            uint256(keccak256(abi.encodePacked(_version)))
+        );
+
+        setImplementation(_version, _implementation, _data);
+
         if (_data.length > 0) {
             initializeImplementation(_implementation, _data);
         }
-
-        setImplementation(_implementation);
 
         setUpgradeTimeDelay(1 days);
 

--- a/solidity/contracts/BondedECDSAKeepVendor.sol
+++ b/solidity/contracts/BondedECDSAKeepVendor.sol
@@ -1,10 +1,12 @@
 pragma solidity ^0.5.4;
 
+import "./UpgradableProxyStorage.sol";
+
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "@openzeppelin/upgrades/contracts/upgradeability/Proxy.sol";
 
 /// @title Proxy contract for Bonded ECDSA Keep vendor.
-contract BondedECDSAKeepVendor is Proxy {
+contract BondedECDSAKeepVendor is Proxy, UpgradableProxyStorage {
     using SafeMath for uint256;
 
     /// @dev Storage slot with the admin of the contract.

--- a/solidity/contracts/BondedECDSAKeepVendor.sol
+++ b/solidity/contracts/BondedECDSAKeepVendor.sol
@@ -9,33 +9,6 @@ import "@openzeppelin/upgrades/contracts/upgradeability/Proxy.sol";
 contract BondedECDSAKeepVendor is Proxy, UpgradableProxyStorage {
     using SafeMath for uint256;
 
-    /// @dev Storage slot with the admin of the contract.
-    /// This is the keccak-256 hash of "eip1967.proxy.admin" subtracted by 1, and is
-    /// validated in the constructor.
-    bytes32 internal constant ADMIN_SLOT = 0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103;
-
-    /// @dev Storage slot with the upgrade time delay. Upgrade time delay defines a
-    /// period for implementation upgrade.
-    /// This is the keccak-256 hash of "network.keep.bondedecdsavendor.proxy.upgradeTimeDelay"
-    /// subtracted by 1, and is validated in the constructor.
-    bytes32 internal constant UPGRADE_TIME_DELAY_SLOT = 0x3ca583dafde9ce8bdb41fe825f85984a83b08ecf90ffaccbc4b049e8d8703563;
-
-    /// @dev Storage slot with the ID of the current implementation. The ID is
-    /// an unique identifier of the implementation calculated based on the version.
-    /// This is the keccak-256 hash of "network.keep.proxy.currentimplementationid"
-    /// subtracted by 1, and is validated in the constructor.
-    bytes32 internal constant CURRENT_IMPL_ID_SLOT = 0x2fdc2b7761cb35b3c6cce7021b2c04230161423bd5b9520fd8a7ae15aa03ac9f;
-
-    /// @dev Storage slot with the new implementation ID.
-    /// This is the keccak-256 hash of "network.keep.proxy.upgradeimplementationid"
-    /// subtracted by 1, and is validated in the constructor.
-    bytes32 internal constant UPGRADE_IMPL_ID_SLOT = 0x1836489d800664edd6c29124d8cf32e481082cc2687a6f957a01e0f20a003d40;
-
-    /// @dev Storage slot with the implementation address upgrade initiation.
-    /// This is the keccak-256 hash of "network.keep.bondedecdsavendor.proxy.upgradeInitiatedTimestamp"
-    /// subtracted by 1, and is validated in the constructor.
-    bytes32 internal constant UPGRADE_INIT_TIMESTAMP_SLOT = 0x0816e8d9eeb2554df0d0b7edc58e2d957e6ce18adf92c138b50dd78a420bebaf;
-
     event UpgradeStarted(
         string version,
         address implementation,
@@ -48,25 +21,7 @@ contract BondedECDSAKeepVendor is Proxy, UpgradableProxyStorage {
         string memory _version,
         address _implementation,
         bytes memory _data
-    ) public {
-        assertSlot(ADMIN_SLOT, "eip1967.proxy.admin");
-        assertSlot(
-            UPGRADE_TIME_DELAY_SLOT,
-            "network.keep.bondedecdsavendor.proxy.upgradeTimeDelay"
-        );
-        assertSlot(
-            CURRENT_IMPL_ID_SLOT,
-            "network.keep.proxy.currentimplementationid"
-        );
-        assertSlot(
-            UPGRADE_IMPL_ID_SLOT,
-            "network.keep.proxy.upgradeimplementationid"
-        );
-        assertSlot(
-            UPGRADE_INIT_TIMESTAMP_SLOT,
-            "network.keep.bondedecdsavendor.proxy.upgradeInitiatedTimestamp"
-        );
-
+    ) public UpgradableProxyStorage() {
         require(
             _implementation != address(0),
             "Implementation address can't be zero."
@@ -199,15 +154,6 @@ contract BondedECDSAKeepVendor is Proxy, UpgradableProxyStorage {
         require(success, string(returnData));
     }
 
-    /// @notice Asserts correct slot for provided key.
-    /// @dev To avoid clashing with implementation's fields the proxy contract
-    /// defines its' fields on specific slots. Slot is calculated as hash of a string
-    /// subtracted by 1 to reduce chances of a possible attack. For details see
-    /// EIP-1967.
-    function assertSlot(bytes32 slot, bytes memory key) internal pure {
-        assert(slot == bytes32(uint256(keccak256(key)) - 1));
-    }
-
     /// @notice Gets the address of the current vendor implementation address.
     /// @return Address of the current implementation.
     function implementation() public view returns (address) {
@@ -233,104 +179,6 @@ contract BondedECDSAKeepVendor is Proxy, UpgradableProxyStorage {
         );
 
         return implementation.version;
-    }
-
-    function currentImplementationID()
-        internal
-        view
-        returns (uint256 _version)
-    {
-        bytes32 position = CURRENT_IMPL_ID_SLOT;
-        /* solium-disable-next-line */
-        assembly {
-            _version := sload(position)
-        }
-    }
-
-    function setCurrentImplementationID(uint256 _id) internal {
-        bytes32 position = CURRENT_IMPL_ID_SLOT;
-        /* solium-disable-next-line */
-        assembly {
-            sstore(position, _id)
-        }
-    }
-
-    function upgradeImplementationID() internal view returns (uint256 _newID) {
-        bytes32 position = UPGRADE_IMPL_ID_SLOT;
-        /* solium-disable-next-line */
-        assembly {
-            _newID := sload(position)
-        }
-    }
-
-    function setUpgradeImplementationID(uint256 _newID) internal {
-        bytes32 position = UPGRADE_IMPL_ID_SLOT;
-        /* solium-disable-next-line */
-        assembly {
-            sstore(position, _newID)
-        }
-    }
-
-    function upgradeInitiatedTimestamp()
-        public
-        view
-        returns (uint256 _upgradeInitiatedTimestamp)
-    {
-        bytes32 position = UPGRADE_INIT_TIMESTAMP_SLOT;
-        /* solium-disable-next-line */
-        assembly {
-            _upgradeInitiatedTimestamp := sload(position)
-        }
-    }
-
-    function setUpgradeInitiatedTimestamp(uint256 _upgradeInitiatedTimestamp)
-        internal
-    {
-        bytes32 position = UPGRADE_INIT_TIMESTAMP_SLOT;
-        /* solium-disable-next-line */
-        assembly {
-            sstore(position, _upgradeInitiatedTimestamp)
-        }
-    }
-
-    function upgradeTimeDelay()
-        public
-        view
-        returns (uint256 _upgradeTimeDelay)
-    {
-        bytes32 position = UPGRADE_TIME_DELAY_SLOT;
-        /* solium-disable-next-line */
-        assembly {
-            _upgradeTimeDelay := sload(position)
-        }
-    }
-
-    function setUpgradeTimeDelay(uint256 _upgradeTimeDelay) internal {
-        bytes32 position = UPGRADE_TIME_DELAY_SLOT;
-        /* solium-disable-next-line */
-        assembly {
-            sstore(position, _upgradeTimeDelay)
-        }
-    }
-
-    /// @notice The admin slot.
-    /// @return The contract owner's address.
-    function admin() public view returns (address adm) {
-        bytes32 slot = ADMIN_SLOT;
-        /* solium-disable-next-line */
-        assembly {
-            adm := sload(slot)
-        }
-    }
-
-    /// @dev Sets the address of the proxy admin.
-    /// @param _newAdmin Address of the new proxy admin.
-    function setAdmin(address _newAdmin) internal {
-        bytes32 slot = ADMIN_SLOT;
-        /* solium-disable-next-line */
-        assembly {
-            sstore(slot, _newAdmin)
-        }
     }
 
     /// @dev Throws if called by any account other than the contract owner.

--- a/solidity/contracts/UpgradableProxyStorage.sol
+++ b/solidity/contracts/UpgradableProxyStorage.sol
@@ -1,12 +1,40 @@
 pragma solidity ^0.5.4;
 
-/// @title Storage for upgradable proxy contract used to track implementations.
+/// @title Storage for two-step upgradable proxy contract.
 /// @dev This contract can be used to hold implementation details in a two-step
 /// upgradeable proxy to hold details of the implementation. In proxy pattern
 /// data should be stored in a ways that reduces possibility of collisions between
-/// proxy and implementation contracts. In this contract we use a mapping which
-/// is allocating storage slot for the data in a dynamic way.
+/// proxy and implementation contracts. In this contract we define variables at
+/// fixed positions according to the Unstructured Storage pattern and a mapping
+/// which is allocating storage slot for the data in a dynamic way.
 contract UpgradableProxyStorage {
+    /// @dev Storage slot with the admin of the contract.
+    /// This is the keccak-256 hash of "eip1967.proxy.admin" subtracted by 1, and is
+    /// validated in the constructor.
+    bytes32 internal constant ADMIN_SLOT = 0xb53127684a568b3173ae13b9f8a6016e243e63b6e8ee1178d6a717850b5d6103;
+
+    /// @dev Storage slot with the upgrade time delay. Upgrade time delay defines a
+    /// period for implementation upgrade.
+    /// This is the keccak-256 hash of "network.keep.proxy.upgradetimedelay"
+    /// subtracted by 1, and is validated in the constructor.
+    bytes32 internal constant UPGRADE_TIME_DELAY_SLOT = 0xa0361fd71e28dd9e0781644db9ca971cf5aeafd12b5d0aaaebff68299a2cbbee;
+
+    /// @dev Storage slot with the ID of the current implementation. The ID is
+    /// an unique identifier of the implementation calculated based on the version.
+    /// This is the keccak-256 hash of "network.keep.proxy.currentimplementationid"
+    /// subtracted by 1, and is validated in the constructor.
+    bytes32 internal constant CURRENT_IMPL_ID_SLOT = 0x2fdc2b7761cb35b3c6cce7021b2c04230161423bd5b9520fd8a7ae15aa03ac9f;
+
+    /// @dev Storage slot with the new implementation ID.
+    /// This is the keccak-256 hash of "network.keep.proxy.upgradeimplementationid"
+    /// subtracted by 1, and is validated in the constructor.
+    bytes32 internal constant UPGRADE_IMPL_ID_SLOT = 0x1836489d800664edd6c29124d8cf32e481082cc2687a6f957a01e0f20a003d40;
+
+    /// @dev Storage slot with the implementation address upgrade initiation.
+    /// This is the keccak-256 hash of "network.keep.proxy.upgradeinitiatedtimestamp"
+    /// subtracted by 1, and is validated in the constructor.
+    bytes32 internal constant UPGRADE_INIT_TIMESTAMP_SLOT = 0xf4917e72ec7208070be0cec8873a121e5971a5d90b452600ca1524183a489ed5;
+
     // Structure holding details of an implementation.
     struct Implementation {
         string version;
@@ -17,6 +45,26 @@ contract UpgradableProxyStorage {
     // Mapping from version ID to implementation contract. It is expected that
     // the map key is a keccak256 of the implementation version.
     mapping(uint256 => Implementation) public implementations;
+
+    constructor() public {
+        assertSlot(ADMIN_SLOT, "eip1967.proxy.admin");
+        assertSlot(
+            UPGRADE_TIME_DELAY_SLOT,
+            "network.keep.proxy.upgradetimedelay"
+        );
+        assertSlot(
+            CURRENT_IMPL_ID_SLOT,
+            "network.keep.proxy.currentimplementationid"
+        );
+        assertSlot(
+            UPGRADE_IMPL_ID_SLOT,
+            "network.keep.proxy.upgradeimplementationid"
+        );
+        assertSlot(
+            UPGRADE_INIT_TIMESTAMP_SLOT,
+            "network.keep.proxy.upgradeinitiatedtimestamp"
+        );
+    }
 
     function getImplementation(string memory _version)
         internal
@@ -45,5 +93,114 @@ contract UpgradableProxyStorage {
         implementations[versionInt].version = _version;
         implementations[versionInt].implementationContract = _implementation;
         implementations[versionInt].initializationData = _initializationData;
+    }
+
+    /// @notice Asserts correct slot for provided key.
+    /// @dev To avoid clashing with implementation's fields the proxy contract
+    /// defines its' fields on specific slots. Slot is calculated as hash of a string
+    /// subtracted by 1 to reduce chances of a possible attack. For details see
+    /// EIP-1967.
+    function assertSlot(bytes32 slot, bytes memory key) internal pure {
+        assert(slot == bytes32(uint256(keccak256(key)) - 1));
+    }
+
+    function currentImplementationID()
+        internal
+        view
+        returns (uint256 _version)
+    {
+        bytes32 position = CURRENT_IMPL_ID_SLOT;
+        /* solium-disable-next-line */
+        assembly {
+            _version := sload(position)
+        }
+    }
+
+    function setCurrentImplementationID(uint256 _id) internal {
+        bytes32 position = CURRENT_IMPL_ID_SLOT;
+        /* solium-disable-next-line */
+        assembly {
+            sstore(position, _id)
+        }
+    }
+
+    function upgradeImplementationID() internal view returns (uint256 _newID) {
+        bytes32 position = UPGRADE_IMPL_ID_SLOT;
+        /* solium-disable-next-line */
+        assembly {
+            _newID := sload(position)
+        }
+    }
+
+    function setUpgradeImplementationID(uint256 _newID) internal {
+        bytes32 position = UPGRADE_IMPL_ID_SLOT;
+        /* solium-disable-next-line */
+        assembly {
+            sstore(position, _newID)
+        }
+    }
+
+    function upgradeInitiatedTimestamp()
+        public
+        view
+        returns (uint256 _upgradeInitiatedTimestamp)
+    {
+        bytes32 position = UPGRADE_INIT_TIMESTAMP_SLOT;
+        /* solium-disable-next-line */
+        assembly {
+            _upgradeInitiatedTimestamp := sload(position)
+        }
+    }
+
+    function setUpgradeInitiatedTimestamp(uint256 _upgradeInitiatedTimestamp)
+        internal
+    {
+        bytes32 position = UPGRADE_INIT_TIMESTAMP_SLOT;
+        /* solium-disable-next-line */
+        assembly {
+            sstore(position, _upgradeInitiatedTimestamp)
+        }
+    }
+
+    /// @notice The admin slot.
+    /// @return The contract owner's address.
+    function upgradeTimeDelay()
+        public
+        view
+        returns (uint256 _upgradeTimeDelay)
+    {
+        bytes32 position = UPGRADE_TIME_DELAY_SLOT;
+        /* solium-disable-next-line */
+        assembly {
+            _upgradeTimeDelay := sload(position)
+        }
+    }
+
+    function setUpgradeTimeDelay(uint256 _upgradeTimeDelay) internal {
+        bytes32 position = UPGRADE_TIME_DELAY_SLOT;
+        /* solium-disable-next-line */
+        assembly {
+            sstore(position, _upgradeTimeDelay)
+        }
+    }
+
+    /// @notice The admin slot.
+    /// @return The contract owner's address.
+    function admin() public view returns (address adm) {
+        bytes32 slot = ADMIN_SLOT;
+        /* solium-disable-next-line */
+        assembly {
+            adm := sload(slot)
+        }
+    }
+
+    /// @dev Sets the address of the proxy admin.
+    /// @param _newAdmin Address of the new proxy admin.
+    function setAdmin(address _newAdmin) internal {
+        bytes32 slot = ADMIN_SLOT;
+        /* solium-disable-next-line */
+        assembly {
+            sstore(slot, _newAdmin)
+        }
     }
 }

--- a/solidity/contracts/UpgradableProxyStorage.sol
+++ b/solidity/contracts/UpgradableProxyStorage.sol
@@ -1,0 +1,49 @@
+pragma solidity ^0.5.4;
+
+/// @title Storage for upgradable proxy contract used to track implementations.
+/// @dev This contract can be used to hold implementation details in a two-step
+/// upgradeable proxy to hold details of the implementation. In proxy pattern
+/// data should be stored in a ways that reduces possibility of collisions between
+/// proxy and implementation contracts. In this contract we use a mapping which
+/// is allocating storage slot for the data in a dynamic way.
+contract UpgradableProxyStorage {
+    // Structure holding details of an implementation.
+    struct Implementation {
+        string version;
+        address implementationContract;
+        bytes initializationData;
+    }
+
+    // Mapping from version ID to implementation contract. It is expected that
+    // the map key is a keccak256 of the implementation version.
+    mapping(uint256 => Implementation) public implementations;
+
+    function getImplementation(string memory _version)
+        internal
+        view
+        returns (Implementation memory)
+    {
+        return
+            getImplementation(uint256(keccak256(abi.encodePacked(_version))));
+    }
+
+    function getImplementation(uint256 _version)
+        internal
+        view
+        returns (Implementation memory)
+    {
+        return implementations[_version];
+    }
+
+    function setImplementation(
+        string memory _version,
+        address _implementation,
+        bytes memory _initializationData
+    ) internal {
+        uint256 versionInt = uint256(keccak256(abi.encodePacked(_version)));
+
+        implementations[versionInt].version = _version;
+        implementations[versionInt].implementationContract = _implementation;
+        implementations[versionInt].initializationData = _initializationData;
+    }
+}

--- a/solidity/migrations/2_deploy_contracts.js
+++ b/solidity/migrations/2_deploy_contracts.js
@@ -48,6 +48,7 @@ module.exports = async function (deployer) {
 
     await deployer.deploy(
         BondedECDSAKeepVendor,
+        "V1",
         BondedECDSAKeepVendorImplV1.address,
         implInitializeCallData
     )

--- a/solidity/test/BondedECDSAKeepVendorImplV1viaProxyTest.js
+++ b/solidity/test/BondedECDSAKeepVendorImplV1viaProxyTest.js
@@ -238,6 +238,7 @@ contract("BondedECDSAKeepVendorImplV1viaProxy", async accounts => {
             .contract.methods.initialize(registryAddress, factoryAddress).encodeABI()
 
         const bondedECDSAKeepVendorProxy = await BondedECDSAKeepVendor.new(
+            "V1",
             bondedECDSAKeepVendorImplV1Stub.address,
             initializeCallData,
             { from: proxyAdmin }

--- a/solidity/test/BondedECDSAKeepVendorTest.js
+++ b/solidity/test/BondedECDSAKeepVendorTest.js
@@ -12,7 +12,7 @@ const chai = require("chai");
 chai.use(require("bn-chai")(BN));
 const expect = chai.expect;
 
-const BondedECDSAKeepVendor = artifacts.require("BondedECDSAKeepVendor");
+const BondedECDSAKeepVendor = artifacts.require("BondedECDSAKeepVendorStub");
 const BondedECDSAKeepVendorImplV1 = artifacts.require(
   "BondedECDSAKeepVendorImplV1"
 );
@@ -21,6 +21,7 @@ contract("BondedECDSAKeepVendor", async accounts => {
   const address0 = constants.ZERO_ADDRESS;
   const address1 = "0xF2D3Af2495E286C7820643B963FB9D34418c871d";
   const address2 = "0x4566716c07617c5854fe7dA9aE5a1219B19CCd27";
+  const address3 = "0xc005694f9b7806af17aa05df09b6e83207cb2fd8";
 
   let registryAddress = "0x0000000000000000000000000000000000000001";
   let factoryAddress = "0x0000000000000000000000000000000000000002";
@@ -32,6 +33,10 @@ contract("BondedECDSAKeepVendor", async accounts => {
   let keepVendor;
   let initializeCallData;
 
+  const V1 = "V1";
+  const V2 = "V2";
+  const V3 = "V3";
+
   before(async () => {
     const bondedECDSAKeepVendorImplV1 = await BondedECDSAKeepVendorImplV1.new({
       from: implOwner
@@ -42,6 +47,7 @@ contract("BondedECDSAKeepVendor", async accounts => {
       .encodeABI();
 
     keepVendor = await BondedECDSAKeepVendor.new(
+      V1,
       bondedECDSAKeepVendorImplV1.address,
       initializeCallData,
       { from: proxyAdmin }
@@ -62,6 +68,7 @@ contract("BondedECDSAKeepVendor", async accounts => {
 
       await expectRevert(
         BondedECDSAKeepVendor.new(
+          V2,
           bondedECDSAKeepVendorImplV1.address,
           initializeCallData,
           { from: proxyAdmin }
@@ -81,7 +88,7 @@ contract("BondedECDSAKeepVendor", async accounts => {
     });
 
     it("sets timestamp", async () => {
-      await keepVendor.upgradeToAndCall(address1, initializeCallData, {
+      await keepVendor.upgradeToAndCall(V2, address1, initializeCallData, {
         from: proxyAdmin
       });
 
@@ -92,17 +99,43 @@ contract("BondedECDSAKeepVendor", async accounts => {
       );
     });
 
-    it("sets new implementation", async () => {
-      await keepVendor.upgradeToAndCall(address1, initializeCallData, {
+    it("sets new version", async () => {
+      await keepVendor.upgradeToAndCall(V2, address1, initializeCallData, {
         from: proxyAdmin
       });
 
-      assert.equal(await keepVendor.newImplementation.call(), address1);
+      assert.equal(await keepVendor.version.call(), V1);
+      assert.equal(await keepVendor.upgradeVersion.call(), V2);
+    });
+
+    it("sets new implementation", async () => {
+      await keepVendor.upgradeToAndCall(V2, address1, initializeCallData, {
+        from: proxyAdmin
+      });
+
       assert.equal(await keepVendor.implementation.call(), currentAddress);
+      assert.equal(await keepVendor.upgradeImplementation.call(), address1);
+    });
+
+    it("sets initialization call data", async () => {
+      await keepVendor.upgradeToAndCall(V2, address1, initializeCallData, {
+        from: proxyAdmin
+      });
+
+      assert.equal(await keepVendor.upgradeInitialization.call(), initializeCallData);
+    });
+
+    it("supports empty initialization call data", async () => {
+      await keepVendor.upgradeToAndCall(V2, address1, [], {
+        from: proxyAdmin
+      });
+
+      assert.notExists(await keepVendor.upgradeInitialization.call());
     });
 
     it("emits an event", async () => {
       const receipt = await keepVendor.upgradeToAndCall(
+        V2,
         address1,
         initializeCallData,
         { from: proxyAdmin }
@@ -111,61 +144,102 @@ contract("BondedECDSAKeepVendor", async accounts => {
       const expectedTimestamp = await time.latest();
 
       expectEvent(receipt, "UpgradeStarted", {
+        version: V2,
         implementation: address1,
         timestamp: expectedTimestamp
       });
     });
 
-    it("allows new value overwrite", async () => {
-      await keepVendor.upgradeToAndCall(address1, initializeCallData, {
+    it("allows upgrade overwrite for the same version", async () => {
+      await keepVendor.upgradeToAndCall(V2, address1, initializeCallData, {
         from: proxyAdmin
       });
 
-      await keepVendor.upgradeToAndCall(address2, initializeCallData, {
+      // With the same implementation address
+      await keepVendor.upgradeToAndCall(V2, address1, initializeCallData, {
         from: proxyAdmin
       });
 
-      assert.equal(await keepVendor.newImplementation.call(), address2);
+      assert.equal(await keepVendor.version.call(), V1);
+      assert.equal(await keepVendor.upgradeVersion.call(), V2);
+      assert.equal(await keepVendor.upgradeImplementation.call(), address1);
+
+      // With different implementation address
+      await keepVendor.upgradeToAndCall(V2, address2, initializeCallData, {
+        from: proxyAdmin
+      });
+
+      assert.equal(await keepVendor.version.call(), V1);
+      assert.equal(await keepVendor.upgradeVersion.call(), V2);
+      assert.equal(await keepVendor.upgradeImplementation.call(), address2);
+    });
+
+    it("allows upgrade overwrite with new version", async () => {
+      await keepVendor.upgradeToAndCall(V2, address1, initializeCallData, {
+        from: proxyAdmin
+      });
+
+      await keepVendor.upgradeToAndCall(V3, address2, initializeCallData, {
+        from: proxyAdmin
+      });
+
+      assert.equal(await keepVendor.version.call(), V1);
+      assert.equal(await keepVendor.upgradeVersion.call(), V3);
+      assert.equal(await keepVendor.upgradeImplementation.call(), address2);
+    });
+
+    it("reverts on empty version", async () => {
+      await expectRevert(
+        keepVendor.upgradeToAndCall("", address2, initializeCallData, {
+          from: proxyAdmin
+        }),
+        "Version can't be empty string."
+      );
     });
 
     it("reverts on zero address", async () => {
       await expectRevert(
-        keepVendor.upgradeToAndCall(address0, initializeCallData, {
+        keepVendor.upgradeToAndCall(V2, address0, initializeCallData, {
           from: proxyAdmin
         }),
         "Implementation address can't be zero."
       );
-      0;
     });
 
-    it("reverts on the same address", async () => {
+    it("reverts on the same version", async () => {
       await expectRevert(
-        keepVendor.upgradeToAndCall(currentAddress, initializeCallData, {
+        keepVendor.upgradeToAndCall(V1, address2, initializeCallData, {
           from: proxyAdmin
         }),
-        "Implementation address must be different from the current one."
+        "Implementation version must be different from the current one"
       );
+    });
+
+    it("reverts on the same version as one of historic", async () => {
+      await keepVendor.upgradeToAndCall(V2, address2, initializeCallData, {
+        from: proxyAdmin
+      });
+      await time.increase(await keepVendor.upgradeTimeDelay());
+      await keepVendor.completeUpgrade({ from: proxyAdmin });
+
+      await expectRevert(
+        keepVendor.upgradeToAndCall(V1, address3, initializeCallData, {
+          from: proxyAdmin
+        }),
+        "Implementation version has already been registered before"
+      );
+    });
+
+    it("allows the same implementation address as the current", async () => {
+      await keepVendor.upgradeToAndCall(V2, currentAddress, initializeCallData, {
+        from: proxyAdmin
+      })
     });
 
     it("reverts when called by non-admin", async () => {
       await expectRevert(
-        keepVendor.upgradeToAndCall(address1, initializeCallData),
+        keepVendor.upgradeToAndCall(V2, address1, initializeCallData),
         "Caller is not the admin"
-      );
-    });
-
-    it("reverts when initialization call fails", async () => {
-      const bondedECDSAKeepVendorImplV1 = await BondedECDSAKeepVendorImplV1.new();
-
-      const failingData = bondedECDSAKeepVendorImplV1.contract.methods
-        .initialize(registryAddress, address0)
-        .encodeABI();
-
-      await expectRevert(
-        keepVendor.upgradeToAndCall(bondedECDSAKeepVendorImplV1.address, failingData, {
-          from: proxyAdmin
-        }),
-        "Incorrect factory address"
       );
     });
   });
@@ -180,37 +254,37 @@ contract("BondedECDSAKeepVendor", async accounts => {
     });
 
     it("reverts when upgrade not initiated", async () => {
-      await expectRevert(keepVendor.completeUpgrade(), "Upgrade not initiated");
+      await expectRevert(keepVendor.completeUpgrade({ from: proxyAdmin }), "Upgrade not initiated");
     });
 
     it("reverts when timer not elapsed", async () => {
-      await keepVendor.upgradeToAndCall(address1, initializeCallData, {
+      await keepVendor.upgradeToAndCall(V2, address1, initializeCallData, {
         from: proxyAdmin
       });
 
       await time.increase((await keepVendor.upgradeTimeDelay()).subn(2));
 
-      await expectRevert(keepVendor.completeUpgrade(), "Timer not elapsed");
+      await expectRevert(keepVendor.completeUpgrade({ from: proxyAdmin }), "Timer not elapsed");
     });
 
     it("clears timestamp", async () => {
-      await keepVendor.upgradeToAndCall(address1, initializeCallData, {
+      await keepVendor.upgradeToAndCall(V2, address1, initializeCallData, {
         from: proxyAdmin
       });
       await time.increase(await keepVendor.upgradeTimeDelay());
 
-      await keepVendor.completeUpgrade();
+      await keepVendor.completeUpgrade({ from: proxyAdmin });
 
       expect(await keepVendor.upgradeInitiatedTimestamp()).to.eq.BN(0);
     });
 
     it("sets implementation", async () => {
-      await keepVendor.upgradeToAndCall(address1, initializeCallData, {
+      await keepVendor.upgradeToAndCall(V2, address1, initializeCallData, {
         from: proxyAdmin
       });
       await time.increase(await keepVendor.upgradeTimeDelay());
 
-      await keepVendor.completeUpgrade();
+      await keepVendor.completeUpgrade({ from: proxyAdmin });
       assert.equal(
         await keepVendor.implementation.call({ from: proxyAdmin }),
         address1
@@ -218,16 +292,56 @@ contract("BondedECDSAKeepVendor", async accounts => {
     });
 
     it("emits an event", async () => {
-      await keepVendor.upgradeToAndCall(address1, initializeCallData, {
+      await keepVendor.upgradeToAndCall(V2, address1, initializeCallData, {
         from: proxyAdmin
       });
       await time.increase(await keepVendor.upgradeTimeDelay());
 
-      const receipt = await keepVendor.completeUpgrade();
+      const receipt = await keepVendor.completeUpgrade({ from: proxyAdmin });
 
       expectEvent(receipt, "UpgradeCompleted", {
+        version: V2,
         implementation: address1
       });
+    });
+
+    it("supports empty initialization call data", async () => {
+      await keepVendor.upgradeToAndCall(V2, address1, [], {
+        from: proxyAdmin
+      });
+      await time.increase(await keepVendor.upgradeTimeDelay());
+
+      await keepVendor.completeUpgrade({ from: proxyAdmin });
+      assert.equal(
+        await keepVendor.implementation.call({ from: proxyAdmin }),
+        address1
+      );
+    });
+
+    it("reverts when called by non-admin", async () => {
+      await expectRevert(
+        keepVendor.completeUpgrade(),
+        "Caller is not the admin"
+      );
+    });
+
+    it("reverts when initialization call fails", async () => {
+      const bondedECDSAKeepVendorImplV1 = await BondedECDSAKeepVendorImplV1.new();
+
+      const failingData = bondedECDSAKeepVendorImplV1.contract.methods
+        .initialize(registryAddress, address0)
+        .encodeABI();
+
+
+      keepVendor.upgradeToAndCall(V2, bondedECDSAKeepVendorImplV1.address, failingData, {
+        from: proxyAdmin
+      })
+      await time.increase(await keepVendor.upgradeTimeDelay());
+
+      await expectRevert(
+        keepVendor.completeUpgrade({ from: proxyAdmin }),
+        "Incorrect factory address"
+      );
     });
   });
 });

--- a/solidity/test/contracts/BondedECDSAKeepVendorStub.sol
+++ b/solidity/test/contracts/BondedECDSAKeepVendorStub.sol
@@ -1,0 +1,37 @@
+pragma solidity ^0.5.4;
+
+import "../../contracts/BondedECDSAKeepVendor.sol";
+
+/// @title Bonded ECDSA Keep Vendor Stub
+/// @dev This contract is for testing purposes only.
+contract BondedECDSAKeepVendorStub is BondedECDSAKeepVendor {
+    constructor(
+        string memory _version,
+        address _implementation,
+        bytes memory _data
+    ) public BondedECDSAKeepVendor(_version, _implementation, _data) {}
+
+    function upgradeVersion() public view returns (string memory) {
+        Implementation memory implementation = getImplementation(
+            upgradeImplementationID()
+        );
+
+        return implementation.version;
+    }
+
+    function upgradeImplementation() public view returns (address) {
+        Implementation memory implementation = getImplementation(
+            upgradeImplementationID()
+        );
+
+        return implementation.implementationContract;
+    }
+
+    function upgradeInitialization() public view returns (bytes memory) {
+        Implementation memory implementation = getImplementation(
+            upgradeImplementationID()
+        );
+
+        return implementation.initializationData;
+    }
+}


### PR DESCRIPTION
This PR is a followup covering https://github.com/keep-network/keep-ecdsa/issues/297#issuecomment-601595942.

With the previous implementation of the two-step proxy upgradeability, we allowed the admin to interact with the implementation contract at the first step of the upgrade process, which gave some exploits possibilities. In this PR we moved the call to an initialize function of the implementation (logic contract) to a second step so it can only be executed after the required time delay.

To be able to pass the initialization call data between the two steps we were required to store dynamic length bytes array in the contract storage. Due to the risk of clashing data storage between proxy and implementation we previously decided to use Unstructured Storage pattern where we define fixed positions for each of the variables used in the proxy contract. Unfortunately, it didn't work for dynamic bytes array, so we decided to store this dynamic type data in a mapping which is [distributing storage based on the data's hash](https://solidity.readthedocs.io/en/v0.5.15/miscellaneous.html#mappings-and-dynamic-arrays).

To clean up the code a little bit and prepare it for reusing we extracted storage variables for the two-step upgradeability pattern to a separate contract. There are more parts that can be extracted to separate contracts but it does not make much sense now taking into consideration the timeframes and that we are willing to reorganize our repositories in the near future.