### PR TITLE
Updated tss-lib dependency to version 1.3.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ replace (
 require (
 	github.com/BurntSushi/toml v0.3.1
 	github.com/aristanetworks/goarista v0.0.0-20200211191935-58c705f5cf52 // indirect
-	github.com/binance-chain/tss-lib v1.3.0
+	github.com/binance-chain/tss-lib v1.3.1
 	github.com/btcsuite/btcd v0.20.1-beta
 	github.com/ethereum/go-ethereum v1.9.10
 	github.com/gogo/protobuf v1.3.1

--- a/go.sum
+++ b/go.sum
@@ -52,6 +52,8 @@ github.com/binance-chain/tss-lib v1.1.1 h1:WWVVb7GlWuOy2usumPDWuzR0pTPl+t+faGEjk
 github.com/binance-chain/tss-lib v1.1.1/go.mod h1:5mmPQOOkBIjHxyGVesSUB2AemcZj5YkMJ+HPZY4Jd38=
 github.com/binance-chain/tss-lib v1.3.0 h1:I3UfAkzC/TP4CqsnCX+MpzHxZavTC6t5r6n49P8pI38=
 github.com/binance-chain/tss-lib v1.3.0/go.mod h1:y85qADlz1+q+Eo01GupDnNt68XJDmb6I/jEwAolIHtQ=
+github.com/binance-chain/tss-lib v1.3.1 h1:CkPKXA28NK0w3umQ4eCwtxPQQbOzRt1oqMTbflCzh98=
+github.com/binance-chain/tss-lib v1.3.1/go.mod h1:y85qADlz1+q+Eo01GupDnNt68XJDmb6I/jEwAolIHtQ=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f h1:bAs4lUbRJpnnkd9VhRV3jjAVU7DJVjMaK+IsvSeZvFo=
 github.com/btcsuite/btclog v0.0.0-20170628155309-84c8d2346e9f/go.mod h1:TdznJufoqS23FtqVCzL0ZqgP5MqXbb4fg/WgDys70nA=
 github.com/btcsuite/go-socks v0.0.0-20170105172521-4720035b7bfd/go.mod h1:HHNXQzUsZCxOoE+CPiyCTO6x34Zs86zZUiwtpXoGdtg=

--- a/pkg/ecdsa/tss/keygen.go
+++ b/pkg/ecdsa/tss/keygen.go
@@ -19,15 +19,6 @@ const (
 // It is possible to generate the parameters way ahead of the TSS protocol
 // execution.
 func GenerateTSSPreParams(concurrency int) (*keygen.LocalPreParams, error) {
-	// As a workaround for a bug in tss-lib we have to provide `optionalConcurrency`
-	// parameter with value of at least `3` so the underlying goroutines are
-	// executed on machines with less than 3 CPU.
-	//
-	// See: https://github.com/binance-chain/tss-lib/issues/93
-	if concurrency < 3 {
-		concurrency = 3
-	}
-
 	preParams, err := keygen.GeneratePreParams(preParamsGenerationTimeout, concurrency)
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate tss pre-params: [%v]", err)


### PR DESCRIPTION
We updated tss-lib dependency to version 1.3.1 which contains fix for a bug binance-chain/tss-lib#93. We removed a workaround as it's no longer needed.