### PR TITLE
Delegating staking authorization from factory to keep  

### DIFF
--- a/solidity/contracts/BondedECDSAKeep.sol
+++ b/solidity/contracts/BondedECDSAKeep.sol
@@ -40,6 +40,10 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
     // Minimum number of honest keep members required to produce a signature.
     uint256 honestThreshold;
 
+    // Minimum stake that was required from each keep member on keep creation.
+    // The value is used for keep members slashing.
+    uint256 public minimumStake;
+
     // Keep's ECDSA public key serialized to 64-bytes, where X and Y coordinates
     // are padded with zeros to 32-byte each.
     bytes publicKey;
@@ -475,6 +479,7 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
         address _owner,
         address[] memory _members,
         uint256 _honestThreshold,
+        uint256 _minimumStake,
         address _tokenStaking,
         address _keepBonding,
         address payable _keepFactory
@@ -484,6 +489,7 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
         owner = _owner;
         members = _members;
         honestThreshold = _honestThreshold;
+        minimumStake = _minimumStake;
         tokenStaking = TokenStaking(_tokenStaking);
         keepBonding = KeepBonding(_keepBonding);
         keepFactory = BondedECDSAKeepFactory(_keepFactory);
@@ -582,11 +588,10 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
         return submittedPublicKeys[_member].length != 0;
     }
 
-    /// @notice Slashes signers' KEEP tokens.
-    /// @dev Keep contract is not authorized to slash tokens directly, so it calls
-    /// the factory to do it.
-    function slashSignerStakes() internal {
-        keepFactory.slashKeepMembers();
+    /// @notice Slashes keep members' KEEP tokens. For each keep member it slashes
+    /// amount equal to the minimum stake from the moment the keep was created.
+    function slashSignerStakes() internal onlyWhenActive {
+        tokenStaking.slash(minimumStake, members);
     }
 
     /// @notice Returns true if signing of a digest is currently in progress.

--- a/solidity/contracts/BondedECDSAKeep.sol
+++ b/solidity/contracts/BondedECDSAKeep.sol
@@ -490,6 +490,8 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
         status = Status.Active;
         isInitialized = true;
 
+        tokenStaking.claimDelegatedAuthority(address(keepFactory));
+
         /* solium-disable-next-line security/no-block-members*/
         keyGenerationStartTimestamp = block.timestamp;
     }

--- a/solidity/contracts/BondedECDSAKeepFactory.sol
+++ b/solidity/contracts/BondedECDSAKeepFactory.sol
@@ -276,6 +276,7 @@ contract BondedECDSAKeepFactory is
             _owner,
             members,
             _honestThreshold,
+            minimumStake,
             address(tokenStaking),
             address(keepBonding),
             address(this)
@@ -439,14 +440,6 @@ contract BondedECDSAKeepFactory is
         return tokenStaking.balanceOf(_operator);
     }
 
-    /// @notice Slashes keep members' KEEP tokens. For each keep member it slashes
-    /// amount equal to the minimum stake configured for this factory.
-    function slashKeepMembers() public onlyActiveKeep {
-        BondedECDSAKeep keep = BondedECDSAKeep(msg.sender);
-
-        tokenStaking.slash(minimumStake, keep.getMembers());
-    }
-
     /// @notice Gets bonded sortition pool of specific application for the
     /// operator.
     /// @dev Reverts if the operator is not registered for the application.
@@ -502,17 +495,6 @@ contract BondedECDSAKeepFactory is
                     callbackGas
                 )
             );
-    }
-
-    /// @notice Checks if the caller is a keep created by this factory.
-    /// @dev Throws an error if called by any account other than a keep.
-    modifier onlyActiveKeep() {
-        require(
-            keepOpenedTimestamp[msg.sender] != 0 &&
-                BondedECDSAKeep(msg.sender).isActive(),
-            "Caller is not an active keep created by this factory"
-        );
-        _;
     }
 
     /// @notice Checks if the caller is the random beacon.

--- a/solidity/test/BondedECDSAKeepFactoryIntegrationTest.js
+++ b/solidity/test/BondedECDSAKeepFactoryIntegrationTest.js
@@ -1,0 +1,180 @@
+import {createSnapshot, restoreSnapshot} from "./helpers/snapshot"
+
+const {time} = require("@openzeppelin/test-helpers")
+
+import {mineBlocks} from "./helpers/mineBlocks"
+
+const KeepToken = artifacts.require("KeepTokenIntegration")
+const Registry = artifacts.require("Registry")
+const BondedECDSAKeepFactoryStub = artifacts.require(
+  "BondedECDSAKeepFactoryStub"
+)
+const KeepBonding = artifacts.require("KeepBonding")
+const TokenStaking = artifacts.require("TokenStaking")
+const BondedSortitionPool = artifacts.require("BondedSortitionPool")
+const BondedSortitionPoolFactory = artifacts.require(
+  "BondedSortitionPoolFactory"
+)
+const RandomBeaconStub = artifacts.require("RandomBeaconStub")
+const BondedECDSAKeep = artifacts.require("BondedECDSAKeep")
+
+const BN = web3.utils.BN
+
+contract("BondedECDSAKeepFactory", async (accounts) => {
+  let keepToken
+  let tokenStaking
+  let keepFactory
+  let bondedSortitionPoolFactory
+  let keepBonding
+  let randomBeacon
+  let signerPool
+
+  const application = accounts[1]
+  const members = [accounts[2], accounts[3], accounts[4]]
+  const authorizers = [members[0], members[1], members[2]]
+
+  const keepOwner = accounts[5]
+
+  const groupSize = new BN(members.length)
+  const threshold = groupSize
+
+  const singleBond = new BN(1)
+  const bond = singleBond.mul(groupSize)
+
+  const initializationPeriod = new BN(100)
+  const undelegationPeriod = 30
+
+  beforeEach(async () => {
+    await createSnapshot()
+  })
+
+  afterEach(async () => {
+    await restoreSnapshot()
+  })
+
+  describe("openKeep", async () => {
+    let feeEstimate
+
+    before(async () => {
+      await initializeNewFactory()
+      await initializeMemberCandidates()
+      await registerMemberCandidates()
+
+      feeEstimate = await keepFactory.openKeepFeeEstimate()
+    })
+
+    it("registers token staking delegated authority claim from keep", async () => {
+      const keepAddress = await keepFactory.openKeep.call(
+        groupSize,
+        threshold,
+        keepOwner,
+        bond,
+        {from: application, value: feeEstimate}
+      )
+
+      await keepFactory.openKeep(groupSize, threshold, keepOwner, bond, {
+        from: application,
+        value: feeEstimate,
+      })
+
+      assert.equal(
+        await tokenStaking.getAuthoritySource(keepAddress),
+        keepFactory.address,
+        "invalid token staking authority source"
+      )
+    })
+  })
+
+  async function initializeNewFactory() {
+    keepToken = await KeepToken.new()
+    const registry = await Registry.new()
+
+    bondedSortitionPoolFactory = await BondedSortitionPoolFactory.new()
+    tokenStaking = await TokenStaking.new(
+      keepToken.address,
+      registry.address,
+      initializationPeriod,
+      undelegationPeriod
+    )
+
+    keepBonding = await KeepBonding.new(registry.address, tokenStaking.address)
+    randomBeacon = await RandomBeaconStub.new()
+    const bondedECDSAKeepMasterContract = await BondedECDSAKeep.new()
+    keepFactory = await BondedECDSAKeepFactoryStub.new(
+      bondedECDSAKeepMasterContract.address,
+      bondedSortitionPoolFactory.address,
+      tokenStaking.address,
+      keepBonding.address,
+      randomBeacon.address
+    )
+
+    await registry.approveOperatorContract(keepFactory.address)
+  }
+
+  async function stakeOperators(stakeBalance) {
+    const tokenOwner = accounts[0]
+
+    for (let i = 0; i < members.length; i++) {
+      const beneficiary = tokenOwner
+      const operator = members[i]
+      const authorizer = authorizers[i]
+
+      const delegation = Buffer.concat([
+        Buffer.from(web3.utils.hexToBytes(beneficiary)),
+        Buffer.from(web3.utils.hexToBytes(operator)),
+        Buffer.from(web3.utils.hexToBytes(authorizer)),
+      ])
+
+      await keepToken.approveAndCall(
+        tokenStaking.address,
+        stakeBalance,
+        delegation,
+        {from: tokenOwner}
+      )
+
+      await time.increase(initializationPeriod.addn(1))
+    }
+  }
+
+  async function initializeMemberCandidates(unbondedValue) {
+    const minimumStake = await keepFactory.minimumStake.call()
+    await stakeOperators(minimumStake)
+
+    signerPool = await keepFactory.createSortitionPool.call(application)
+    await keepFactory.createSortitionPool(application)
+
+    for (let i = 0; i < members.length; i++) {
+      await tokenStaking.authorizeOperatorContract(
+        members[i],
+        keepFactory.address,
+        {from: authorizers[i]}
+      )
+      await keepBonding.authorizeSortitionPoolContract(members[i], signerPool, {
+        from: authorizers[i],
+      })
+    }
+
+    const minimumBond = await keepFactory.minimumBond.call()
+    const unbondedAmount = unbondedValue || minimumBond
+
+    await depositMemberCandidates(unbondedAmount)
+  }
+
+  async function depositMemberCandidates(unbondedAmount) {
+    for (let i = 0; i < members.length; i++) {
+      await keepBonding.deposit(members[i], {value: unbondedAmount})
+    }
+  }
+
+  async function registerMemberCandidates() {
+    for (let i = 0; i < members.length; i++) {
+      await keepFactory.registerMemberCandidate(application, {
+        from: members[i],
+      })
+    }
+
+    const pool = await BondedSortitionPool.at(signerPool)
+    const initBlocks = await pool.operatorInitBlocks()
+    await mineBlocks(initBlocks.add(new BN(1)))
+  }
+})

--- a/solidity/test/BondedECDSAKeepFactoryTest.js
+++ b/solidity/test/BondedECDSAKeepFactoryTest.js
@@ -18,7 +18,6 @@ const BondedSortitionPoolFactory = artifacts.require(
 )
 const RandomBeaconStub = artifacts.require("RandomBeaconStub")
 const BondedECDSAKeep = artifacts.require("BondedECDSAKeep")
-const BondedECDSAKeepStub = artifacts.require("BondedECDSAKeepStub")
 
 const BN = web3.utils.BN
 
@@ -66,7 +65,9 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
       const minimumStakeMultiplier = new BN("10")
       await stakeOperators(members, minimumStake.mul(minimumStakeMultiplier))
 
-      await keepFactory.registerMemberCandidate(application, {from: members[0]})
+      await keepFactory.registerMemberCandidate(application, {
+        from: members[0],
+      })
 
       const pool = await BondedSortitionPool.at(signerPool)
       const actualWeight = await pool.getPoolWeight.call(members[0])
@@ -76,8 +77,12 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
     })
 
     it("inserts operators to the same pool", async () => {
-      await keepFactory.registerMemberCandidate(application, {from: members[0]})
-      await keepFactory.registerMemberCandidate(application, {from: members[1]})
+      await keepFactory.registerMemberCandidate(application, {
+        from: members[0],
+      })
+      await keepFactory.registerMemberCandidate(application, {
+        from: members[1],
+      })
 
       const pool = await BondedSortitionPool.at(signerPool)
       assert.isTrue(
@@ -91,7 +96,9 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
     })
 
     it("does not add an operator to the pool if it is already there", async () => {
-      await keepFactory.registerMemberCandidate(application, {from: members[0]})
+      await keepFactory.registerMemberCandidate(application, {
+        from: members[0],
+      })
 
       const pool = await BondedSortitionPool.at(signerPool)
 
@@ -100,7 +107,9 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
         "operator is not in the pool"
       )
 
-      await keepFactory.registerMemberCandidate(application, {from: members[0]})
+      await keepFactory.registerMemberCandidate(application, {
+        from: members[0],
+      })
 
       assert.isTrue(
         await pool.isOperatorInPool(members[0]),
@@ -125,7 +134,9 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
         signerPool
       )
       const withdrawValue = availableUnbonded.sub(minimumBond).add(new BN(1))
-      await keepBonding.withdraw(withdrawValue, members[0], {from: members[0]})
+      await keepBonding.withdraw(withdrawValue, members[0], {
+        from: members[0],
+      })
 
       await expectRevert(
         keepFactory.registerMemberCandidate(application, {from: members[0]}),
@@ -249,7 +260,9 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
     })
 
     it("returns true if the operator is registered for the application", async () => {
-      await keepFactory.registerMemberCandidate(application, {from: members[0]})
+      await keepFactory.registerMemberCandidate(application, {
+        from: members[0],
+      })
 
       assert.isTrue(
         await keepFactory.isOperatorRegistered(members[0], application)
@@ -259,7 +272,9 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
     it("returns false if the operator is registered for another application", async () => {
       const application2 = "0x0000000000000000000000000000000000000002"
 
-      await keepFactory.registerMemberCandidate(application, {from: members[0]})
+      await keepFactory.registerMemberCandidate(application, {
+        from: members[0],
+      })
 
       assert.isFalse(
         await keepFactory.isOperatorRegistered(members[0], application2)
@@ -281,7 +296,9 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
     })
 
     it("returns true if the operator is up to date for the application", async () => {
-      await keepFactory.registerMemberCandidate(application, {from: members[0]})
+      await keepFactory.registerMemberCandidate(application, {
+        from: members[0],
+      })
 
       assert.isTrue(
         await keepFactory.isOperatorUpToDate(members[0], application)
@@ -289,7 +306,9 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
     })
 
     it("returns false if the operator stake is below minimum", async () => {
-      await keepFactory.registerMemberCandidate(application, {from: members[0]})
+      await keepFactory.registerMemberCandidate(application, {
+        from: members[0],
+      })
 
       await stakeOperators(members, minimumStake.subn(1))
 
@@ -299,7 +318,9 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
     })
 
     it("returns true if the operator stake changed insufficiently", async () => {
-      await keepFactory.registerMemberCandidate(application, {from: members[0]})
+      await keepFactory.registerMemberCandidate(application, {
+        from: members[0],
+      })
 
       // We multiply minimumStake as sortition pools expect multiplies of the
       // minimum stake to calculate stakers weight for eligibility.
@@ -313,7 +334,9 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
     })
 
     it("returns false if the operator stake is above minimum", async () => {
-      await keepFactory.registerMemberCandidate(application, {from: members[0]})
+      await keepFactory.registerMemberCandidate(application, {
+        from: members[0],
+      })
 
       // We multiply minimumStake as sortition pools expect multiplies of the
       // minimum stake to calculate stakers weight for eligibility.
@@ -325,7 +348,9 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
     })
 
     it("returns false if the operator bonding value is below minimum", async () => {
-      await keepFactory.registerMemberCandidate(application, {from: members[0]})
+      await keepFactory.registerMemberCandidate(application, {
+        from: members[0],
+      })
 
       await keepBonding.withdraw(new BN(1), members[0], {from: members[0]})
 
@@ -335,7 +360,9 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
     })
 
     it("returns true if the operator bonding value is above minimum", async () => {
-      await keepFactory.registerMemberCandidate(application, {from: members[0]})
+      await keepFactory.registerMemberCandidate(application, {
+        from: members[0],
+      })
 
       await keepBonding.deposit(members[0], {value: new BN(1)})
 
@@ -447,7 +474,9 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
     })
 
     it("returns true if the operator is registered for the application", async () => {
-      await keepFactory.registerMemberCandidate(application, {from: members[0]})
+      await keepFactory.registerMemberCandidate(application, {
+        from: members[0],
+      })
 
       assert.isTrue(
         await keepFactory.isOperatorRegistered(members[0], application)
@@ -457,7 +486,9 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
     it("returns false if the operator is registered for another application", async () => {
       const application2 = "0x0000000000000000000000000000000000000002"
 
-      await keepFactory.registerMemberCandidate(application, {from: members[0]})
+      await keepFactory.registerMemberCandidate(application, {
+        from: members[0],
+      })
 
       assert.isFalse(
         await keepFactory.isOperatorRegistered(members[0], application2)
@@ -479,7 +510,9 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
     })
 
     it("returns true if the operator is up to date for the application", async () => {
-      await keepFactory.registerMemberCandidate(application, {from: members[0]})
+      await keepFactory.registerMemberCandidate(application, {
+        from: members[0],
+      })
 
       assert.isTrue(
         await keepFactory.isOperatorUpToDate(members[0], application)
@@ -487,7 +520,9 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
     })
 
     it("returns false if the operator stake is below minimum", async () => {
-      await keepFactory.registerMemberCandidate(application, {from: members[0]})
+      await keepFactory.registerMemberCandidate(application, {
+        from: members[0],
+      })
 
       await stakeOperators(members, minimumStake.sub(new BN(1)))
 
@@ -497,7 +532,9 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
     })
 
     it("returns true if the operator stake changed insignificantly", async () => {
-      await keepFactory.registerMemberCandidate(application, {from: members[0]})
+      await keepFactory.registerMemberCandidate(application, {
+        from: members[0],
+      })
 
       // We multiply minimumStake as sortition pools expect multiplies of the
       // minimum stake to calculate stakers weight for eligibility.
@@ -511,7 +548,9 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
     })
 
     it("returns false if the operator stake is above minimum", async () => {
-      await keepFactory.registerMemberCandidate(application, {from: members[0]})
+      await keepFactory.registerMemberCandidate(application, {
+        from: members[0],
+      })
 
       // We multiply minimumStake as sortition pools expect multiplies of the
       // minimum stake to calculate stakers weight for eligibility.
@@ -523,7 +562,9 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
     })
 
     it("returns false if the operator bonding value is below minimum", async () => {
-      await keepFactory.registerMemberCandidate(application, {from: members[0]})
+      await keepFactory.registerMemberCandidate(application, {
+        from: members[0],
+      })
 
       keepBonding.withdraw(new BN(1), members[0], {from: members[0]})
 
@@ -533,7 +574,9 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
     })
 
     it("returns true if the operator bonding value is above minimum", async () => {
-      await keepFactory.registerMemberCandidate(application, {from: members[0]})
+      await keepFactory.registerMemberCandidate(application, {
+        from: members[0],
+      })
 
       keepBonding.deposit(members[0], {value: new BN(1)})
 
@@ -842,7 +885,9 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
         signerPool
       )
       const withdrawValue = availableUnbonded.sub(minimumBond).add(new BN(1))
-      await keepBonding.withdraw(withdrawValue, members[2], {from: members[2]})
+      await keepBonding.withdraw(withdrawValue, members[2], {
+        from: members[2],
+      })
 
       await expectRevert(
         keepFactory.openKeep(groupSize, threshold, keepOwner, bond, {
@@ -1116,7 +1161,9 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
           from: operator,
         })
         await keepBonding.deposit(operator, {value: unbondedAmount})
-        await keepFactory.registerMemberCandidate(application, {from: operator})
+        await keepFactory.registerMemberCandidate(application, {
+          from: operator,
+        })
       }
     }
   })
@@ -1161,87 +1208,6 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
         }),
         "Caller is not the random beacon"
       )
-    })
-  })
-
-  describe("slashKeepMembers", async () => {
-    const keepOwner = "0xbc4862697a1099074168d54A555c4A60169c18BD"
-    let keep
-
-    before(async () => {
-      await initializeNewFactory()
-
-      keep = await BondedECDSAKeepStub.new()
-      await keep.initialize(
-        keepOwner,
-        members,
-        members.length,
-        tokenStaking.address,
-        keepBonding.address,
-        keepFactory.address
-      )
-    })
-
-    it("reverts if called not by keep", async () => {
-      await expectRevert(
-        keepFactory.slashKeepMembers(),
-        "Caller is not an active keep created by this factory"
-      )
-    })
-
-    it("reverts if called by not authorized keep", async () => {
-      // The keep is not added to the list of keeps created by the factory.
-      await expectRevert(
-        keep.publicSlashSignerStakes(),
-        "Caller is not an active keep created by this factory"
-      )
-    })
-
-    it("reverts if called by closed keep", async () => {
-      // Add keep to the list of keeps created by the factory.
-      await keepFactory.addKeep(keep.address)
-
-      await keep.publicMarkAsClosed()
-
-      await expectRevert(
-        keep.publicSlashSignerStakes(),
-        "Caller is not an active keep created by this factory"
-      )
-    })
-
-    it("reverts if called by terminated keep", async () => {
-      // Add keep to the list of keeps created by the factory.
-      await keepFactory.addKeep(keep.address)
-
-      await keep.publicMarkAsTerminated()
-
-      await expectRevert(
-        keep.publicSlashSignerStakes(),
-        "Caller is not an active keep created by this factory"
-      )
-    })
-
-    it("slashes keep members stakes", async () => {
-      // Add keep to the list of keeps created by the factory.
-      await keepFactory.addKeep(keep.address)
-
-      const minimumStake = await keepFactory.minimumStake.call()
-      const remainingStake = new BN(10)
-      const stakeBalance = minimumStake.add(remainingStake)
-      await stakeOperators(members, stakeBalance)
-
-      await keep.publicSlashSignerStakes()
-
-      for (let i = 0; i < members.length; i++) {
-        const actualStake = await tokenStaking.eligibleStake(
-          members[i],
-          keepFactory.address
-        )
-        expect(actualStake).to.eq.BN(
-          remainingStake,
-          `incorrect stake for member ${i}`
-        )
-      }
     })
   })
 
@@ -1514,7 +1480,9 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
 
   async function registerMemberCandidates() {
     for (let i = 0; i < members.length; i++) {
-      await keepFactory.registerMemberCandidate(application, {from: members[i]})
+      await keepFactory.registerMemberCandidate(application, {
+        from: members[i],
+      })
     }
 
     const pool = await BondedSortitionPool.at(signerPool)

--- a/solidity/test/BondedECDSAKeepTest.js
+++ b/solidity/test/BondedECDSAKeepTest.js
@@ -135,6 +135,24 @@ contract("BondedECDSAKeep", (accounts) => {
       )
     })
 
+    it("claims token staking delegated authority", async () => {
+      keep = await BondedECDSAKeep.new()
+      await keep.initialize(
+        owner,
+        members,
+        honestThreshold,
+        tokenStaking.address,
+        keepBonding.address,
+        factoryStub.address
+      )
+
+      assert.equal(
+        await tokenStaking.delegatedAuthority(),
+        factoryStub.address,
+        "incorrect token staking delegated authority"
+      )
+    })
+
     it("reverts if called for the second time", async () => {
       // first call was a part of beforeEach
       await expectRevert(

--- a/solidity/test/contracts/BondedECDSAKeepCloneFactoryStub.sol
+++ b/solidity/test/contracts/BondedECDSAKeepCloneFactoryStub.sol
@@ -3,9 +3,12 @@ pragma solidity ^0.5.4;
 import "../../contracts/BondedECDSAKeep.sol";
 import "../../contracts/CloneFactory.sol";
 
+
 /// @title Bonded ECDSA Keep Factory Stub using clone factory.
 /// @dev This contract is for testing purposes only.
 contract BondedECDSAKeepCloneFactory is CloneFactory {
+    uint256 public minimumStake = 200000 * 1e18;
+
     address public masterBondedECDSAKeepAddress;
     bool public membersSlashed;
 
@@ -19,6 +22,7 @@ contract BondedECDSAKeepCloneFactory is CloneFactory {
         address _owner,
         address[] calldata _members,
         uint256 _honestThreshold,
+        uint256 _minimumStake,
         address _tokenStaking,
         address _keepBonding,
         address payable _keepFactory
@@ -31,15 +35,12 @@ contract BondedECDSAKeepCloneFactory is CloneFactory {
             _owner,
             _members,
             _honestThreshold,
+            _minimumStake,
             _tokenStaking,
             _keepBonding,
             _keepFactory
         );
 
         emit BondedECDSAKeepCreated(keepAddress);
-    }
-
-    function slashKeepMembers() public {
-        membersSlashed = true;
     }
 }

--- a/solidity/test/contracts/TokenStakingStub.sol
+++ b/solidity/test/contracts/TokenStakingStub.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.5.4;
 import "@keep-network/sortition-pools/contracts/api/IStaking.sol";
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 
+
 /// @title Token Staking Stub
 /// @dev This contract is for testing purposes only.
 contract TokenStakingStub is IStaking {
@@ -17,6 +18,8 @@ contract TokenStakingStub is IStaking {
 
     // Map of operator -> owner.
     mapping(address => address) owners;
+
+    address public delegatedAuthority;
 
     /// @dev Sets balance variable value.
     function setBalance(address _operator, uint256 _balance) public {
@@ -77,5 +80,9 @@ contract TokenStakingStub is IStaking {
 
     function ownerOf(address _operator) public view returns (address) {
         return owners[_operator];
+    }
+
+    function claimDelegatedAuthority(address delegatedAuthoritySource) public {
+        delegatedAuthority = delegatedAuthoritySource;
     }
 }

--- a/solidity/test/contracts/integration/ExternalContractsIntegration.sol
+++ b/solidity/test/contracts/integration/ExternalContractsIntegration.sol
@@ -1,0 +1,15 @@
+pragma solidity ^0.5.4;
+
+import "@keep-network/keep-core/contracts/KeepToken.sol";
+
+
+// This file contains a workaround for a truffle bug described in [truffle#1250].
+// We are not able to directly require artifacts from other packages, e.g.:
+// `artifacts.require("@keep-network/keep-core/KeepTokenIntegration")`.
+// We first need to import the contracts so they are compiled and placed in
+// `build/contracts/` directory.
+//
+// [truffle#1250]:https://github.com/trufflesuite/truffle/issues/1250
+contract KeepTokenIntegration is KeepToken {
+
+}


### PR DESCRIPTION
In this PR we incorporate updates introduced in `TokenStaking` contract. It's now possible to delegate authorization from the initially authorized contract. We use this to delegate authorization for slashing from `BondedECDSAKeepFactory` to `BondedECDSAKeep`.

This allowed us to remove slashing function from the factory and handle slashing directly in keep.

Closes: https://github.com/keep-network/keep-ecdsa/issues/361