### PR TITLE
Updated sortition-pool dependency to 0.3.0

### DIFF
--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -896,9 +896,9 @@
       }
     },
     "@keep-network/sortition-pools": {
-      "version": "0.2.1-pre.3",
-      "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-0.2.1-pre.3.tgz",
-      "integrity": "sha512-YIXz3pCkYKh73+h8nzSS3K7VtWfM5QmuNTNGCpBpb/Z+kbfVLq1XPXMOkRTJiVww4nXsJX/HWrT1jgfdSv79LA==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-0.3.0.tgz",
+      "integrity": "sha512-1nr1Wq3wmKYxtkWynB/xMHEYpVAOSCL5XBcHMlsUBGuG9rw+JhbDUNYbbxHNYUZ7sMRq0S0pOrzQVWb5M+ZUig==",
       "requires": {
         "@openzeppelin/contracts": "^2.4.0"
       }

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/keep-network/keep-ecdsa",
   "dependencies": {
     "@keep-network/keep-core": ">0.13.0-pre <0.13.0-rc",
-    "@keep-network/sortition-pools": "0.2.1-pre.3",
+    "@keep-network/sortition-pools": "0.3.0",
     "@openzeppelin/upgrades": "^2.7.2",
     "openzeppelin-solidity": "2.3.0",
     "solidity-bytes-utils": "0.0.7"


### PR DESCRIPTION
Updated sortition pool dependency to [v. 0.3.0](https://github.com/keep-network/sortition-pools/releases/tag/v0.3.0-rc)