### PR TITLE
Fixed possible context leak for monitoring key publication context

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -264,7 +264,7 @@ func (n *Node) monitorKeepPublicKeySubmission(
 		if monitoringCtx.Err() == context.DeadlineExceeded {
 			logger.Warningf(
 				"monitoring of public key submission for keep [%s] "+
-					"has been cancelled due to timeout exceeding",
+					"has been cancelled due to exceeded timeout",
 				keepAddress.String(),
 			)
 		}

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -137,18 +137,15 @@ func (n *Node) GenerateSignerForKeep(
 		return nil, fmt.Errorf("failed to serialize public key: [%v]", err)
 	}
 
-	monitoringCtx, monitoringCancel := context.WithTimeout(
-		context.Background(),
-		monitorKeepPublicKeySubmissionTimeout,
-	)
-	go n.monitorKeepPublicKeySubmission(monitoringCtx, keepAddress)
+	monitoringAbort := make(chan interface{})
+	go n.monitorKeepPublicKeySubmission(ctx, monitoringAbort, keepAddress)
 
 	err = n.ethereumChain.SubmitKeepPublicKey(
 		keepAddress,
 		serializedPublicKey,
 	)
 	if err != nil {
-		monitoringCancel()
+		close(monitoringAbort)
 		return nil, fmt.Errorf("failed to submit public key: [%v]", err)
 	}
 
@@ -210,8 +207,15 @@ func (n *Node) CalculateSignature(
 // or until key generation timed out.
 func (n *Node) monitorKeepPublicKeySubmission(
 	ctx context.Context,
+	abort chan interface{},
 	keepAddress common.Address,
 ) {
+	monitoringCtx, monitoringCancel := context.WithTimeout(
+		ctx,
+		monitorKeepPublicKeySubmissionTimeout,
+	)
+	defer monitoringCancel()
+
 	publicKeyPublished := make(chan *eth.PublicKeyPublishedEvent)
 	conflictingPublicKey := make(chan *eth.ConflictingPublicKeySubmittedEvent)
 
@@ -256,13 +260,19 @@ func (n *Node) monitorKeepPublicKeySubmission(
 			event.SubmittingMember,
 			event.ConflictingPublicKey,
 		)
-	case <-ctx.Done():
-		if ctx.Err() == context.DeadlineExceeded {
+	case <-monitoringCtx.Done():
+		if monitoringCtx.Err() == context.DeadlineExceeded {
 			logger.Warningf(
 				"monitoring of public key submission for keep [%s] "+
 					"has been cancelled due to timeout exceeding",
 				keepAddress.String(),
 			)
 		}
+	case <-abort:
+		logger.Warningf(
+			"monitoring of public key submission for keep [%s] "+
+				"has been aborted",
+			keepAddress.String(),
+		)
 	}
 }

--- a/solidity/migrations/external-contracts.js
+++ b/solidity/migrations/external-contracts.js
@@ -1,8 +1,8 @@
 // Addresses of externally deployed smart contracts
-const RegistryAddress = "0x9aF7d664E6d7DB318c6BdE54ED77A7D99361F539"
-const TokenStakingAddress = "0x602c5f7d11eb786E14cDfBafe34E70c0b6717a8c"
-const RandomBeaconAddress = "0xB901EDDE70EcB59c1243f404a238fd97B78f1F54"
-const TBTCSystemAddress = "0x065c3Ab1D2cb67c70dAC17Cf3BD4B8A165ffceFa"
+const RegistryAddress = "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+const TokenStakingAddress = "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
+const RandomBeaconAddress = "0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"
+const TBTCSystemAddress = "0xDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD"
 
 module.exports = {
   RegistryAddress,

--- a/solidity/scripts/lcl-provision-external-contracts.sh
+++ b/solidity/scripts/lcl-provision-external-contracts.sh
@@ -28,6 +28,8 @@ ADDRESS_REGEXP=^0[xX][0-9a-fA-F]{40}$
 # Query to get address of the deployed contract for the first network on the list.
 JSON_QUERY=".networks.\"${NETWORKID}\".address"
 
+SED_SUBSTITUTION_REGEXP="['\"][a-zA-Z0-9]*['\"]"
+
 FAILED=false
 
 function fetch_registry_contract_address() {
@@ -40,7 +42,7 @@ function fetch_registry_contract_address() {
     FAILED=true
   else
     echo "Found value for ${REGISTRY_PROPERTY} = ${ADDRESS}"
-    sed -i -e "/${REGISTRY_PROPERTY}/s/'[a-zA-Z0-9]*'/'${ADDRESS}'/" $DESTINATION_FILE
+    sed -i -e "/${REGISTRY_PROPERTY}/s/${SED_SUBSTITUTION_REGEXP}/\"${ADDRESS}\"/" $DESTINATION_FILE
   fi
 }
 
@@ -55,7 +57,7 @@ function fetch_token_staking_contract_address() {
     FAILED=true
   else 
     echo "Found value for ${TOKEN_STAKING_PROPERTY} = ${ADDRESS}"
-    sed -i -e "/${TOKEN_STAKING_PROPERTY}/s/'[a-zA-Z0-9]*'/'${ADDRESS}'/" $DESTINATION_FILE
+    sed -i -e "/${TOKEN_STAKING_PROPERTY}/s/${SED_SUBSTITUTION_REGEXP}/\"${ADDRESS}\"/" $DESTINATION_FILE
   fi
 }
 
@@ -70,7 +72,7 @@ function fetch_random_beacon_contract_address() {
     FAILED=true
   else
   echo "Found value for ${TOKEN_STAKING_PROPERTY} = ${ADDRESS}"
-  sed -i -e "/${RANDOM_BEACON_PROPERTY}/s/'[a-zA-Z0-9]*'/'${ADDRESS}'/" $DESTINATION_FILE
+  sed -i -e "/${RANDOM_BEACON_PROPERTY}/s/${SED_SUBSTITUTION_REGEXP}/\"${ADDRESS}\"/" $DESTINATION_FILE
   fi
 }
 

--- a/solidity/scripts/lcl-set-client-address.sh
+++ b/solidity/scripts/lcl-set-client-address.sh
@@ -11,10 +11,12 @@ set -ex
 
 TBTC_SYSTEM_PROPERTY="TBTCSystemAddress"
 
+SED_SUBSTITUTION_REGEXP="['\"][a-zA-Z0-9]*['\"]"
+
 DESTINATION_FILE=$(realpath $(dirname $0)/../migrations/external-contracts.js)
 
 function update_tbtc_system_address() {
-  sed -i -e "/${TBTC_SYSTEM_PROPERTY}/s/'[a-zA-Z0-9]*'/'${CLIENT_APP_ADDRESS}'/" $DESTINATION_FILE
+  sed -i -e "/${TBTC_SYSTEM_PROPERTY}/s/${SED_SUBSTITUTION_REGEXP}/\"${CLIENT_APP_ADDRESS}\"/" $DESTINATION_FILE
 }
 
 update_tbtc_system_address


### PR DESCRIPTION
There was a possible context leak around key submission monitoring reported by go vet.

We moved context initialization inside the function that is actually using the context.
We added a channel to be able to abort monitoring goroutine in case of an error occurred in the parent function.

Closes: https://github.com/keep-network/keep-ecdsa/issues/334