### PR TITLE
Event confirmations

### DIFF
--- a/pkg/chain/ethereum/ethereum.go
+++ b/pkg/chain/ethereum/ethereum.go
@@ -76,7 +76,7 @@ func (ec *EthereumChain) OnKeepClosed(
 	}
 	return keepContract.WatchKeepClosed(
 		func(blockNumber uint64) {
-			handler(&eth.KeepClosedEvent{})
+			handler(&eth.KeepClosedEvent{BlockNumber: blockNumber})
 		},
 		func(err error) error {
 			return fmt.Errorf("keep closed callback failed: [%v]", err)
@@ -96,7 +96,7 @@ func (ec *EthereumChain) OnKeepTerminated(
 	}
 	return keepContract.WatchKeepTerminated(
 		func(blockNumber uint64) {
-			handler(&eth.KeepTerminatedEvent{})
+			handler(&eth.KeepTerminatedEvent{BlockNumber: blockNumber})
 		},
 		func(err error) error {
 			return fmt.Errorf("keep terminated callback failed: [%v]", err)
@@ -175,7 +175,8 @@ func (ec *EthereumChain) OnSignatureRequested(
 			blockNumber uint64,
 		) {
 			handler(&eth.SignatureRequestedEvent{
-				Digest: Digest,
+				Digest:      Digest,
+				BlockNumber: blockNumber,
 			})
 		},
 		func(err error) error {

--- a/pkg/chain/event.go
+++ b/pkg/chain/event.go
@@ -10,6 +10,27 @@ type BondedECDSAKeepCreatedEvent struct {
 	Members     []common.Address // keep members addresses
 }
 
+// ConflictingPublicKeySubmittedEvent is an event emitted each time when one of
+// the members of a keep has submitted a key that does not match the keys submitted
+// so far by other members.
+type ConflictingPublicKeySubmittedEvent struct {
+	SubmittingMember     common.Address
+	ConflictingPublicKey []byte
+}
+
+// PublicKeyPublishedEvent is an event emitted once all the members have submitted
+// the same public key and it was accepted by keep as its public key.
+type PublicKeyPublishedEvent struct {
+	PublicKey []byte
+}
+
+// SignatureRequestedEvent is an event emitted when a user requests
+// a digest to be signed.
+type SignatureRequestedEvent struct {
+	Digest      [32]byte
+	BlockNumber uint64
+}
+
 // KeepClosedEvent is an event emitted when a keep has been closed.
 type KeepClosedEvent struct {
 	BlockNumber uint64
@@ -28,25 +49,4 @@ func (e *BondedECDSAKeepCreatedEvent) IsMember(address common.Address) bool {
 		}
 	}
 	return false
-}
-
-// SignatureRequestedEvent is an event emitted when a user requests
-// a digest to be signed.
-type SignatureRequestedEvent struct {
-	Digest      [32]byte
-	BlockNumber uint64
-}
-
-// ConflictingPublicKeySubmittedEvent is an event emitted each time when one of
-// the members of a keep has submitted a key that does not match the keys submitted
-// so far by other members.
-type ConflictingPublicKeySubmittedEvent struct {
-	SubmittingMember     common.Address
-	ConflictingPublicKey []byte
-}
-
-// PublicKeyPublishedEvent is an event emitted once all the members have submitted
-// the same public key and it was accepted by keep as its public key.
-type PublicKeyPublishedEvent struct {
-	PublicKey []byte
 }

--- a/pkg/chain/event.go
+++ b/pkg/chain/event.go
@@ -12,10 +12,12 @@ type BondedECDSAKeepCreatedEvent struct {
 
 // KeepClosedEvent is an event emitted when a keep has been closed.
 type KeepClosedEvent struct {
+	BlockNumber uint64
 }
 
 // KeepTerminatedEvent is an event emitted when a keep has been terminated.
 type KeepTerminatedEvent struct {
+	BlockNumber uint64
 }
 
 // IsMember checks if list of members contains the given address.
@@ -31,7 +33,8 @@ func (e *BondedECDSAKeepCreatedEvent) IsMember(address common.Address) bool {
 // SignatureRequestedEvent is an event emitted when a user requests
 // a digest to be signed.
 type SignatureRequestedEvent struct {
-	Digest [32]byte
+	Digest      [32]byte
+	BlockNumber uint64
 }
 
 // ConflictingPublicKeySubmittedEvent is an event emitted each time when one of

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -445,7 +445,7 @@ func waitForEventConfirmation(
 
 	result, err := stateCheck()
 	if err != nil {
-		return false, fmt.Errorf("failed to get state confirmation: [%v]", err)
+		return false, fmt.Errorf("failed to get chain state confirmation: [%v]", err)
 	}
 
 	return result, nil

--- a/solidity/integration/sign_with_existing_keep.js
+++ b/solidity/integration/sign_with_existing_keep.js
@@ -1,15 +1,21 @@
 const BondedECDSAKeep = artifacts.require("./BondedECDSAKeep.sol")
 
-// This test validates integration between on-chain contracts and off-chain client.
-// It requires contracts to be deployed before running the test. It requests
-// signature for a specific keep contract provided as a <KEEP_ADDRESS> argument
-// using keep owner (privileged application) provided as a <KEEP_OWNER> argument.
-//
-// To execute this test run:
-// truffle exec integration/sign_with_existing_keep.js <KEEP_ADDRESS> <KEEP_OWNER>
+/*
+This test validates integration between on-chain contracts and off-chain client.
+It requires contracts to be deployed before running the test. It requests
+signature for a specific keep contract provided as a KEEP_ADDRESS environment
+variable using keep owner (privileged application) provided as a KEEP_OWNER
+environment variable.
+
+To execute this test run:
+  KEEP_ADDRESS=<KEEP_ADDRESS> \
+  KEEP_OWNER=<KEEP_OWNER> \
+  truffle exec integration/sign_with_existing_keep.js --network local
+*/
+
 module.exports = async function () {
-  const keepAddress = process.argv[4]
-  const keepOwnerArg = process.argv[5]
+  const keepAddress = process.env.KEEP_ADDRESS
+  const keepOwnerArg = process.env.KEEP_OWNER
 
   let keepOwner
   let keep
@@ -18,7 +24,7 @@ module.exports = async function () {
   try {
     if (!keepOwnerArg) {
       const accounts = await web3.eth.getAccounts()
-      keepOwner = accounts[4] // keep owner address from smoke_test.js
+      keepOwner = accounts[5] // keep owner address from smoke_test.js
     } else {
       keepOwner = keepOwnerArg
     }


### PR DESCRIPTION
After receiving a signing request, keep closing or keep terminating events we want to wait for 12 blocks and check that state of the contract is really as in the emitted event.

Closes: https://github.com/keep-network/keep-ecdsa/issues/364