### PR TITLE
Retry operator registration on status monitoring failure

### DIFF
--- a/pkg/client/registration.go
+++ b/pkg/client/registration.go
@@ -22,7 +22,7 @@ func checkStatusAndRegisterForApplication(
 	ethereumChain eth.Handle,
 	application common.Address,
 ) {
-Registration:
+RegistrationLoop:
 	for {
 		select {
 		case <-ctx.Done():
@@ -49,7 +49,7 @@ Registration:
 			// registered, we can start to monitor the status
 			if err := monitorSignerPoolStatus(ctx, ethereumChain, application); err != nil {
 				logger.Errorf("failed on signer pool status monitoring: [%v]", err)
-				continue Registration
+				continue RegistrationLoop
 			}
 		}
 	}

--- a/pkg/client/registration.go
+++ b/pkg/client/registration.go
@@ -35,7 +35,7 @@ RegistrationLoop:
 					application.String(),
 					err,
 				)
-				return
+				continue RegistrationLoop
 			}
 
 			if !isRegistered {


### PR DESCRIPTION
Status monitoring can fail if the operator gets removed from the signer candidates pool. In such a case, we want to restart the registration loop to check if the operator is already registered and if not register when they are eligible.

Closes: https://github.com/keep-network/keep-ecdsa/issues/317