### PR TITLE
v0.13.0-rc release preparation

### DIFF
--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "0.13.0-rc",
+  "version": "0.14.0-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -879,9 +879,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "0.13.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.13.0-rc.0.tgz",
-      "integrity": "sha512-hYZYnxo/T6a/TcJhfFAc4F+YTbj4iTGWZB39EhlGwecBZnNOWuwJnqw3l3Co7ZOuVLdPdxnkLyEy1f0NFlt+8g==",
+      "version": "0.14.0-pre.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.14.0-pre.0.tgz",
+      "integrity": "sha512-etiQWKwtxTCA7QFQ/wsvYAu8owdddEDOEGZ3H1QMPljbyKiDuvHmdAdzeuGsou1+i9fL/XzZPv32ctWob5xT/w==",
       "requires": {
         "@openzeppelin/contracts-ethereum-package": "^2.4.0",
         "@openzeppelin/upgrades": "^2.7.2",

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "0.13.0-pre",
+  "version": "0.13.0-rc",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -879,9 +879,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "0.13.0-pre.9",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.13.0-pre.9.tgz",
-      "integrity": "sha512-I8MsomNf8o5fhc02O6TkThpXnEkbHSjAgHPsL42k4EJbVkOfrxBLHDAc04Rg8LeNsFygpifmncoV6jtbiQwxbA==",
+      "version": "0.13.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.13.0-rc.0.tgz",
+      "integrity": "sha512-hYZYnxo/T6a/TcJhfFAc4F+YTbj4iTGWZB39EhlGwecBZnNOWuwJnqw3l3Co7ZOuVLdPdxnkLyEy1f0NFlt+8g==",
       "requires": {
         "@openzeppelin/contracts-ethereum-package": "^2.4.0",
         "@openzeppelin/upgrades": "^2.7.2",

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "0.13.0-rc",
+  "version": "0.14.0-pre",
   "description": "Smart contracts for ECDSA Keep",
   "repository": {
     "type": "git",
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/keep-network/keep-ecdsa",
   "dependencies": {
-    "@keep-network/keep-core": ">0.13.0-rc <0.13.0",
+    "@keep-network/keep-core": ">0.14.0-pre <0.14.0-rc",
     "@keep-network/sortition-pools": "0.3.0",
     "@openzeppelin/upgrades": "^2.7.2",
     "openzeppelin-solidity": "2.3.0",

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/keep-network/keep-ecdsa",
   "dependencies": {
-    "@keep-network/keep-core": ">0.13.0-pre <0.13.0-rc",
+    "@keep-network/keep-core": ">0.13.0-rc <0.13.0",
     "@keep-network/sortition-pools": "0.3.0",
     "@openzeppelin/upgrades": "^2.7.2",
     "openzeppelin-solidity": "2.3.0",

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "0.13.0-pre",
+  "version": "0.13.0-rc",
   "description": "Smart contracts for ECDSA Keep",
   "repository": {
     "type": "git",


### PR DESCRIPTION
1. Bumped up Solidity contracts version to `0.13.0-rc`, `keep-core` contracts dependency set to `>0.13.0-rc <0.13.0`. Tagged 3c9067a as [`0.13.0-rc`](https://github.com/keep-network/keep-ecdsa/releases/tag/v0.13.0-rc)
2. Bumped up Solidity contracts version to `0.14.0-pre`, `keep-core` contracts dependency set to `>0.14.0-pre <0.14.0-rc`