### PR TITLE
0.12.0-rc and 0.13.0-pre

### DIFF
--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "0.12.0-rc",
+  "version": "0.13.0-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -879,9 +879,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "0.12.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.12.0-rc.0.tgz",
-      "integrity": "sha512-BEZTISatWuLl3gALCNNWi1mjlOMnpwjFWvwCz2tPAr2EcHyuRzRqPeYxrEFeB+gIbBzWSRPL957O79nCmOqA0Q==",
+      "version": "0.13.0-pre.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.13.0-pre.0.tgz",
+      "integrity": "sha512-VDmCmecn527GSg3wlKx918Mni8nF4t2LfVOa1X3WnFVUROwx1FI3cZcZyrij+oSz0lDDyrY4wFdpxO8oWPl+sA==",
       "requires": {
         "@openzeppelin/contracts-ethereum-package": "^2.4.0",
         "@openzeppelin/upgrades": "^2.7.2",

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "0.12.0-pre",
+  "version": "0.12.0-rc",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -879,9 +879,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "0.12.0-pre.4",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.12.0-pre.4.tgz",
-      "integrity": "sha512-UF5RsCB4HunM9B4YJ48PQVwqQHcuiogxXSU7hCOxH+xGhNhi01IJQohCvj+cWTojbTCd4eOcWxSSx5O5ixsMfg==",
+      "version": "0.12.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.12.0-rc.0.tgz",
+      "integrity": "sha512-BEZTISatWuLl3gALCNNWi1mjlOMnpwjFWvwCz2tPAr2EcHyuRzRqPeYxrEFeB+gIbBzWSRPL957O79nCmOqA0Q==",
       "requires": {
         "@openzeppelin/contracts-ethereum-package": "^2.4.0",
         "@openzeppelin/upgrades": "^2.7.2",

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "0.12.0-pre",
+  "version": "0.12.0-rc",
   "description": "Smart contracts for ECDSA Keep",
   "repository": {
     "type": "git",
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/keep-network/keep-ecdsa",
   "dependencies": {
-    "@keep-network/keep-core": ">0.12.0-pre <0.12.0-rc",
+    "@keep-network/keep-core": ">0.12.0-rc <0.12.0",
     "@keep-network/sortition-pools": "0.1.1",
     "@openzeppelin/upgrades": "^2.7.2",
     "openzeppelin-solidity": "2.3.0",

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "0.12.0-rc",
+  "version": "0.13.0-pre",
   "description": "Smart contracts for ECDSA Keep",
   "repository": {
     "type": "git",
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/keep-network/keep-ecdsa",
   "dependencies": {
-    "@keep-network/keep-core": ">0.12.0-rc <0.12.0",
+    "@keep-network/keep-core": ">0.13.0-pre <0.13.0-rc",
     "@keep-network/sortition-pools": "0.1.1",
     "@openzeppelin/upgrades": "^2.7.2",
     "openzeppelin-solidity": "2.3.0",


### PR DESCRIPTION
- Bumping up version to `0.12.0-rc` for RC and setting `keep-core` dependency to `>0.12.0-rc <0.12.0`
- Bumping up version to `0.13.0-pre` after releasing `v0.12.0-rc` and setting `keep-core` dependency to `>0.13.0-pre <0.13.0-rc`