### PR TITLE
Public key monitoring context update

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -419,13 +419,12 @@ func (n *Node) monitorKeepPublicKeySubmission(
 			event.ConflictingPublicKey,
 		)
 	case <-monitoringCtx.Done():
-		if monitoringCtx.Err() == context.DeadlineExceeded {
-			logger.Warningf(
-				"monitoring of public key submission for keep [%s] "+
-					"has been cancelled due to exceeded timeout",
-				keepAddress.String(),
-			)
-		}
+		logger.Warningf(
+			"monitoring of public key submission for keep [%s] "+
+				"has been cancelled: [%v]",
+			keepAddress.String(),
+			monitoringCtx.Err(),
+		)
 	case <-abort:
 		logger.Warningf(
 			"monitoring of public key submission for keep [%s] "+

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -205,7 +205,7 @@ func (n *Node) publishSignerPublicKey(
 	)
 
 	monitoringAbort := make(chan interface{})
-	go n.monitorKeepPublicKeySubmission(ctx, monitoringAbort, keepAddress)
+	go n.monitorKeepPublicKeySubmission(monitoringAbort, keepAddress)
 
 	err := n.ethereumChain.SubmitKeepPublicKey(keepAddress, publicKey)
 	if err != nil {
@@ -365,12 +365,11 @@ func (n *Node) publishSignature(
 // conflicting public key is published or until keep established public key
 // or until key generation timed out.
 func (n *Node) monitorKeepPublicKeySubmission(
-	ctx context.Context,
 	abort chan interface{},
 	keepAddress common.Address,
 ) {
 	monitoringCtx, monitoringCancel := context.WithTimeout(
-		ctx,
+		context.Background(),
 		monitorKeepPublicKeySubmissionTimeout,
 	)
 	defer monitoringCancel()


### PR DESCRIPTION
Previously the context for public key submission monitoring was a child of public key generation context. Once the operator published their key the parent context was completed so the monitoring routine was canceled. Here we define a separate unique context for monitoring
function with a dedicated timeout.

There is an abort channel so the monitoring can be aborted in case of key submission failure. If everything goes well the monitoring will track chain after the signer establishment.

When the context is done we will log the message regardless of the error type. It would be abnormal if the context gets canceled for any reason so we should log every occurrence.

Closes: https://github.com/keep-network/keep-ecdsa/issues/402