### PR TITLE
keep-dev: TBTCSystem contract update

### DIFF
--- a/infrastructure/kube/keep-dev/keep-ecdsa-0-statefulset.yaml
+++ b/infrastructure/kube/keep-dev/keep-ecdsa-0-statefulset.yaml
@@ -52,6 +52,8 @@ spec:
                   key: account-0
             - name: LOG_LEVEL
               value: 'keep*=debug tss-lib=warning'
+            - name: IPFS_LOGGING_FMT
+              value: nocolor
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-dev/keep-ecdsa-0-statefulset.yaml
+++ b/infrastructure/kube/keep-dev/keep-ecdsa-0-statefulset.yaml
@@ -107,7 +107,7 @@ spec:
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
             - name: TBTC_SYSTEM_ADDRESS
-              value: '0xEBFaCe35675e5c7253dC088Cc8Eb9a17FFA6172D' # Shall we extract this property to a configmap?
+              value: '0x7F68B90dce19d2ac034477B7ba2229106656A084' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-dev/keep-ecdsa-1-statefulset.yaml
+++ b/infrastructure/kube/keep-dev/keep-ecdsa-1-statefulset.yaml
@@ -107,7 +107,7 @@ spec:
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
             - name: TBTC_SYSTEM_ADDRESS
-              value: '0xEBFaCe35675e5c7253dC088Cc8Eb9a17FFA6172D' # Shall we extract this property to a configmap?
+              value: '0x7F68B90dce19d2ac034477B7ba2229106656A084' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-dev/keep-ecdsa-1-statefulset.yaml
+++ b/infrastructure/kube/keep-dev/keep-ecdsa-1-statefulset.yaml
@@ -52,6 +52,8 @@ spec:
                   key: account-1
             - name: LOG_LEVEL
               value: 'keep*=debug tss-lib=warning'
+            - name: IPFS_LOGGING_FMT
+              value: nocolor
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-dev/keep-ecdsa-2-statefulset.yaml
+++ b/infrastructure/kube/keep-dev/keep-ecdsa-2-statefulset.yaml
@@ -108,7 +108,7 @@ spec:
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
             - name: TBTC_SYSTEM_ADDRESS
-              value: '0xEBFaCe35675e5c7253dC088Cc8Eb9a17FFA6172D' # Shall we extract this property to a configmap?
+              value: '0x7F68B90dce19d2ac034477B7ba2229106656A084' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-dev/keep-ecdsa-2-statefulset.yaml
+++ b/infrastructure/kube/keep-dev/keep-ecdsa-2-statefulset.yaml
@@ -53,6 +53,8 @@ spec:
                   key: account-2
             - name: LOG_LEVEL
               value: 'keep*=debug tss-lib=warning'
+            - name: IPFS_LOGGING_FMT
+              value: nocolor
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-dev/keep-ecdsa-3-statefulset.yaml
+++ b/infrastructure/kube/keep-dev/keep-ecdsa-3-statefulset.yaml
@@ -108,7 +108,7 @@ spec:
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
             - name: TBTC_SYSTEM_ADDRESS
-              value: '0xEBFaCe35675e5c7253dC088Cc8Eb9a17FFA6172D' # Shall we extract this property to a configmap?
+              value: '0x7F68B90dce19d2ac034477B7ba2229106656A084' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-dev/keep-ecdsa-3-statefulset.yaml
+++ b/infrastructure/kube/keep-dev/keep-ecdsa-3-statefulset.yaml
@@ -53,6 +53,8 @@ spec:
                   key: account-3
             - name: LOG_LEVEL
               value: 'keep*=debug tss-lib=warning'
+            - name: IPFS_LOGGING_FMT
+              value: nocolor
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-dev/keep-ecdsa-4-statefulset.yaml
+++ b/infrastructure/kube/keep-dev/keep-ecdsa-4-statefulset.yaml
@@ -108,7 +108,7 @@ spec:
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
             - name: TBTC_SYSTEM_ADDRESS
-              value: '0xEBFaCe35675e5c7253dC088Cc8Eb9a17FFA6172D' # Shall we extract this property to a configmap?
+              value: '0x7F68B90dce19d2ac034477B7ba2229106656A084' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-dev/keep-ecdsa-4-statefulset.yaml
+++ b/infrastructure/kube/keep-dev/keep-ecdsa-4-statefulset.yaml
@@ -53,6 +53,8 @@ spec:
                   key: account-4
             - name: LOG_LEVEL
               value: 'keep*=debug tss-lib=warning'
+            - name: IPFS_LOGGING_FMT
+              value: nocolor
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-test/keep-ecdsa-0-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-ecdsa-0-statefulset.yaml
@@ -52,6 +52,8 @@ spec:
                   key: account-0
             - name: LOG_LEVEL
               value: 'keep*=debug tss-lib=warning'
+            - name: IPFS_LOGGING_FMT
+              value: nocolor
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-test/keep-ecdsa-1-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-ecdsa-1-statefulset.yaml
@@ -52,6 +52,8 @@ spec:
                   key: account-1
             - name: LOG_LEVEL
               value: 'keep*=debug tss-lib=warning'
+            - name: IPFS_LOGGING_FMT
+              value: nocolor
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-test/keep-ecdsa-2-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-ecdsa-2-statefulset.yaml
@@ -53,6 +53,8 @@ spec:
                   key: account-2
             - name: LOG_LEVEL
               value: 'keep*=debug tss-lib=warning'
+            - name: IPFS_LOGGING_FMT
+              value: nocolor
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-test/keep-ecdsa-3-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-ecdsa-3-statefulset.yaml
@@ -53,6 +53,8 @@ spec:
                   key: account-3
             - name: LOG_LEVEL
               value: 'keep*=debug tss-lib=warning'
+            - name: IPFS_LOGGING_FMT
+              value: nocolor
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-test/keep-ecdsa-4-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-ecdsa-4-statefulset.yaml
@@ -53,6 +53,8 @@ spec:
                   key: account-4
             - name: LOG_LEVEL
               value: 'keep*=debug tss-lib=warning'
+            - name: IPFS_LOGGING_FMT
+              value: nocolor
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-test/keep-ecdsa-5-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-ecdsa-5-statefulset.yaml
@@ -52,6 +52,8 @@ spec:
                   key: account-5
             - name: LOG_LEVEL
               value: 'keep*=debug tss-lib=warning'
+            - name: IPFS_LOGGING_FMT
+              value: nocolor
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-test/keep-ecdsa-6-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-ecdsa-6-statefulset.yaml
@@ -52,6 +52,8 @@ spec:
                   key: account-6
             - name: LOG_LEVEL
               value: 'keep*=debug tss-lib=warning'
+            - name: IPFS_LOGGING_FMT
+              value: nocolor
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-test/keep-ecdsa-7-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-ecdsa-7-statefulset.yaml
@@ -52,6 +52,8 @@ spec:
                   key: account-7
             - name: LOG_LEVEL
               value: 'keep*=debug tss-lib=warning'
+            - name: IPFS_LOGGING_FMT
+              value: nocolor
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-test/keep-ecdsa-8-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-ecdsa-8-statefulset.yaml
@@ -52,6 +52,8 @@ spec:
                   key: account-8
             - name: LOG_LEVEL
               value: 'keep*=debug tss-lib=warning'
+            - name: IPFS_LOGGING_FMT
+              value: nocolor
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-test/keep-ecdsa-9-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-ecdsa-9-statefulset.yaml
@@ -52,6 +52,8 @@ spec:
                   key: account-9
             - name: LOG_LEVEL
               value: 'keep*=debug tss-lib=warning'
+            - name: IPFS_LOGGING_FMT
+              value: nocolor
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config


### PR DESCRIPTION
Two things happening here:

1. Update to the latest `TBTCSystem`
2. Enable `nocolor` IPFS format logging

2 is to aid with log parsing in Stackdriver, as the default logging gets sliced up in weird ways when shipped to Stackdriver.