### PR TITLE
BondedECDSAKeepFactory implements IRandombeaconConsumer

### DIFF
--- a/solidity/contracts/BondedECDSAKeepFactory.sol
+++ b/solidity/contracts/BondedECDSAKeepFactory.sol
@@ -29,7 +29,8 @@ import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 contract BondedECDSAKeepFactory is
     IBondedECDSAKeepFactory,
     CloneFactory,
-    AuthorityDelegator
+    AuthorityDelegator,
+    IRandomBeaconConsumer
 {
     using AddressArrayUtils for address[];
     using SafeMath for uint256;

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -879,9 +879,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "0.14.0-pre.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.14.0-pre.0.tgz",
-      "integrity": "sha512-etiQWKwtxTCA7QFQ/wsvYAu8owdddEDOEGZ3H1QMPljbyKiDuvHmdAdzeuGsou1+i9fL/XzZPv32ctWob5xT/w==",
+      "version": "0.14.0-pre.4",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.14.0-pre.4.tgz",
+      "integrity": "sha512-tAVamCDTOqd4gtQIChpMBe/6ntqSCqUJqhsPtdx5DepKednvdpSjfmWrbVKCAss4zyiwRDUtXQRVZs01tpbr1A==",
       "requires": {
         "@openzeppelin/contracts-ethereum-package": "^2.4.0",
         "@openzeppelin/upgrades": "^2.7.2",


### PR DESCRIPTION
Closes https://github.com/keep-network/keep-core/issues/1537
Depends on https://github.com/keep-network/keep-core/pull/1609

It is to ensure the beacon callback function has a correct signature. If it has not, the contract cannot be deployed:

```
Error:  *** Deployment Failed ***

"BondedECDSAKeepFactory" is an abstract contract or an interface and cannot be deployed.
   * Import abstractions into the '.sol' file that uses them instead of deploying them separately.
   * Contracts that inherit an abstraction must implement all its method signatures exactly.
   * A contract that only implements part of an inherited abstraction is
   also considered abstract.
```