### PR TITLE
Proxy initialization call moved to the upgrade's second step - simple approach

### DIFF
--- a/solidity/contracts/BondedECDSAKeepVendor.sol
+++ b/solidity/contracts/BondedECDSAKeepVendor.sol
@@ -33,6 +33,13 @@ contract BondedECDSAKeepVendor is Proxy {
     /// subtracted by 1, and is validated in the constructor.
     bytes32 internal constant UPGRADE_INIT_TIMESTAMP_SLOT = 0x0816e8d9eeb2554df0d0b7edc58e2d957e6ce18adf92c138b50dd78a420bebaf;
 
+    /// @notice Details of initialization data to be called on the second step
+    /// of upgrade.
+    /// @dev Mapping is stored at position calculated with keccak256 of the entry
+    /// details, hence it should be protected from clashing with implementation's
+    /// fields.
+    mapping(address => bytes) public initializationData;
+
     event UpgradeStarted(address implementation, uint256 timestamp);
     event UpgradeCompleted(address implementation);
 
@@ -88,9 +95,7 @@ contract BondedECDSAKeepVendor is Proxy {
             "Implementation address must be different from the current one."
         );
 
-        if (_data.length > 0) {
-            initializeImplementation(_newImplementation, _data);
-        }
+        initializationData[_newImplementation] = _data;
 
         setNewImplementation(_newImplementation);
 
@@ -106,7 +111,7 @@ contract BondedECDSAKeepVendor is Proxy {
     /// process. The function emits an event containing the new implementation
     /// address. It can be called after upgrade time delay period has passed since
     /// upgrade initiation.
-    function completeUpgrade() public {
+    function completeUpgrade() public onlyAdmin {
         require(upgradeInitiatedTimestamp() > 0, "Upgrade not initiated");
 
         require(
@@ -119,6 +124,12 @@ contract BondedECDSAKeepVendor is Proxy {
         address newImplementation = newImplementation();
 
         setImplementation(newImplementation);
+
+        bytes memory data = initializationData[newImplementation];
+        if (data.length > 0) {
+            initializeImplementation(newImplementation, data);
+        }
+
         setUpgradeInitiatedTimestamp(0);
 
         emit UpgradeCompleted(newImplementation);

--- a/solidity/contracts/BondedECDSAKeepVendor.sol
+++ b/solidity/contracts/BondedECDSAKeepVendor.sol
@@ -81,7 +81,7 @@ contract BondedECDSAKeepVendor is Proxy {
     /// block timestamp.
     /// @param _newImplementation Address of the new vendor implementation contract.
     /// @param _data Delegate call data for implementation initialization.
-    function upgradeToAndCall(address _newImplementation, bytes memory _data)
+    function upgradeTo(address _newImplementation, bytes memory _data)
         public
         onlyAdmin
     {

--- a/solidity/test/BondedECDSAKeepVendorImplV1viaProxyTest.js
+++ b/solidity/test/BondedECDSAKeepVendorImplV1viaProxyTest.js
@@ -149,15 +149,15 @@ contract("BondedECDSAKeepVendorImplV1viaProxy", async accounts => {
 
         it("cannot be called by proxy admin", async () => {
             await expectRevert(
-                keepVendor.completeFactoryUpgrade({ from: proxyAdmin }),
-                "Upgrade not initiated"
+                keepVendor.upgradeFactory(address2, { from: proxyAdmin }),
+                "Caller is not operator contract upgrader"
             );
         });
 
         it("cannot be called by implementation owner", async () => {
             await expectRevert(
-                keepVendor.completeFactoryUpgrade({ from: implOwner }),
-                "Upgrade not initiated"
+                keepVendor.upgradeFactory(address2, { from: implOwner }),
+                "Caller is not operator contract upgrader"
             );
         });
 

--- a/solidity/test/BondedECDSAKeepVendorTest.js
+++ b/solidity/test/BondedECDSAKeepVendorTest.js
@@ -71,7 +71,7 @@ contract("BondedECDSAKeepVendor", async accounts => {
     });
   });
 
-  describe("upgradeToAndCall", async () => {
+  describe("upgradeTo", async () => {
     beforeEach(async () => {
       await createSnapshot();
     });
@@ -81,7 +81,7 @@ contract("BondedECDSAKeepVendor", async accounts => {
     });
 
     it("sets timestamp", async () => {
-      await keepVendor.upgradeToAndCall(address1, initializeCallData, {
+      await keepVendor.upgradeTo(address1, initializeCallData, {
         from: proxyAdmin
       });
 
@@ -93,7 +93,7 @@ contract("BondedECDSAKeepVendor", async accounts => {
     });
 
     it("sets new implementation", async () => {
-      await keepVendor.upgradeToAndCall(address1, initializeCallData, {
+      await keepVendor.upgradeTo(address1, initializeCallData, {
         from: proxyAdmin
       });
 
@@ -102,7 +102,7 @@ contract("BondedECDSAKeepVendor", async accounts => {
     });
 
     it("sets initialization call data", async () => {
-      await keepVendor.upgradeToAndCall(address1, initializeCallData, {
+      await keepVendor.upgradeTo(address1, initializeCallData, {
         from: proxyAdmin
       });
 
@@ -110,7 +110,7 @@ contract("BondedECDSAKeepVendor", async accounts => {
     });
 
     it("supports empty initialization call data", async () => {
-      await keepVendor.upgradeToAndCall(address1, [], {
+      await keepVendor.upgradeTo(address1, [], {
         from: proxyAdmin
       });
 
@@ -118,7 +118,7 @@ contract("BondedECDSAKeepVendor", async accounts => {
     });
 
     it("emits an event", async () => {
-      const receipt = await keepVendor.upgradeToAndCall(
+      const receipt = await keepVendor.upgradeTo(
         address1,
         initializeCallData,
         { from: proxyAdmin }
@@ -133,11 +133,11 @@ contract("BondedECDSAKeepVendor", async accounts => {
     });
 
     it("allows implementation overwrite", async () => {
-      await keepVendor.upgradeToAndCall(address1, initializeCallData, {
+      await keepVendor.upgradeTo(address1, initializeCallData, {
         from: proxyAdmin
       });
 
-      await keepVendor.upgradeToAndCall(address2, initializeCallData, {
+      await keepVendor.upgradeTo(address2, initializeCallData, {
         from: proxyAdmin
       });
 
@@ -147,11 +147,11 @@ contract("BondedECDSAKeepVendor", async accounts => {
     it("allows initialization data overwrite", async () => {
       const initializeCallData2 = '0x123456';
 
-      await keepVendor.upgradeToAndCall(address1, initializeCallData, {
+      await keepVendor.upgradeTo(address1, initializeCallData, {
         from: proxyAdmin
       });
 
-      await keepVendor.upgradeToAndCall(address1, initializeCallData2, {
+      await keepVendor.upgradeTo(address1, initializeCallData2, {
         from: proxyAdmin
       });
 
@@ -161,7 +161,7 @@ contract("BondedECDSAKeepVendor", async accounts => {
 
     it("reverts on zero address", async () => {
       await expectRevert(
-        keepVendor.upgradeToAndCall(address0, initializeCallData, {
+        keepVendor.upgradeTo(address0, initializeCallData, {
           from: proxyAdmin
         }),
         "Implementation address can't be zero."
@@ -171,7 +171,7 @@ contract("BondedECDSAKeepVendor", async accounts => {
 
     it("reverts on the same address", async () => {
       await expectRevert(
-        keepVendor.upgradeToAndCall(currentAddress, initializeCallData, {
+        keepVendor.upgradeTo(currentAddress, initializeCallData, {
           from: proxyAdmin
         }),
         "Implementation address must be different from the current one."
@@ -180,7 +180,7 @@ contract("BondedECDSAKeepVendor", async accounts => {
 
     it("reverts when called by non-admin", async () => {
       await expectRevert(
-        keepVendor.upgradeToAndCall(address1, initializeCallData),
+        keepVendor.upgradeTo(address1, initializeCallData),
         "Caller is not the admin"
       );
     });
@@ -202,7 +202,7 @@ contract("BondedECDSAKeepVendor", async accounts => {
     });
 
     it("reverts when timer not elapsed", async () => {
-      await keepVendor.upgradeToAndCall(address1, initializeCallData, {
+      await keepVendor.upgradeTo(address1, initializeCallData, {
         from: proxyAdmin
       });
 
@@ -212,7 +212,7 @@ contract("BondedECDSAKeepVendor", async accounts => {
     });
 
     it("clears timestamp", async () => {
-      await keepVendor.upgradeToAndCall(address1, initializeCallData, {
+      await keepVendor.upgradeTo(address1, initializeCallData, {
         from: proxyAdmin
       });
       await time.increase(await keepVendor.upgradeTimeDelay());
@@ -223,7 +223,7 @@ contract("BondedECDSAKeepVendor", async accounts => {
     });
 
     it("sets implementation", async () => {
-      await keepVendor.upgradeToAndCall(address1, initializeCallData, {
+      await keepVendor.upgradeTo(address1, initializeCallData, {
         from: proxyAdmin
       });
       await time.increase(await keepVendor.upgradeTimeDelay());
@@ -236,7 +236,7 @@ contract("BondedECDSAKeepVendor", async accounts => {
     });
 
     it("emits an event", async () => {
-      await keepVendor.upgradeToAndCall(address1, initializeCallData, {
+      await keepVendor.upgradeTo(address1, initializeCallData, {
         from: proxyAdmin
       });
       await time.increase(await keepVendor.upgradeTimeDelay());
@@ -249,7 +249,7 @@ contract("BondedECDSAKeepVendor", async accounts => {
     });
 
     it("supports empty initialization call data", async () => {
-      await keepVendor.upgradeToAndCall(address1, [], {
+      await keepVendor.upgradeTo(address1, [], {
         from: proxyAdmin
       });
       await time.increase(await keepVendor.upgradeTimeDelay());
@@ -271,7 +271,7 @@ contract("BondedECDSAKeepVendor", async accounts => {
         .initialize(registryAddress, address0)
         .encodeABI();
 
-      keepVendor.upgradeToAndCall(
+      keepVendor.upgradeTo(
         bondedECDSAKeepVendorImplV1.address,
         failingData,
         {

--- a/solidity/test/BondedECDSAKeepVendorUpgradeTest.js
+++ b/solidity/test/BondedECDSAKeepVendorUpgradeTest.js
@@ -53,7 +53,7 @@ contract("BondedECDSAKeepVendorUpgrade", async accounts => {
         .initialize(false)
         .encodeABI();
 
-      await keepVendorProxy.upgradeToAndCall(implV2.address, initializeCallData, {
+      await keepVendorProxy.upgradeTo(implV2.address, initializeCallData, {
         from: proxyAdmin
       });
       await time.increase(await keepVendorProxy.upgradeTimeDelay());
@@ -85,7 +85,7 @@ contract("BondedECDSAKeepVendorUpgrade", async accounts => {
         .initialize(registryAddress, factoryAddress)
         .encodeABI();
 
-      keepVendorProxy.upgradeToAndCall(implV2.address, initializeCallData, {
+      keepVendorProxy.upgradeTo(implV2.address, initializeCallData, {
         from: proxyAdmin
       })
       await time.increase(await keepVendorProxy.upgradeTimeDelay());
@@ -106,7 +106,7 @@ contract("BondedECDSAKeepVendorUpgrade", async accounts => {
         .encodeABI();
 
 
-      keepVendorProxy.upgradeToAndCall(
+      keepVendorProxy.upgradeTo(
         implV2.address,
         initializeCallData2,
         {
@@ -117,7 +117,7 @@ contract("BondedECDSAKeepVendorUpgrade", async accounts => {
 
       await keepVendorProxy.completeUpgrade({ from: proxyAdmin })
 
-      await keepVendorProxy.upgradeToAndCall(
+      await keepVendorProxy.upgradeTo(
         implV1.address,
         initializeCallData1,
         {


### PR DESCRIPTION
This PR is a followup covering https://github.com/keep-network/keep-ecdsa/issues/297#issuecomment-601595942.

With the previous implementation of the two-step proxy upgradeability, we allowed the admin to interact with the implementation contract at the first step of the upgrade process, which gave some exploits possibilities. In this PR we moved the call to an initialize function of the implementation (logic contract) to a second step so it can only be executed after the required time delay.

To be able to pass the initialization call data between the two steps we were required to store dynamic length bytes array in the contract storage. Due to the risk of clashing data storage between proxy and implementation we previously decided to use Unstructured Storage pattern where we define fixed positions for each of the variables used in the proxy contract. Unfortunately, it didn't work for dynamic bytes array, so we decided to store this dynamic type data in a mapping which is [distributing storage based on the data's hash](https://solidity.readthedocs.io/en/v0.5.15/miscellaneous.html#mappings-and-dynamic-arrays).