### PR TITLE
keep-test: Reduce ecdsa unbonded deposit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -224,7 +224,7 @@ jobs:
       - run:
           name: Tag Docker images
           command: |
-            docker tag keep-ecdsa $GCR_REGISTRY_URL/$GOOGLE_PROJECT_ID/keep-ecdsa
+            # docker tag keep-ecdsa $GCR_REGISTRY_URL/$GOOGLE_PROJECT_ID/keep-ecdsa
             docker tag initcontainer-provision-keep-ecdsa $GCR_REGISTRY_URL/$GOOGLE_PROJECT_ID/initcontainer-provision-keep-ecdsa
       - gcp-gcr/gcr-auth:
           google-project-id: GOOGLE_PROJECT_ID

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,8 +116,10 @@ jobs:
           command: |
             gsutil cp gs://${CONTRACT_DATA_BUCKET}/keep-core/KeepToken.json .
             gsutil cp gs://${CONTRACT_DATA_BUCKET}/keep-core/TokenStaking.json .
-            cp /tmp/keep-ecdsa/contracts/BondedECDSAKeepFactory.json .
-            cp /tmp/keep-ecdsa/contracts/KeepBonding.json .
+            gsutil cp gs://${CONTRACT_DATA_BUCKET}/keep-ecdsa/BondedECDSAKeepFactory.json .
+            gsutil cp gs://${CONTRACT_DATA_BUCKET}/keep-ecdsa/KeepBonding.json .
+            # cp /tmp/keep-ecdsa/contracts/BondedECDSAKeepFactory.json .
+            # cp /tmp/keep-ecdsa/contracts/KeepBonding.json .
 
             docker build \
               --tag initcontainer-provision-keep-ecdsa .
@@ -229,11 +231,11 @@ jobs:
           google-compute-zone: GOOGLE_COMPUTE_ZONE_A
           # This param doesn't actually set anything, leaving here as a reminder to check when they fix it.
           gcloud-service-key: GCLOUD_SERVICE_KEY
-      - gcp-gcr/push-image:
-          google-project-id: GOOGLE_PROJECT_ID
-          registry-url: $GCR_REGISTRY_URL
-          image: keep-ecdsa
-          tag: latest
+      # - gcp-gcr/push-image:
+          # google-project-id: GOOGLE_PROJECT_ID
+          # registry-url: $GCR_REGISTRY_URL
+          # image: keep-ecdsa
+          # tag: latest
       - gcp-gcr/push-image:
           google-project-id: GOOGLE_PROJECT_ID
           registry-url: $GCR_REGISTRY_URL
@@ -305,64 +307,64 @@ workflows:
     jobs:
       - keep_test_approval:
           type: approval
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
-      - build_client_and_test_go:
-          context: github-package-registry
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
-          requires:
-            - keep_test_approval
-      - migrate_contracts:
-          context: keep-test
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
-          requires:
-            - build_client_and_test_go
+          # filters:
+          #   tags:
+          #     only: /^v.*/
+          #   branches:
+          #     ignore: /.*/
+      # - build_client_and_test_go:
+      #     context: github-package-registry
+      #     filters:
+      #       tags:
+      #         only: /^v.*/
+      #       branches:
+      #         ignore: /.*/
+      #     requires:
+      #       - keep_test_approval
+      # - migrate_contracts:
+      #     context: keep-test
+      #     filters:
+      #       tags:
+      #         only: /^v.*/
+      #       branches:
+      #         ignore: /.*/
+      #     requires:
+      #       - build_client_and_test_go
       - build_initcontainer:
           context: keep-test
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
+          # filters:
+          #   tags:
+          #     only: /^v.*/
+          #   branches:
+          #     ignore: /.*/
           requires:
             - migrate_contracts
       - publish_client:
           context: keep-test
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
+          # filters:
+          #   tags:
+          #     only: /^v.*/
+          #   branches:
+          #     ignore: /.*/
           requires:
-            - build_client_and_test_go
+            # - build_client_and_test_go
             - build_initcontainer
-            - migrate_contracts
-      - publish_npm_package:
-          context: keep-test
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
-          requires:
-            - migrate_contracts
-      - publish_contract_data:
-          context: keep-test
-          filters:
-            tags:
-              only: /^v.*/
-            branches:
-              ignore: /.*/
-          requires:
-            - migrate_contracts
+            # - migrate_contracts
+      # - publish_npm_package:
+      #     context: keep-test
+      #     filters:
+      #       tags:
+      #         only: /^v.*/
+      #       branches:
+      #         ignore: /.*/
+      #     requires:
+      #       - migrate_contracts
+      # - publish_contract_data:
+      #     context: keep-test
+      #     filters:
+      #       tags:
+      #         only: /^v.*/
+      #       branches:
+      #         ignore: /.*/
+      #     requires:
+      #       - migrate_contracts

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -219,7 +219,7 @@ jobs:
       - run:
           name: Load Docker images
           command: |
-            docker load -i /tmp/keep-ecdsa/docker-images/keep-ecdsa.tar
+            # docker load -i /tmp/keep-ecdsa/docker-images/keep-ecdsa.tar
             docker load -i /tmp/keep-ecdsa/docker-images/initcontainer-provision-keep-ecdsa.tar
       - run:
           name: Tag Docker images

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -337,8 +337,8 @@ workflows:
           #     only: /^v.*/
           #   branches:
           #     ignore: /.*/
-          requires:
-            - migrate_contracts
+          # requires:
+          #   - migrate_contracts
       - publish_client:
           context: keep-test
           # filters:

--- a/infrastructure/kube/templates/keep-ecdsa/initcontainer/provision-keep-ecdsa/provision-keep-ecdsa.js
+++ b/infrastructure/kube/templates/keep-ecdsa/initcontainer/provision-keep-ecdsa/provision-keep-ecdsa.js
@@ -74,7 +74,7 @@ async function provisionKeepTecdsa() {
     await fundOperator(operatorAddress, purse, '10')
 
     console.log(`\n<<<<<<<<<<<< Deposit to KeepBondingContract ${keepBondingContract.address} >>>>>>>>>>>>`)
-    await depositUnbondedValue(operatorAddress, purse, '50')
+    await depositUnbondedValue(operatorAddress, purse, '10')
 
     console.log(`\n<<<<<<<<<<<< Staking Operator Account ${operatorAddress} >>>>>>>>>>>>`)
     await stakeOperator(operatorAddress, contractOwnerAddress, authorizer)


### PR DESCRIPTION
Drafting this for visibility during the build process.  Will close when done.

We're reducing the unbonded deposit to reduce the amount of ETH needed for application deployment during scale-out testing.

We'll fix this properly against master by making this value configurable via Kube config.  I will do this in a separate PR.