### PR TITLE
Version Tether: Continuous packaging and versioning

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -266,31 +266,12 @@ workflows:
       - build_and_test_solidity
   build-test-migrate-publish-keep-dev:
     jobs:
-      - build_client_and_test_go:
-          context: github-package-registry
+      - build_client_and_test_go
       - migrate_contracts:
           filters:
             branches:
               only: master
           context: keep-dev
-          requires:
-            - build_client_and_test_go
-      - build_initcontainer:
-          filters:
-            branches:
-              only: master
-          context: keep-dev
-          requires:
-            - migrate_contracts
-      - publish_client:
-          filters:
-            branches:
-              only: master
-          context: keep-dev
-          requires:
-            - build_client_and_test_go
-            - build_initcontainer
-            - migrate_contracts
       - publish_npm_package:
           filters:
             branches:
@@ -305,6 +286,21 @@ workflows:
           context: keep-dev
           requires:
             - migrate_contracts
+      - build_initcontainer:
+          filters:
+            branches:
+              only: master
+          context: keep-dev
+          requires:
+            - migrate_contracts
+            - build_client_and_test_go
+      - publish_client:
+          filters:
+            branches:
+              only: master
+          context: keep-dev
+          requires:
+            - build_initcontainer
   build-test-migrate-publish-keep-test:
     jobs:
       - keep_test_approval:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -177,6 +177,50 @@ jobs:
           root: /tmp/keep-ecdsa
           paths:
             - contracts
+  publish_npm_package:
+    executor: docker-node
+    steps:
+      - attach_workspace:
+          at: /tmp/keep-ecdsa
+      - checkout
+      - run:
+          name: Bump and publish npm package
+          working_directory: ~/project/solidity
+          command: |
+            set -x
+            mkdir -p artifacts
+            cp -r /tmp/keep-ecdsa/contracts/* artifacts/
+            name=$(jq --raw-output .name package.json)
+            version=$(jq --raw-output .version package.json)
+            preid=$(echo $version | sed -e s/^.*-\\\([^.]*\\\).*$/\\1/)
+
+            # Find the latest published package version matching this preid.
+            # Note that in jq, we wrap the result in an array and then flatten;
+            # this is because npm show json contains a single string if there
+            # is only one matching version, or an array if there are multiple,
+            # and we want to look at an array always.
+            latest_version=$(npm show -json "$name@^$version" version | jq --raw-output "[.] | flatten | sort | .[-1]")
+            latest_version=${latest_version:-$version}
+            if [ -z $latest_version ]; then
+              echo "Latest version calculation failed. Resolved info:"
+              echo "$name@$version ; preid $preid"
+              exit 1
+            fi
+
+            # Update package.json with the latest published package version matching this
+            # preid to prepare for bumping.
+            echo $(jq -M ".version=\"${latest_version}\"" package.json) > package.json
+
+            # Bump without doing any git work. Versioning is a build-time action for us.
+            # Consider including commit id? Would be +<commit id>.
+            npm version prerelease --preid=$preid --no-git-tag-version
+
+            # Fix resolved dependency versions.
+            npm update
+
+            # Publish to npm.
+            echo //registry.npmjs.org/:_authToken=${NPM_TOKEN} > .npmrc
+            npm publish --access=public
   publish_client:
     executor: gcp-gcr/default
     steps:
@@ -271,6 +315,13 @@ workflows:
             - build_client_and_test_go
             - build_initcontainer
             - migrate_contracts
+      - publish_npm_package:
+          filters:
+            branches:
+              only: master
+          context: keep-dev
+          requires:
+            - migrate_contracts
       - publish_contract_data:
           filters:
             branches:
@@ -333,6 +384,15 @@ workflows:
           requires:
             - build_client_and_test_go
             - build_initcontainer
+            - migrate_contracts
+      - publish_npm_package:
+          context: keep-test
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+          requires:
             - migrate_contracts
       - publish_contract_data:
           context: keep-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,18 +16,6 @@ orbs:
   gcp-gcr: circleci/gcp-gcr@0.0.4
 
 jobs:
-  setup_github_package_registry:
-    executor: docker-node
-    steps:
-      - checkout
-      - run:
-          name: Authenticate GitHub Package Registry
-          working_directory: ~/project/solidity
-          command: echo "//npm.pkg.github.com/:_authToken=$GITHUB_TOKEN" >> .npmrc
-      - persist_to_workspace:
-          root: solidity
-          paths:
-            - .npmrc
   lint:
     executor: docker-node
     steps:
@@ -272,26 +260,14 @@ workflows:
   version: 2
   lint:
     jobs:
-      - setup_github_package_registry:
-          context: github-package-registry
-      - lint:
-          requires:
-            - setup_github_package_registry
+      - lint
   solidity:
     jobs:
-      - setup_github_package_registry:
-          context: github-package-registry
-      - build_and_test_solidity:
-          requires:
-            - setup_github_package_registry
+      - build_and_test_solidity
   build-test-migrate-publish-keep-dev:
     jobs:
-      - setup_github_package_registry:
-          context: github-package-registry
       - build_client_and_test_go:
           context: github-package-registry
-          requires:
-            - setup_github_package_registry
       - migrate_contracts:
           filters:
             branches:
@@ -338,15 +314,6 @@ workflows:
               only: /^v.*/
             branches:
               ignore: /.*/
-      - setup_github_package_registry:
-          context: github-package-registry
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
-          requires:
-            - keep_test_approval
       - build_client_and_test_go:
           context: github-package-registry
           filters:
@@ -354,8 +321,6 @@ workflows:
               only: /^v.*/
             branches:
               ignore: /.*/
-          requires:
-            - setup_github_package_registry
       - migrate_contracts:
           context: keep-test
           filters:

--- a/solidity/.npmrc
+++ b/solidity/.npmrc
@@ -1,1 +1,0 @@
-@keep-network:registry=https://npm.pkg.github.com

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "0.11.0-rc",
+  "version": "0.12.0-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -879,12 +879,13 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "0.9.2",
-      "resolved": "https://npm.pkg.github.com/download/@keep-network/keep-core/0.9.2/5359ca4c55a914c370ecc9bcaa8ebc0545e094ff2166f68e071f7064eb6dac5c",
-      "integrity": "sha512-4rB0vIrIXWE77ty1psofaWC+URM4fc9tTP7DVwGmr68TpvQxK0tEWe7E2CSiHEdv/VwQux/FtbTtZqrAnsVqAA==",
+      "version": "0.12.0-pre.4",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.12.0-pre.4.tgz",
+      "integrity": "sha512-UF5RsCB4HunM9B4YJ48PQVwqQHcuiogxXSU7hCOxH+xGhNhi01IJQohCvj+cWTojbTCd4eOcWxSSx5O5ixsMfg==",
       "requires": {
-        "openzeppelin-solidity": "2.4.0",
-        "solidity-bytes-utils": "0.0.7"
+        "@openzeppelin/contracts-ethereum-package": "^2.4.0",
+        "@openzeppelin/upgrades": "^2.7.2",
+        "openzeppelin-solidity": "2.4.0"
       },
       "dependencies": {
         "openzeppelin-solidity": {
@@ -896,8 +897,8 @@
     },
     "@keep-network/sortition-pools": {
       "version": "0.1.1",
-      "resolved": "https://npm.pkg.github.com/download/@keep-network/sortition-pools/0.1.1/e0792a48a6f8b67c38349a71b78c07c1b57ba5587a36d6ee4e51daecb34e49cc",
-      "integrity": "sha512-oDaDyryLZcTVljYNrVgUsFHsMBb+dDqSOIlQi25C4gR++vfSDOtIFxMg3yvgM1zg/EpXcGdTLqY20WNjBPDLAg==",
+      "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-0.1.1.tgz",
+      "integrity": "sha512-0A4N6wbtFfjWez7KwHEd2aMh6iB4kNaxI5fGDUCaCkeo2zP/FHOFcI9POIYLQ/17bL71EK/WxM5CnZJz4n/9vg==",
       "requires": {
         "@openzeppelin/contracts": "^2.4.0",
         "solidity-bytes-utils": "0.0.7"
@@ -946,6 +947,11 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-2.5.0.tgz",
       "integrity": "sha512-t3jm8FrhL9tkkJTofkznTqo/XXdHi21w5yXwalEnaMOp22ZwZ0f/mmKdlgMMLPFa6bSVHbY88mKESwJT/7m5Lg=="
+    },
+    "@openzeppelin/contracts-ethereum-package": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts-ethereum-package/-/contracts-ethereum-package-2.5.0.tgz",
+      "integrity": "sha512-14CijdTyy4Y/3D3UUeFC2oW12nt1Yq1M8gFOtkuODEvSYPe3YSAKnKyhUeGf0UDNCZzwfGr15KdiFK6AoJjoSQ=="
     },
     "@openzeppelin/test-helpers": {
       "version": "0.5.4",

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,17 +1,15 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "0.11.0-rc",
+  "version": "0.12.0-pre",
   "description": "Smart contracts for ECDSA Keep",
   "repository": {
     "type": "git",
     "url": "ssh://git@github.com/keep-network/keep-ecdsa.git"
   },
   "files": [
-    "contracts/**/*.sol"
+    "contracts/**/*.sol",
+    "artifacts/"
   ],
-  "publishConfig": {
-    "registry": "https://npm.pkg.github.com/"
-  },
   "scripts": {
     "truffle": "truffle",
     "clean": "rm -rf build/",
@@ -34,7 +32,7 @@
   },
   "homepage": "https://github.com/keep-network/keep-ecdsa",
   "dependencies": {
-    "@keep-network/keep-core": "0.9.2",
+    "@keep-network/keep-core": ">0.12.0-pre <0.12.0-rc",
     "@keep-network/sortition-pools": "0.1.1",
     "@openzeppelin/upgrades": "^2.7.2",
     "openzeppelin-solidity": "2.3.0",


### PR DESCRIPTION
This PR picks up the work in keep-network/keep-core#1408 to publish
new, artifacts-included npm packages on contract migration. It adds the
same functionality to keep-ecdsa, and additionally updates the version
string referencing keep-core to properly integrate with keep-core's
versioning.

The major changes are as in keep-core:
- `package.json` for Solidity contracts is set to `<version>-pre`, with no
  numeric suffix.
- A new Circle job, `publish_npm_package`, runs on master merge. This
  job updates the package version to `-pre.<number>`, where `<number>`
  represents a new, unpublished version.
- Contract artifacts from the contract migration are copied to an `artifacts/`
  subdirectory and included in the package.
- The package is published to the main npm repository (not the GitHub
  package repository).
- We trigger a downstream build (placeholder, didn't get a chance to hook this
  up yet, plus we should wait until this build strategy propagates to the other
  repositories).