### PR TITLE
Token staking locks and unlocks

### DIFF
--- a/solidity/contracts/BondedECDSAKeep.sol
+++ b/solidity/contracts/BondedECDSAKeep.sol
@@ -40,9 +40,9 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
     // Minimum number of honest keep members required to produce a signature.
     uint256 honestThreshold;
 
-    // Minimum stake that was required from each keep member on keep creation.
+    // Stake that was required from each keep member on keep creation.
     // The value is used for keep members slashing.
-    uint256 public minimumStake;
+    uint256 public memberStake;
 
     // Keep's ECDSA public key serialized to 64-bytes, where X and Y coordinates
     // are padded with zeros to 32-byte each.
@@ -471,8 +471,9 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
     /// @param _owner Address of the keep owner.
     /// @param _members Addresses of the keep members.
     /// @param _honestThreshold Minimum number of honest keep members.
-    /// @param _tokenStaking Address of the TokenStaking contract.
+    /// @param _memberStake Stake required from each keep member.
     /// @param _stakeLockDuration Stake lock duration in seconds.
+    /// @param _tokenStaking Address of the TokenStaking contract.
     /// @param _keepBonding Address of the KeepBonding contract.
     /// @param _keepFactory Address of the BondedECDSAKeepFactory that created
     /// this keep.
@@ -480,7 +481,7 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
         address _owner,
         address[] memory _members,
         uint256 _honestThreshold,
-        uint256 _minimumStake,
+        uint256 _memberStake,
         uint256 _stakeLockDuration,
         address _tokenStaking,
         address _keepBonding,
@@ -491,7 +492,7 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
         owner = _owner;
         members = _members;
         honestThreshold = _honestThreshold;
-        minimumStake = _minimumStake;
+        memberStake = _memberStake;
         tokenStaking = TokenStaking(_tokenStaking);
         keepBonding = KeepBonding(_keepBonding);
         keepFactory = BondedECDSAKeepFactory(_keepFactory);
@@ -595,9 +596,9 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
     }
 
     /// @notice Slashes keep members' KEEP tokens. For each keep member it slashes
-    /// amount equal to the minimum stake from the moment the keep was created.
+    /// amount equal to the member stake set by the factory when keep was created.
     function slashSignerStakes() internal onlyWhenActive {
-        tokenStaking.slash(minimumStake, members);
+        tokenStaking.slash(memberStake, members);
     }
 
     /// @notice Returns true if signing of a digest is currently in progress.

--- a/solidity/contracts/BondedECDSAKeep.sol
+++ b/solidity/contracts/BondedECDSAKeep.sol
@@ -472,6 +472,7 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
     /// @param _members Addresses of the keep members.
     /// @param _honestThreshold Minimum number of honest keep members.
     /// @param _tokenStaking Address of the TokenStaking contract.
+    /// @param _stakeLockDuration Stake lock duration in seconds.
     /// @param _keepBonding Address of the KeepBonding contract.
     /// @param _keepFactory Address of the BondedECDSAKeepFactory that created
     /// this keep.
@@ -480,6 +481,7 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
         address[] memory _members,
         uint256 _honestThreshold,
         uint256 _minimumStake,
+        uint256 _stakeLockDuration,
         address _tokenStaking,
         address _keepBonding,
         address payable _keepFactory

--- a/solidity/contracts/BondedECDSAKeep.sol
+++ b/solidity/contracts/BondedECDSAKeep.sol
@@ -629,7 +629,7 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
     }
 
     /// @notice Marks the keep as terminated.
-    /// Keep can be marked as closed only when there is no signing in progress
+    /// Keep can be marked as terminated only when there is no signing in progress
     /// or the requested signing process has timed out.
     function markAsTerminated() internal {
         require(

--- a/solidity/contracts/BondedECDSAKeep.sol
+++ b/solidity/contracts/BondedECDSAKeep.sol
@@ -625,7 +625,7 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
             "Requested signing has not timed out yet"
         );
 
-        unlockMembersTokenStakes();
+        unlockMemberStakes();
 
         status = Status.Closed;
         emit KeepClosed();
@@ -640,7 +640,7 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
             "Requested signing has not timed out yet"
         );
 
-        unlockMembersTokenStakes();
+        unlockMemberStakes();
 
         status = Status.Terminated;
         emit KeepTerminated();
@@ -648,7 +648,7 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
 
     /// @notice Releases locks the keep had previously placed on the members'
     /// token stakes.
-    function unlockMembersTokenStakes() internal {
+    function unlockMemberStakes() internal {
         for (uint256 i = 0; i < members.length; i++) {
             tokenStaking.unlockStake(members[i]);
         }

--- a/solidity/contracts/BondedECDSAKeep.sol
+++ b/solidity/contracts/BondedECDSAKeep.sol
@@ -496,7 +496,7 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
         status = Status.Active;
         isInitialized = true;
 
-        tokenStaking.claimDelegatedAuthority(address(keepFactory));
+        tokenStaking.claimDelegatedAuthority(_keepFactory);
 
         /* solium-disable-next-line security/no-block-members*/
         keyGenerationStartTimestamp = block.timestamp;

--- a/solidity/contracts/BondedECDSAKeep.sol
+++ b/solidity/contracts/BondedECDSAKeep.sol
@@ -624,6 +624,8 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
             "Requested signing has not timed out yet"
         );
 
+        unlockMembersTokenStakes();
+
         status = Status.Closed;
         emit KeepClosed();
     }
@@ -637,8 +639,18 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
             "Requested signing has not timed out yet"
         );
 
+        unlockMembersTokenStakes();
+
         status = Status.Terminated;
         emit KeepTerminated();
+    }
+
+    /// @notice Releases locks the keep had previously placed on the members'
+    /// token stakes.
+    function unlockMembersTokenStakes() internal {
+        for (uint256 i = 0; i < members.length; i++) {
+            tokenStaking.unlockStake(members[i]);
+        }
     }
 
     /// @notice Returns bonds to the keep members.

--- a/solidity/contracts/BondedECDSAKeep.sol
+++ b/solidity/contracts/BondedECDSAKeep.sol
@@ -500,6 +500,10 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
 
         tokenStaking.claimDelegatedAuthority(_keepFactory);
 
+        for (uint256 i = 0; i < _members.length; i++) {
+            tokenStaking.lockStake(_members[i], _stakeLockDuration);
+        }
+
         /* solium-disable-next-line security/no-block-members*/
         keyGenerationStartTimestamp = block.timestamp;
     }

--- a/solidity/contracts/BondedECDSAKeepFactory.sol
+++ b/solidity/contracts/BondedECDSAKeepFactory.sol
@@ -224,12 +224,14 @@ contract BondedECDSAKeepFactory is
     /// @param _honestThreshold Minimum number of honest keep signers.
     /// @param _owner Address of the keep owner.
     /// @param _bond Value of ETH bond required from the keep in wei.
+    /// @param _stakeLockDuration Stake lock duration in seconds.
     /// @return Created keep address.
     function openKeep(
         uint256 _groupSize,
         uint256 _honestThreshold,
         address _owner,
-        uint256 _bond
+        uint256 _bond,
+        uint256 _stakeLockDuration
     ) external payable returns (address keepAddress) {
         require(_groupSize <= 16, "Maximum signing group size is 16");
         require(
@@ -277,6 +279,7 @@ contract BondedECDSAKeepFactory is
             members,
             _honestThreshold,
             minimumStake,
+            _stakeLockDuration,
             address(tokenStaking),
             address(keepBonding),
             address(this)

--- a/solidity/contracts/api/IBondedECDSAKeepFactory.sol
+++ b/solidity/contracts/api/IBondedECDSAKeepFactory.sol
@@ -1,5 +1,6 @@
 pragma solidity ^0.5.4;
 
+
 /// @title Bonded ECDSA Keep Factory
 /// @notice Factory for Bonded ECDSA Keeps.
 interface IBondedECDSAKeepFactory {
@@ -8,12 +9,14 @@ interface IBondedECDSAKeepFactory {
     /// @param _honestThreshold Minimum number of honest keep members.
     /// @param _owner Address of the keep owner.
     /// @param _bond Value of ETH bond required from the keep.
+    /// @param _stakeLockDuration Stake lock duration in seconds.
     /// @return Address of the opened keep.
     function openKeep(
         uint256 _groupSize,
         uint256 _honestThreshold,
         address _owner,
-        uint256 _bond
+        uint256 _bond,
+        uint256 _stakeLockDuration
     ) external payable returns (address keepAddress);
 
     /// @notice Gets a fee estimate for opening a new keep.

--- a/solidity/integration/smoke_test.js
+++ b/solidity/integration/smoke_test.js
@@ -33,6 +33,7 @@ module.exports = async function () {
   const groupSize = 3
   const threshold = 3
   const bond = 10
+  const stakeLockDuration = 100
 
   try {
     startBlockNumber = await web3.eth.getBlock("latest").number
@@ -83,10 +84,17 @@ module.exports = async function () {
     relayEntryGeneratedWatcher = watchRelayEntryGenerated(randomBeacon)
     const keepCreatedWatcher = watchKeepCreated(keepFactory)
 
-    await keepFactory.openKeep(groupSize, threshold, keepOwner, bond, {
-      from: application,
-      value: fee,
-    })
+    await keepFactory.openKeep(
+      groupSize,
+      threshold,
+      keepOwner,
+      bond,
+      stakeLockDuration,
+      {
+        from: application,
+        value: fee,
+      }
+    )
 
     const keepCreatedEvent = await keepCreatedWatcher
 

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -879,9 +879,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "0.13.0-pre.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.13.0-pre.0.tgz",
-      "integrity": "sha512-VDmCmecn527GSg3wlKx918Mni8nF4t2LfVOa1X3WnFVUROwx1FI3cZcZyrij+oSz0lDDyrY4wFdpxO8oWPl+sA==",
+      "version": "0.13.0-pre.9",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.13.0-pre.9.tgz",
+      "integrity": "sha512-I8MsomNf8o5fhc02O6TkThpXnEkbHSjAgHPsL42k4EJbVkOfrxBLHDAc04Rg8LeNsFygpifmncoV6jtbiQwxbA==",
       "requires": {
         "@openzeppelin/contracts-ethereum-package": "^2.4.0",
         "@openzeppelin/upgrades": "^2.7.2",

--- a/solidity/test/BondedECDSAKeepFactoryTest.js
+++ b/solidity/test/BondedECDSAKeepFactoryTest.js
@@ -1,6 +1,6 @@
 import {createSnapshot, restoreSnapshot} from "./helpers/snapshot"
 
-const {expectRevert} = require("@openzeppelin/test-helpers")
+const {expectRevert, time} = require("@openzeppelin/test-helpers")
 
 import {mineBlocks} from "./helpers/mineBlocks"
 
@@ -46,6 +46,8 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
 
   const singleBond = new BN(1)
   const bond = singleBond.mul(groupSize)
+
+  const stakeLockDuration = time.duration.days(180)
 
   beforeEach(async () => {
     await createSnapshot()
@@ -694,9 +696,16 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
 
     it("reverts if no member candidates are registered", async () => {
       await expectRevert(
-        keepFactory.openKeep(groupSize, threshold, keepOwner, bond, {
-          value: feeEstimate,
-        }),
+        keepFactory.openKeep(
+          groupSize,
+          threshold,
+          keepOwner,
+          bond,
+          stakeLockDuration,
+          {
+            value: feeEstimate,
+          }
+        ),
         "No signer pool for this application"
       )
     })
@@ -705,10 +714,17 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
       const bond = 0
 
       await expectRevert(
-        keepFactory.openKeep(groupSize, threshold, keepOwner, bond, {
-          from: application,
-          value: feeEstimate,
-        }),
+        keepFactory.openKeep(
+          groupSize,
+          threshold,
+          keepOwner,
+          bond,
+          stakeLockDuration,
+          {
+            from: application,
+            value: feeEstimate,
+          }
+        ),
         "Bond per member must be greater than zero"
       )
     })
@@ -717,10 +733,17 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
       const insufficientFee = feeEstimate.sub(new BN(1))
 
       await expectRevert(
-        keepFactory.openKeep(groupSize, threshold, keepOwner, bond, {
-          from: application,
-          fee: insufficientFee,
-        }),
+        keepFactory.openKeep(
+          groupSize,
+          threshold,
+          keepOwner,
+          bond,
+          stakeLockDuration,
+          {
+            from: application,
+            fee: insufficientFee,
+          }
+        ),
         "Insufficient payment for opening a new keep"
       )
     })
@@ -728,10 +751,17 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
     it("opens keep with multiple members", async () => {
       const blockNumber = await web3.eth.getBlockNumber()
 
-      await keepFactory.openKeep(groupSize, threshold, keepOwner, bond, {
-        from: application,
-        value: feeEstimate,
-      })
+      await keepFactory.openKeep(
+        groupSize,
+        threshold,
+        keepOwner,
+        bond,
+        stakeLockDuration,
+        {
+          from: application,
+          value: feeEstimate,
+        }
+      )
 
       const eventList = await keepFactory.getPastEvents(
         "BondedECDSAKeepCreated",
@@ -753,10 +783,17 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
     it("opens bonds for keep", async () => {
       const blockNumber = await web3.eth.getBlockNumber()
 
-      await keepFactory.openKeep(groupSize, threshold, keepOwner, bond, {
-        from: application,
-        value: feeEstimate,
-      })
+      await keepFactory.openKeep(
+        groupSize,
+        threshold,
+        keepOwner,
+        bond,
+        stakeLockDuration,
+        {
+          from: application,
+          value: feeEstimate,
+        }
+      )
 
       const eventList = await keepFactory.getPastEvents(
         "BondedECDSAKeepCreated",
@@ -794,6 +831,7 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
         threshold,
         keepOwner,
         requestedBond,
+        stakeLockDuration,
         {from: application, value: feeEstimate}
       )
 
@@ -836,6 +874,7 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
         threshold,
         keepOwner,
         requestedBond,
+        stakeLockDuration,
         {from: application, value: feeEstimate}
       )
 
@@ -869,10 +908,17 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
       const requestedGroupSize = groupSize.addn(1)
 
       await expectRevert(
-        keepFactory.openKeep(requestedGroupSize, threshold, keepOwner, bond, {
-          from: application,
-          value: feeEstimate,
-        }),
+        keepFactory.openKeep(
+          requestedGroupSize,
+          threshold,
+          keepOwner,
+          bond,
+          stakeLockDuration,
+          {
+            from: application,
+            value: feeEstimate,
+          }
+        ),
         "Not enough operators in pool"
       )
     })
@@ -890,10 +936,17 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
       })
 
       await expectRevert(
-        keepFactory.openKeep(groupSize, threshold, keepOwner, bond, {
-          from: application,
-          value: feeEstimate,
-        }),
+        keepFactory.openKeep(
+          groupSize,
+          threshold,
+          keepOwner,
+          bond,
+          stakeLockDuration,
+          {
+            from: application,
+            value: feeEstimate,
+          }
+        ),
         "Not enough operators in pool"
       )
     })
@@ -942,10 +995,17 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
 
       await randomBeacon.setEntry(expectedNewEntry)
 
-      await keepFactory.openKeep(groupSize, threshold, keepOwner, bond, {
-        from: application,
-        value: feeEstimate,
-      })
+      await keepFactory.openKeep(
+        groupSize,
+        threshold,
+        keepOwner,
+        bond,
+        stakeLockDuration,
+        {
+          from: application,
+          value: feeEstimate,
+        }
+      )
 
       assert.equal(
         await randomBeacon.requestCount.call(),
@@ -970,10 +1030,17 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
         web3.utils.soliditySha3(groupSelectionSeed, keepFactory.address)
       )
 
-      await keepFactory.openKeep(groupSize, threshold, keepOwner, bond, {
-        from: application,
-        value: feeEstimate,
-      })
+      await keepFactory.openKeep(
+        groupSize,
+        threshold,
+        keepOwner,
+        bond,
+        stakeLockDuration,
+        {
+          from: application,
+          value: feeEstimate,
+        }
+      )
 
       expect(await keepFactory.getGroupSelectionSeed()).to.eq.BN(
         expectedNewGroupSelectionSeed,
@@ -984,10 +1051,17 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
     it("ignores beacon request relay entry failure", async () => {
       await randomBeacon.setShouldFail(true)
 
-      await keepFactory.openKeep(groupSize, threshold, keepOwner, bond, {
-        from: application,
-        value: feeEstimate,
-      })
+      await keepFactory.openKeep(
+        groupSize,
+        threshold,
+        keepOwner,
+        bond,
+        stakeLockDuration,
+        {
+          from: application,
+          value: feeEstimate,
+        }
+      )
 
       // TODO: Add verification of what we will do in case of the failure.
     })
@@ -995,10 +1069,17 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
     it("forwards payment to random beacon", async () => {
       const value = new BN(150)
 
-      await keepFactory.openKeep(groupSize, threshold, keepOwner, bond, {
-        from: application,
-        value: value,
-      })
+      await keepFactory.openKeep(
+        groupSize,
+        threshold,
+        keepOwner,
+        bond,
+        stakeLockDuration,
+        {
+          from: application,
+          value: value,
+        }
+      )
 
       expect(await web3.eth.getBalance(randomBeacon.address)).to.eq.BN(
         value,
@@ -1011,10 +1092,17 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
       const groupSize = 3
 
       await expectRevert(
-        keepFactory.openKeep(groupSize, honestThreshold, keepOwner, bond, {
-          from: application,
-          value: feeEstimate,
-        }),
+        keepFactory.openKeep(
+          groupSize,
+          honestThreshold,
+          keepOwner,
+          bond,
+          stakeLockDuration,
+          {
+            from: application,
+            value: feeEstimate,
+          }
+        ),
         "Honest threshold must be less or equal the group size"
       )
     })
@@ -1025,10 +1113,17 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
 
       const blockNumber = await web3.eth.getBlockNumber()
 
-      await keepFactory.openKeep(groupSize, honestThreshold, keepOwner, bond, {
-        from: application,
-        value: feeEstimate,
-      })
+      await keepFactory.openKeep(
+        groupSize,
+        honestThreshold,
+        keepOwner,
+        bond,
+        stakeLockDuration,
+        {
+          from: application,
+          value: feeEstimate,
+        }
+      )
 
       const eventList = await keepFactory.getPastEvents(
         "BondedECDSAKeepCreated",
@@ -1049,13 +1144,21 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
         threshold,
         keepOwner,
         bond,
+        stakeLockDuration,
         {from: application, value: feeEstimate}
       )
 
-      await keepFactory.openKeep(groupSize, threshold, keepOwner, bond, {
-        from: application,
-        value: feeEstimate,
-      })
+      await keepFactory.openKeep(
+        groupSize,
+        threshold,
+        keepOwner,
+        bond,
+        stakeLockDuration,
+        {
+          from: application,
+          value: feeEstimate,
+        }
+      )
       const recordedKeepAddress = await keepFactory.getKeepAtIndex(preKeepCount)
       const keep = await BondedECDSAKeep.at(keepAddress)
       const keepOpenedTime = await keep.getOpenedTimestamp()
@@ -1081,13 +1184,21 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
         threshold,
         keepOwner,
         bond,
+        stakeLockDuration,
         {from: application, value: feeEstimate}
       )
 
-      await keepFactory.openKeep(groupSize, threshold, keepOwner, bond, {
-        from: application,
-        value: feeEstimate,
-      })
+      await keepFactory.openKeep(
+        groupSize,
+        threshold,
+        keepOwner,
+        bond,
+        stakeLockDuration,
+        {
+          from: application,
+          value: feeEstimate,
+        }
+      )
 
       const keep = await BondedECDSAKeep.at(keepAddress)
 
@@ -1103,10 +1214,17 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
 
       const blockNumber = await web3.eth.getBlockNumber()
 
-      await keepFactory.openKeep(groupSize, threshold, keepOwner, bond, {
-        from: application,
-        value: feeEstimate,
-      })
+      await keepFactory.openKeep(
+        groupSize,
+        threshold,
+        keepOwner,
+        bond,
+        stakeLockDuration,
+        {
+          from: application,
+          value: feeEstimate,
+        }
+      )
 
       const eventList = await keepFactory.getPastEvents(
         "BondedECDSAKeepCreated",
@@ -1128,10 +1246,17 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
       const groupSize = 17
 
       await expectRevert(
-        keepFactory.openKeep(groupSize, threshold, keepOwner, bond, {
-          from: application,
-          value: feeEstimate,
-        }),
+        keepFactory.openKeep(
+          groupSize,
+          threshold,
+          keepOwner,
+          bond,
+          stakeLockDuration,
+          {
+            from: application,
+            value: feeEstimate,
+          }
+        ),
         "Maximum signing group size is 16"
       )
     })
@@ -1498,13 +1623,21 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
       threshold,
       keepOwner,
       bond,
+      stakeLockDuration,
       {from: application, value: feeEstimate}
     )
 
-    await keepFactory.openKeep(groupSize, threshold, keepOwner, bond, {
-      from: application,
-      value: feeEstimate,
-    })
+    await keepFactory.openKeep(
+      groupSize,
+      threshold,
+      keepOwner,
+      bond,
+      stakeLockDuration,
+      {
+        from: application,
+        value: feeEstimate,
+      }
+    )
 
     return await BondedECDSAKeep.at(keepAddress)
   }

--- a/solidity/test/BondedECDSAKeepIntegrationTest.js
+++ b/solidity/test/BondedECDSAKeepIntegrationTest.js
@@ -46,6 +46,8 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
   const singleBond = new BN(1)
   const bond = singleBond.mul(groupSize)
 
+  const stakeLockDuration = time.duration.days(180)
+
   const initializationPeriod = new BN(100)
   const undelegationPeriod = 30
 
@@ -72,19 +74,92 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
         threshold,
         keepOwner,
         bond,
+        stakeLockDuration,
         {from: application, value: feeEstimate}
       )
 
-      await keepFactory.openKeep(groupSize, threshold, keepOwner, bond, {
-        from: application,
-        value: feeEstimate,
-      })
+      await keepFactory.openKeep(
+        groupSize,
+        threshold,
+        keepOwner,
+        bond,
+        stakeLockDuration,
+        {
+          from: application,
+          value: feeEstimate,
+        }
+      )
 
       assert.equal(
         await tokenStaking.getAuthoritySource(keepAddress),
         keepFactory.address,
         "invalid token staking authority source"
       )
+    })
+
+    it("locks members token stakes", async () => {
+      const tx = await keepFactory.openKeep(
+        groupSize,
+        threshold,
+        keepOwner,
+        bond,
+        stakeLockDuration,
+        {
+          from: application,
+          value: feeEstimate,
+        }
+      )
+      const keepAddress = tx.logs[0].args.keepAddress
+
+      const expectedExpirationTime = (await time.latest()).add(
+        stakeLockDuration
+      )
+
+      for (let i = 0; i < members.length; i++) {
+        const {creators, expirations} = await tokenStaking.getLocks(members[i])
+
+        assert.deepEqual(
+          creators,
+          [keepAddress],
+          "incorrect token lock creator"
+        )
+
+        expect(expirations[0], "incorrect token lock expiration time").to.eq.BN(
+          expectedExpirationTime
+        )
+      }
+    })
+  })
+
+  describe("closeKeep", async () => {
+    it("releases locks on members token stakes", async () => {
+      const keep = await openKeep({from: keepOwner})
+
+      await keep.closeKeep({from: keepOwner})
+
+      for (let i = 0; i < members.length; i++) {
+        const {creators, expirations} = await tokenStaking.getLocks(members[i])
+
+        assert.isEmpty(creators, "incorrect token lock creator")
+
+        assert.isEmpty(expirations, "incorrect token lock expiration time")
+      }
+    })
+  })
+
+  describe("seizeSignerBonds", async () => {
+    it("releases locks on members token stakes", async () => {
+      const keep = await openKeep({from: keepOwner})
+
+      await keep.seizeSignerBonds({from: keepOwner})
+
+      for (let i = 0; i < members.length; i++) {
+        const {creators, expirations} = await tokenStaking.getLocks(members[i])
+
+        assert.isEmpty(creators, "incorrect token lock creator")
+
+        assert.isEmpty(expirations, "incorrect token lock expiration time")
+      }
     })
   })
 
@@ -258,13 +333,21 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
       threshold,
       keepOwner,
       bond,
+      stakeLockDuration,
       {from: application, value: feeEstimate}
     )
 
-    await keepFactory.openKeep(groupSize, threshold, keepOwner, bond, {
-      from: application,
-      value: feeEstimate,
-    })
+    await keepFactory.openKeep(
+      groupSize,
+      threshold,
+      keepOwner,
+      bond,
+      stakeLockDuration,
+      {
+        from: application,
+        value: feeEstimate,
+      }
+    )
 
     return await BondedECDSAKeep.at(keepAddress)
   }

--- a/solidity/test/BondedECDSAKeepIntegrationTest.js
+++ b/solidity/test/BondedECDSAKeepIntegrationTest.js
@@ -97,7 +97,7 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
       )
     })
 
-    it("locks members token stakes", async () => {
+    it("locks member stakes", async () => {
       const tx = await keepFactory.openKeep(
         groupSize,
         threshold,
@@ -132,7 +132,7 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
   })
 
   describe("closeKeep", async () => {
-    it("releases locks on members token stakes", async () => {
+    it("releases locks on member stakes", async () => {
       const keep = await openKeep({from: keepOwner})
 
       await keep.closeKeep({from: keepOwner})
@@ -148,7 +148,7 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
   })
 
   describe("seizeSignerBonds", async () => {
-    it("releases locks on members token stakes", async () => {
+    it("releases locks on member stakes", async () => {
       const keep = await openKeep({from: keepOwner})
 
       await keep.seizeSignerBonds({from: keepOwner})

--- a/solidity/test/BondedECDSAKeepTest.js
+++ b/solidity/test/BondedECDSAKeepTest.js
@@ -45,13 +45,13 @@ contract("BondedECDSAKeep", (accounts) => {
   let bondedECDSAKeepStubMaster
   let keep
   let factoryStub
-  let minimumStake
+  let memberStake
 
   async function newKeep(
     owner,
     members,
     honestThreshold,
-    minimumStake,
+    memberStake,
     stakeLockDuration,
     tokenStaking,
     keepBonding,
@@ -63,7 +63,7 @@ contract("BondedECDSAKeep", (accounts) => {
       owner,
       members,
       honestThreshold,
-      minimumStake,
+      memberStake,
       stakeLockDuration,
       tokenStaking,
       keepBonding,
@@ -95,8 +95,8 @@ contract("BondedECDSAKeep", (accounts) => {
 
     await registry.approveOperatorContract(bondCreator)
 
-    minimumStake = await factoryStub.minimumStake.call()
-    await stakeOperators(members, minimumStake)
+    memberStake = await factoryStub.minimumStake.call()
+    await stakeOperators(members, memberStake)
 
     await keepBonding.authorizeSortitionPoolContract(members[0], signingPool, {
       from: authorizers[0],
@@ -116,7 +116,7 @@ contract("BondedECDSAKeep", (accounts) => {
       owner,
       members,
       honestThreshold,
-      minimumStake,
+      memberStake,
       stakeLockDuration,
       tokenStaking.address,
       keepBonding.address,
@@ -138,7 +138,7 @@ contract("BondedECDSAKeep", (accounts) => {
         owner,
         members,
         honestThreshold,
-        minimumStake,
+        memberStake,
         stakeLockDuration,
         tokenStaking.address,
         keepBonding.address,
@@ -160,7 +160,7 @@ contract("BondedECDSAKeep", (accounts) => {
         owner,
         members,
         honestThreshold,
-        minimumStake,
+        memberStake,
         stakeLockDuration,
         tokenStaking.address,
         keepBonding.address,
@@ -180,7 +180,7 @@ contract("BondedECDSAKeep", (accounts) => {
         owner,
         members,
         honestThreshold,
-        minimumStake,
+        memberStake,
         stakeLockDuration,
         tokenStaking.address,
         keepBonding.address,
@@ -202,7 +202,7 @@ contract("BondedECDSAKeep", (accounts) => {
           owner,
           members,
           honestThreshold,
-          minimumStake,
+          memberStake,
           stakeLockDuration,
           tokenStaking.address,
           keepBonding.address,
@@ -889,7 +889,7 @@ contract("BondedECDSAKeep", (accounts) => {
           constants.ZERO_ADDRESS
         )
         expect(actualStake).to.eq.BN(
-          minimumStake,
+          memberStake,
           `incorrect stake for member ${i}`
         )
       }
@@ -919,7 +919,7 @@ contract("BondedECDSAKeep", (accounts) => {
 
     it("slashes keep members stakes", async () => {
       const remainingStake = new BN(10)
-      const stakeBalance = minimumStake.add(remainingStake)
+      const stakeBalance = memberStake.add(remainingStake)
       await stakeOperators(members, stakeBalance)
 
       await keep.publicSlashSignerStakes()
@@ -1451,7 +1451,7 @@ contract("BondedECDSAKeep", (accounts) => {
         owner,
         testMembers,
         honestThreshold,
-        minimumStake,
+        memberStake,
         stakeLockDuration,
         tokenStaking.address,
         keepBonding.address,
@@ -1487,7 +1487,7 @@ contract("BondedECDSAKeep", (accounts) => {
         owner,
         [member],
         honestThreshold,
-        minimumStake,
+        memberStake,
         stakeLockDuration,
         tokenStaking.address,
         keepBonding.address,
@@ -1507,7 +1507,7 @@ contract("BondedECDSAKeep", (accounts) => {
         owner,
         [member],
         honestThreshold,
-        minimumStake,
+        memberStake,
         stakeLockDuration,
         tokenStaking.address,
         keepBonding.address,
@@ -1646,7 +1646,7 @@ contract("BondedECDSAKeep", (accounts) => {
         owner,
         testMembers,
         honestThreshold,
-        minimumStake,
+        memberStake,
         stakeLockDuration,
         tokenStaking.address,
         keepBonding.address,

--- a/solidity/test/contracts/BondedECDSAKeepCloneFactoryStub.sol
+++ b/solidity/test/contracts/BondedECDSAKeepCloneFactoryStub.sol
@@ -23,6 +23,7 @@ contract BondedECDSAKeepCloneFactory is CloneFactory {
         address[] calldata _members,
         uint256 _honestThreshold,
         uint256 _minimumStake,
+        uint256 _stakeLockDuration,
         address _tokenStaking,
         address _keepBonding,
         address payable _keepFactory
@@ -36,6 +37,7 @@ contract BondedECDSAKeepCloneFactory is CloneFactory {
             _members,
             _honestThreshold,
             _minimumStake,
+            _stakeLockDuration,
             _tokenStaking,
             _keepBonding,
             _keepFactory

--- a/solidity/test/contracts/TokenStakingStub.sol
+++ b/solidity/test/contracts/TokenStakingStub.sol
@@ -13,6 +13,8 @@ contract TokenStakingStub is IStaking {
 
     mapping(address => uint256) stakes;
 
+    mapping(address => int256) public operatorLocks;
+
     // Authorized operator contracts.
     mapping(address => mapping(address => bool)) internal authorizations;
 
@@ -54,6 +56,16 @@ contract TokenStakingStub is IStaking {
             address operator = _misbehavedOperators[i];
             stakes[operator] = stakes[operator].sub(_amount);
         }
+    }
+
+    function lockStake(address operator, uint256 duration) public {
+        operatorLocks[operator] = int256(duration);
+    }
+
+    function unlockStake(address operator) public {
+        // We set it to negative value to be sure in tests that the function is
+        // actually called and not just default `0` value is returned.
+        operatorLocks[operator] = -1;
     }
 
     function authorizeOperatorContract(


### PR DESCRIPTION
Keep is required to lock token stakes for operators, so the stakes are not undelegated when keep is still active. The duration of the lock has to be defined by application opening a keep.
Locks are created on keep initialization and released when keep changes its' status from active to closed or terminated.

Closes: https://github.com/keep-network/keep-ecdsa/issues/360