### PR TITLE
Minimum stake schedule

### DIFF
--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -896,12 +896,11 @@
       }
     },
     "@keep-network/sortition-pools": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-0.1.1.tgz",
-      "integrity": "sha512-0A4N6wbtFfjWez7KwHEd2aMh6iB4kNaxI5fGDUCaCkeo2zP/FHOFcI9POIYLQ/17bL71EK/WxM5CnZJz4n/9vg==",
+      "version": "0.2.1-pre.3",
+      "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-0.2.1-pre.3.tgz",
+      "integrity": "sha512-YIXz3pCkYKh73+h8nzSS3K7VtWfM5QmuNTNGCpBpb/Z+kbfVLq1XPXMOkRTJiVww4nXsJX/HWrT1jgfdSv79LA==",
       "requires": {
-        "@openzeppelin/contracts": "^2.4.0",
-        "solidity-bytes-utils": "0.0.7"
+        "@openzeppelin/contracts": "^2.4.0"
       }
     },
     "@openzeppelin/contract-loader": {

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/keep-network/keep-ecdsa",
   "dependencies": {
     "@keep-network/keep-core": ">0.13.0-pre <0.13.0-rc",
-    "@keep-network/sortition-pools": "0.1.1",
+    "@keep-network/sortition-pools": "0.2.1-pre.3",
     "@openzeppelin/upgrades": "^2.7.2",
     "openzeppelin-solidity": "2.3.0",
     "solidity-bytes-utils": "0.0.7"

--- a/solidity/test/BondedECDSAKeepFactoryTest.js
+++ b/solidity/test/BondedECDSAKeepFactoryTest.js
@@ -334,7 +334,7 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
       )
     })
 
-    it("returns false if the operator stake increased", async () => {
+    it("returns true if the operator stake increased", async () => {
       await keepFactory.registerMemberCandidate(application, {
         from: members[0],
       })

--- a/solidity/test/BondedECDSAKeepIntegrationTest.js
+++ b/solidity/test/BondedECDSAKeepIntegrationTest.js
@@ -218,7 +218,7 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
 
       for (let i = 0; i < members.length; i++) {
         const expectedStake = initialStakes[i].sub(
-          await keepFactory.minimumStake.call()
+          await tokenStaking.minimumStake.call()
         )
 
         const actualStake = await tokenStaking.eligibleStake(
@@ -286,7 +286,7 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
   }
 
   async function initializeMemberCandidates(unbondedValue) {
-    const minimumStake = await keepFactory.minimumStake.call()
+    const minimumStake = await tokenStaking.minimumStake.call()
     await stakeOperators(minimumStake)
 
     signerPool = await keepFactory.createSortitionPool.call(application)

--- a/solidity/test/contracts/TokenStakingStub.sol
+++ b/solidity/test/contracts/TokenStakingStub.sol
@@ -9,6 +9,8 @@ import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 contract TokenStakingStub is IStaking {
     using SafeMath for uint256;
 
+    uint256 public minimumStake = 200000 * 1e18;
+
     mapping(address => address payable) operatorToMagpie;
 
     mapping(address => uint256) stakes;


### PR DESCRIPTION
Closes: keep-network/keep-ecdsa#302

See: https://github.com/keep-network/keep-core/pull/1499
See: https://github.com/keep-network/sortition-pools/pull/74
See: https://github.com/keep-network/sortition-pools/pull/78

Minimum stake is no longer a system-wide constant and it changes over time in `TokenStaking`. `BondedECDSAKeepFactory` needs to be updated to support the minimum stake schedule.

The factory does no longer have the minimum stake hardcoded. To check if the operator has a minimum stake, it queries `TokenStaking` contract.

Also, the sortition pool now expects the recent value of the minimum stake to be passed for each group selection. This is happening in `openKeep` function.

Factory declares the eligible stake divisor for sortition pool to be `1 KEEP`.