### PR TITLE
Configurable TSS pre-parameters generation timeout

### DIFF
--- a/configs/config.toml.SAMPLE
+++ b/configs/config.toml.SAMPLE
@@ -38,4 +38,4 @@
 # should be provided based on resources available on the machine running the client.
 # This is an optional parameter, if not provided timeout for TSS protocol
 # pre-parameters generation will be set to `2 minutes`.
-#  PreParamsGenerationTimeout = "2m"
+#  PreParamsGenerationTimeout = "2m30s"

--- a/configs/config.toml.SAMPLE
+++ b/configs/config.toml.SAMPLE
@@ -29,11 +29,6 @@
 #   # AnnouncedAddresses = ["/dns4/example.com/tcp/3919", "/ip4/80.70.60.50/tcp/3919"]
 
 [TSS]
-# Level of concurrency for TSS protocol pre-parameters generation. The value
-# should be provided based on resources available on the machine running the client.
-# This is an optional parameter, if not provided concurrency level for TSS protocol
-# will be set to `3` which is a minimum to run pre-parameters generation process.
-#  PreParamsGenerationConcurrency = 3
 # Timeout for TSS protocol pre-parameters generation. The value
 # should be provided based on resources available on the machine running the client.
 # This is an optional parameter, if not provided timeout for TSS protocol

--- a/configs/config.toml.SAMPLE
+++ b/configs/config.toml.SAMPLE
@@ -34,3 +34,8 @@
 # This is an optional parameter, if not provided concurrency level for TSS protocol
 # will be set to `3` which is a minimum to run pre-parameters generation process.
 #  PreParamsGenerationConcurrency = 3
+# Timeout for TSS protocol pre-parameters generation. The value
+# should be provided based on resources available on the machine running the client.
+# This is an optional parameter, if not provided timeout for TSS protocol
+# pre-parameters generation will be set to `2 minutes`.
+#  PreParamsGenerationTimeout = "2m"

--- a/pkg/ecdsa/tss/config.go
+++ b/pkg/ecdsa/tss/config.go
@@ -6,8 +6,6 @@ import (
 
 // Config contains configuration for tss protocol execution.
 type Config struct {
-	// Concurrency level for pre-parameters generation in tss-lib.
-	PreParamsGenerationConcurrency int
 	// Timeout for pre-parameters generation in tss-lib.
 	PreParamsGenerationTimeout duration
 }

--- a/pkg/ecdsa/tss/config.go
+++ b/pkg/ecdsa/tss/config.go
@@ -1,7 +1,26 @@
 package tss
 
+import (
+	"time"
+)
+
 // Config contains configuration for tss protocol execution.
 type Config struct {
 	// Concurrency level for pre-parameters generation in tss-lib.
 	PreParamsGenerationConcurrency int
+	// Timeout for pre-parameters generation in tss-lib.
+	PreParamsGenerationTimeout duration
+}
+
+// We use BurntSushi/toml package to parse configuration file. Unfortunately it
+// doesn't support time.Duration out of the box. Here we introduce a workaround
+// to be able to parse values provided in more friendly way, e.g. "4m20s".
+type duration struct {
+	time.Duration
+}
+
+func (d *duration) UnmarshalText(text []byte) error {
+	var err error
+	d.Duration, err = time.ParseDuration(string(text))
+	return err
 }

--- a/pkg/ecdsa/tss/keygen.go
+++ b/pkg/ecdsa/tss/keygen.go
@@ -11,17 +11,13 @@ import (
 )
 
 // GenerateTSSPreParams calculates parameters required by TSS key generation.
-// It times out after 90 seconds if the required parameters could not be generated.
+// It times out after defined period if the required parameters could not be generated.
 // It is possible to generate the parameters way ahead of the TSS protocol
 // execution.
 func GenerateTSSPreParams(
 	preParamsGenerationTimeout time.Duration,
-	concurrency int,
 ) (*keygen.LocalPreParams, error) {
-	preParams, err := keygen.GeneratePreParams(
-		preParamsGenerationTimeout,
-		concurrency,
-	)
+	preParams, err := keygen.GeneratePreParams(preParamsGenerationTimeout)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate tss pre-params: [%v]", err)
 	}

--- a/pkg/ecdsa/tss/keygen.go
+++ b/pkg/ecdsa/tss/keygen.go
@@ -10,15 +10,14 @@ import (
 	"github.com/binance-chain/tss-lib/tss"
 )
 
-const (
-	preParamsGenerationTimeout = 120 * time.Second
-)
-
 // GenerateTSSPreParams calculates parameters required by TSS key generation.
 // It times out after 90 seconds if the required parameters could not be generated.
 // It is possible to generate the parameters way ahead of the TSS protocol
 // execution.
-func GenerateTSSPreParams(concurrency int) (*keygen.LocalPreParams, error) {
+func GenerateTSSPreParams(
+	preParamsGenerationTimeout time.Duration,
+	concurrency int,
+) (*keygen.LocalPreParams, error) {
 	// As a workaround for a bug in tss-lib we have to provide `optionalConcurrency`
 	// parameter with value of at least `3` so the underlying goroutines are
 	// executed on machines with less than 3 CPU.
@@ -28,7 +27,10 @@ func GenerateTSSPreParams(concurrency int) (*keygen.LocalPreParams, error) {
 		concurrency = 3
 	}
 
-	preParams, err := keygen.GeneratePreParams(preParamsGenerationTimeout, concurrency)
+	preParams, err := keygen.GeneratePreParams(
+		preParamsGenerationTimeout,
+		concurrency,
+	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate tss pre-params: [%v]", err)
 	}

--- a/pkg/node/params_pool.go
+++ b/pkg/node/params_pool.go
@@ -33,10 +33,7 @@ func (n *Node) InitializeTSSPreParamsPool() {
 	n.tssParamsPool = &tssPreParamsPool{
 		pool: make(chan *keygen.LocalPreParams, poolSize),
 		new: func() (*keygen.LocalPreParams, error) {
-			return tss.GenerateTSSPreParams(
-				timeout,
-				n.tssConfig.PreParamsGenerationConcurrency,
-			)
+			return tss.GenerateTSSPreParams(timeout)
 		},
 	}
 

--- a/pkg/node/params_pool.go
+++ b/pkg/node/params_pool.go
@@ -45,13 +45,25 @@ func (n *Node) InitializeTSSPreParamsPool() {
 
 func (t *tssPreParamsPool) pumpPool() {
 	for {
+		logger.Info("generate new tss pre parameters")
+
+		start := time.Now()
+
 		params, err := t.new()
 		if err != nil {
-			logger.Warningf("failed to generate tss pre parameters: [%v]", err)
+			logger.Warningf(
+				"failed to generate tss pre parameters after [%s]: [%v]",
+				time.Since(start),
+				err,
+			)
 			continue
 		}
 
-		logger.Infof("generated new tss pre parameters")
+		logger.Infof(
+			"generated new tss pre parameters, took: [%s], current pool size: [%d]",
+			time.Since(start),
+			len(t.pool)+1,
+		)
 
 		t.pool <- params
 	}

--- a/pkg/node/params_pool.go
+++ b/pkg/node/params_pool.go
@@ -45,7 +45,7 @@ func (n *Node) InitializeTSSPreParamsPool() {
 
 func (t *tssPreParamsPool) pumpPool() {
 	for {
-		logger.Info("generate new tss pre parameters")
+		logger.Info("generating new tss pre parameters")
 
 		start := time.Now()
 

--- a/pkg/node/params_pool.go
+++ b/pkg/node/params_pool.go
@@ -1,8 +1,14 @@
 package node
 
 import (
+	"time"
+
 	"github.com/binance-chain/tss-lib/ecdsa/keygen"
 	"github.com/keep-network/keep-ecdsa/pkg/ecdsa/tss"
+)
+
+const (
+	defaultPreParamsGenerationTimeout = 2 * time.Minute
 )
 
 // tssPreParamsPool is a pool holding TSS pre parameters. It autogenerates entries
@@ -20,7 +26,10 @@ func (n *Node) InitializeTSSPreParamsPool() {
 	n.tssParamsPool = &tssPreParamsPool{
 		pool: make(chan *keygen.LocalPreParams, poolSize),
 		new: func() (*keygen.LocalPreParams, error) {
-			return tss.GenerateTSSPreParams(n.tssConfig.PreParamsGenerationConcurrency)
+			return tss.GenerateTSSPreParams(
+				defaultPreParamsGenerationTimeout,
+				n.tssConfig.PreParamsGenerationConcurrency,
+			)
 		},
 	}
 

--- a/pkg/node/params_pool.go
+++ b/pkg/node/params_pool.go
@@ -23,11 +23,18 @@ type tssPreParamsPool struct {
 func (n *Node) InitializeTSSPreParamsPool() {
 	poolSize := 5
 
+	var timeout time.Duration
+	if n.tssConfig.PreParamsGenerationTimeout.Duration > 0 {
+		timeout = time.Duration(n.tssConfig.PreParamsGenerationTimeout.Duration)
+	} else {
+		timeout = defaultPreParamsGenerationTimeout
+	}
+
 	n.tssParamsPool = &tssPreParamsPool{
 		pool: make(chan *keygen.LocalPreParams, poolSize),
 		new: func() (*keygen.LocalPreParams, error) {
 			return tss.GenerateTSSPreParams(
-				defaultPreParamsGenerationTimeout,
+				timeout,
 				n.tssConfig.PreParamsGenerationConcurrency,
 			)
 		},


### PR DESCRIPTION
We used to set a timeout for a pre-parameters generation to a fixed value of `120 seconds`. It felt like a way more than enough when running it on machines with 4+ CPU cores. Unfortunately, it may be to low for less powerful machines. Here we added a possibility to set the timeout to an arbitrary value based on the operator's observations and resources the server has.

The value can be configured in a toml config file under `PreParamsGenerationTimeout`. If not set the default `2 minutes` will be assumed.

We also remove `PreParamsGenerationConcurrency` parameters as it's not longer required after the concurrency fix in `tss-lib`. 