### PR TITLE
__beaconCallback(uint256) to update group selection seed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/ethereum/go-ethereum v1.9.10
 	github.com/gogo/protobuf v1.3.1
 	github.com/ipfs/go-log v0.0.1
-	github.com/keep-network/keep-common v0.1.1-0.20200228111656-16dd370ca897 // TODO: update to released version
+	github.com/keep-network/keep-common v0.1.1-0.20200330215727-8ca95ff9de56 // TODO: update to released version
 	github.com/keep-network/keep-core v0.10.0
 	github.com/olekukonko/tablewriter v0.0.4 // indirect
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -246,10 +246,13 @@ github.com/keep-network/cli v1.20.0 h1:mEufpPsovOVdduTTkk+a2CxS3crIrGFqUsvs58gSi
 github.com/keep-network/cli v1.20.0/go.mod h1:nzsst4JjU+rGE8Q5J839fYxectxWHpLhxKNohQWtQhA=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20190611114437-e92bd71e8199 h1:4EmAF2XUHK1kwXBhg75OO9hgTkJGK7snwJZlpbu+Yy8=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20190611114437-e92bd71e8199/go.mod h1:MtZSKNavpxpPY0VLt2sl118IxptrGQDUb/MBu+j2Yow=
+github.com/keep-network/keep-common v0.1.0 h1:plTuU25eDayYGSyJRzxWCcID0pVtHVBewLYEAvOkOdM=
 github.com/keep-network/keep-common v0.1.1-0.20191203134929-648c427de66e h1:iGKWRCKuuqw8JhByY0d4ahnKem8bh6P/jwzCmlOOxBk=
 github.com/keep-network/keep-common v0.1.1-0.20191203134929-648c427de66e/go.mod h1:QPhFeJa7snRCRlqIr+0G7ifgxEYwALIa/UfcMzeyxAk=
 github.com/keep-network/keep-common v0.1.1-0.20200228111656-16dd370ca897 h1:0T9+w0udjSNnyR07gUiIcV3bkVZmFlGx40Byq9dqAuI=
 github.com/keep-network/keep-common v0.1.1-0.20200228111656-16dd370ca897/go.mod h1:QPhFeJa7snRCRlqIr+0G7ifgxEYwALIa/UfcMzeyxAk=
+github.com/keep-network/keep-common v0.1.1-0.20200330215727-8ca95ff9de56 h1:VVJrhWz7aqloEH7GzwFbWk36ZXTCpnMH6b5DmKMDxM8=
+github.com/keep-network/keep-common v0.1.1-0.20200330215727-8ca95ff9de56/go.mod h1:QPhFeJa7snRCRlqIr+0G7ifgxEYwALIa/UfcMzeyxAk=
 github.com/keep-network/keep-core v0.9.2-0.20200221162942-550bec0a966c h1:R7wNpsCsifhuXNEK98werTW+nTJO+0EYXsOBlxfCCFQ=
 github.com/keep-network/keep-core v0.9.2-0.20200221162942-550bec0a966c/go.mod h1:+bg+0mNutA7iBwL0Id90Cv4UycmmGEwC/z6/9GWYljo=
 github.com/keep-network/keep-core v0.10.0 h1:+aZe5BMwmaGgZdXdGvIHun2PNtJE4L1SPnBtRL8CRVY=

--- a/solidity/contracts/BondedECDSAKeepFactory.sol
+++ b/solidity/contracts/BondedECDSAKeepFactory.sol
@@ -77,7 +77,7 @@ contract BondedECDSAKeepFactory is IBondedECDSAKeepFactory, CloneFactory {
     // gas required to call `__beaconCallback` function in the worst-case
     // scenario with all the checks and maximum allowed uint256 relay entry as
     // a callback parameter.
-    uint256 public constant callbackGas = 41830;
+    uint256 public constant callbackGas = 30000;
 
     // Random beacon sends back callback surplus to the requestor. It may also
     // decide to send additional request subsidy fee. What's more, it may happen
@@ -101,6 +101,10 @@ contract BondedECDSAKeepFactory is IBondedECDSAKeepFactory, CloneFactory {
         tokenStaking = TokenStaking(_tokenStaking);
         keepBonding = KeepBonding(_keepBonding);
         randomBeacon = IRandomBeacon(_randomBeacon);
+
+        // initial value before the random beacon updates the seed
+        // https://www.wolframalpha.com/input/?i=pi+to+78+digits
+        groupSelectionSeed = 31415926535897932384626433832795028841971693993751058209749445923078164062862;
     }
 
     /// @notice Adds any received funds to the factory reseed pool.

--- a/solidity/contracts/BondedECDSAKeepFactory.sol
+++ b/solidity/contracts/BondedECDSAKeepFactory.sol
@@ -308,10 +308,7 @@ contract BondedECDSAKeepFactory is IBondedECDSAKeepFactory, CloneFactory {
     /// @dev The function is expected to be called in a callback by the random
     /// beacon.
     /// @param _relayEntry Beacon output.
-    function __beaconCallback(uint256 _relayEntry)
-        external
-        onlyRandomBeacon
-    {
+    function __beaconCallback(uint256 _relayEntry) external onlyRandomBeacon {
         groupSelectionSeed = _relayEntry;
     }
 

--- a/solidity/contracts/BondedECDSAKeepFactory.sol
+++ b/solidity/contracts/BondedECDSAKeepFactory.sol
@@ -74,7 +74,7 @@ contract BondedECDSAKeepFactory is IBondedECDSAKeepFactory, CloneFactory {
     uint256 public constant minimumBond = 1;
 
     // Gas required for a callback from the random beacon. The value specifies
-    // gas required to call `setGroupSelectionSeed` function in the worst-case
+    // gas required to call `__beaconCallback` function in the worst-case
     // scenario with all the checks and maximum allowed uint256 relay entry as
     // a callback parameter.
     uint256 public constant callbackGas = 41830;
@@ -307,12 +307,12 @@ contract BondedECDSAKeepFactory is IBondedECDSAKeepFactory, CloneFactory {
     /// @notice Sets a new group selection seed value.
     /// @dev The function is expected to be called in a callback by the random
     /// beacon.
-    /// @param _groupSelectionSeed New value of group selection seed.
-    function setGroupSelectionSeed(uint256 _groupSelectionSeed)
+    /// @param _relayEntry Beacon output.
+    function __beaconCallback(uint256 _relayEntry)
         external
         onlyRandomBeacon
     {
-        groupSelectionSeed = _groupSelectionSeed;
+        groupSelectionSeed = _relayEntry;
     }
 
     /// @notice Checks if operator is registered as a candidate for the given
@@ -462,7 +462,7 @@ contract BondedECDSAKeepFactory is IBondedECDSAKeepFactory, CloneFactory {
     }
 
     /// @notice Requests for a relay entry using the beacon payment provided as
-    /// the parameter. Sets `setGroupSelectionSeed(uint256)` as beacon callback.
+    /// the parameter.
     function requestRelayEntry(uint256 payment)
         internal
         returns (bool, bytes memory)
@@ -470,9 +470,8 @@ contract BondedECDSAKeepFactory is IBondedECDSAKeepFactory, CloneFactory {
         return
             address(randomBeacon).call.value(payment)(
                 abi.encodeWithSignature(
-                    "requestRelayEntry(address,string,uint256)",
+                    "requestRelayEntry(address,uint256)",
                     address(this),
-                    "setGroupSelectionSeed(uint256)",
                     callbackGas
                 )
             );

--- a/solidity/integration/smoke_test.js
+++ b/solidity/integration/smoke_test.js
@@ -179,7 +179,7 @@ module.exports = async function () {
     }
 
     console.log(
-      "group selection seed was successfully updated by the random beacon"
+      `group selection seed successfully updated by the random beacon; seed = [${currentSeed}]`
     )
   } catch (err) {
     console.error(`random beacon callback failed: [${err}]`)

--- a/solidity/test/BondedECDSAKeepFactoryTest.js
+++ b/solidity/test/BondedECDSAKeepFactoryTest.js
@@ -1122,7 +1122,7 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
   })
 
   describe("__beaconCallback", async () => {
-    const newGroupSelectionSeed = new BN(2345675)
+    const newRelayEntry = new BN(2345675)
 
     before(async () => {
       registry = await Registry.new()
@@ -1144,19 +1144,19 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
     })
 
     it("sets group selection seed", async () => {
-      await keepFactory.__beaconCallback(newGroupSelectionSeed, {
+      await keepFactory.__beaconCallback(newRelayEntry, {
         from: randomBeacon,
       })
 
       expect(await keepFactory.getGroupSelectionSeed()).to.eq.BN(
-        newGroupSelectionSeed,
+        newRelayEntry,
         "incorrect new group selection seed"
       )
     })
 
     it("reverts if called not by the random beacon", async () => {
       await expectRevert(
-        keepFactory.__beaconCallback(newGroupSelectionSeed, {
+        keepFactory.__beaconCallback(newRelayEntry, {
           from: accounts[2],
         }),
         "Caller is not the random beacon"

--- a/solidity/test/BondedECDSAKeepFactoryTest.js
+++ b/solidity/test/BondedECDSAKeepFactoryTest.js
@@ -2,7 +2,7 @@ import {createSnapshot, restoreSnapshot} from "./helpers/snapshot"
 
 const {expectRevert} = require("@openzeppelin/test-helpers")
 
-import {mineBlocks} from "./helpers/mineBlocks"
+import {mineBlocks} from './helpers/mineBlocks'
 
 const truffleAssert = require("truffle-assertions")
 
@@ -1121,7 +1121,7 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
     }
   })
 
-  describe("setGroupSelectionSeed", async () => {
+  describe("__beaconCallback", async () => {
     const newGroupSelectionSeed = new BN(2345675)
 
     before(async () => {
@@ -1144,7 +1144,7 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
     })
 
     it("sets group selection seed", async () => {
-      await keepFactory.setGroupSelectionSeed(newGroupSelectionSeed, {
+      await keepFactory.__beaconCallback(newGroupSelectionSeed, {
         from: randomBeacon,
       })
 
@@ -1156,7 +1156,7 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
 
     it("reverts if called not by the random beacon", async () => {
       await expectRevert(
-        keepFactory.setGroupSelectionSeed(newGroupSelectionSeed, {
+        keepFactory.__beaconCallback(newGroupSelectionSeed, {
           from: accounts[2],
         }),
         "Caller is not the random beacon"

--- a/solidity/test/BondedECDSAKeepFactoryTest.js
+++ b/solidity/test/BondedECDSAKeepFactoryTest.js
@@ -2,7 +2,7 @@ import {createSnapshot, restoreSnapshot} from "./helpers/snapshot"
 
 const {expectRevert} = require("@openzeppelin/test-helpers")
 
-import {mineBlocks} from './helpers/mineBlocks'
+import {mineBlocks} from "./helpers/mineBlocks"
 
 const truffleAssert = require("truffle-assertions")
 

--- a/solidity/test/BondedECDSAKeepVendorImplV1Test.js
+++ b/solidity/test/BondedECDSAKeepVendorImplV1Test.js
@@ -20,6 +20,9 @@ contract("BondedECDSAKeepVendorImplV1", async (accounts) => {
 
   before(async () => {
     registry = await Registry.new()
+
+    await registry.approveOperatorContract(address0)
+    await registry.approveOperatorContract(address1)
   })
 
   beforeEach(async () => {
@@ -83,9 +86,6 @@ contract("BondedECDSAKeepVendorImplV1", async (accounts) => {
     const keepVendor = await BondedECDSAKeepVendorImplV1Stub.new()
 
     await registry.setOperatorContractUpgrader(keepVendor.address, upgrader)
-
-    await registry.approveOperatorContract(address0)
-    await registry.approveOperatorContract(address1)
 
     return keepVendor
   }

--- a/solidity/test/BondedECDSAKeepVendorImplV1viaProxyTest.js
+++ b/solidity/test/BondedECDSAKeepVendorImplV1viaProxyTest.js
@@ -36,6 +36,11 @@ contract("BondedECDSAKeepVendorImplV1viaProxy", async (accounts) => {
 
   before(async () => {
     registry = await Registry.new()
+    await registry.approveOperatorContract(address0)
+    await registry.approveOperatorContract(address1)
+    await registry.approveOperatorContract(address2)
+    await registry.approveOperatorContract(address3)
+
     keepVendor = await newVendor()
   })
 
@@ -258,11 +263,6 @@ contract("BondedECDSAKeepVendorImplV1viaProxy", async (accounts) => {
     const keepVendor = await deployVendorProxy(registryAddress, factoryAddress)
 
     await registry.setOperatorContractUpgrader(keepVendor.address, upgrader)
-
-    await registry.approveOperatorContract(address0)
-    await registry.approveOperatorContract(address1)
-    await registry.approveOperatorContract(address2)
-    await registry.approveOperatorContract(address3)
 
     return keepVendor
   }

--- a/solidity/test/contracts/RandomBeaconStub.sol
+++ b/solidity/test/contracts/RandomBeaconStub.sol
@@ -1,10 +1,10 @@
 pragma solidity ^0.5.4;
 
-import "@keep-network/keep-core/contracts/IRandomBeacon.sol";
+//import "@keep-network/keep-core/contracts/IRandomBeacon.sol";
 
 /// @title Random Beacon Service Stub
 /// @dev This contract is for testing purposes only.
-contract RandomBeaconStub is IRandomBeacon {
+contract RandomBeaconStub /*is IRandomBeacon*/ {
     uint256 feeEstimate = 58;
     uint256 entry = 0;
     uint256 public requestCount = 0;
@@ -22,7 +22,6 @@ contract RandomBeaconStub is IRandomBeacon {
 
     function requestRelayEntry(
         address callbackContract,
-        string memory callbackMethod,
         uint256 callbackGas
     ) public payable returns (uint256) {
         requestCount++;
@@ -33,13 +32,13 @@ contract RandomBeaconStub is IRandomBeacon {
 
         if (entry != 0) {
             callbackContract.call(
-                abi.encodeWithSignature(callbackMethod, entry)
+                abi.encodeWithSignature("__beaconCallback(uint256)", entry)
             );
         }
     }
 
     function requestRelayEntry() external payable returns (uint256) {
-        return requestRelayEntry(address(0), "", 0);
+        return requestRelayEntry(address(0), 0);
     }
 
     function setEntry(uint256 newEntry) public {

--- a/solidity/test/contracts/RandomBeaconStub.sol
+++ b/solidity/test/contracts/RandomBeaconStub.sol
@@ -1,10 +1,10 @@
 pragma solidity ^0.5.4;
 
-//import "@keep-network/keep-core/contracts/IRandomBeacon.sol";
+import "@keep-network/keep-core/contracts/IRandomBeacon.sol";
 
 /// @title Random Beacon Service Stub
 /// @dev This contract is for testing purposes only.
-contract RandomBeaconStub /*is IRandomBeacon*/ {
+contract RandomBeaconStub is IRandomBeacon {
     uint256 feeEstimate = 58;
     uint256 entry = 0;
     uint256 public requestCount = 0;


### PR DESCRIPTION
Refs https://github.com/keep-network/keep-core/issues/1527

See https://github.com/keep-network/keep-core/pull/1532
See keep-network/keep-common#22

The random beacon does no longer allow to request relay entry passing signature of callback function to be called. Instead, it expects `__beaconCallback(uint256)` function to be declared by the contract receiving the random number.

Additionally:
- [Fixed tests](https://github.com/keep-network/keep-ecdsa/pull/339/commits/941f7aa82be68790aab06a94c249d7dce4374a6f) after bumping up `keep-core` reference
- [Reduced beacon callback gas estimate](https://github.com/keep-network/keep-ecdsa/pull/339/commits/7b04db60c466ec375cc60296ca987290b4e7f617)