### PR TITLE
Minimum stake or active keep membership firewall policy

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -10,6 +10,7 @@ import (
 	"github.com/keep-network/keep-common/pkg/chain/ethereum/ethutil"
 	"github.com/keep-network/keep-common/pkg/persistence"
 
+	"github.com/keep-network/keep-core/pkg/firewall"
 	"github.com/keep-network/keep-core/pkg/net/key"
 	"github.com/keep-network/keep-core/pkg/net/libp2p"
 	"github.com/keep-network/keep-core/pkg/net/retransmission"
@@ -127,7 +128,7 @@ func Start(c *cli.Context) error {
 		ctx,
 		config.LibP2P,
 		networkPrivateKey,
-		stakeMonitor,
+		firewall.MinimumStakePolicy(stakeMonitor),
 		retransmission.NewTimeTicker(ctx, 1*time.Second),
 		libp2p.WithRoutingTableRefreshPeriod(routingTableRefreshPeriod),
 		libp2p.WithBootstrapMinPeerThreshold(bootstrapMinPeerThreshold),

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -10,11 +10,11 @@ import (
 	"github.com/keep-network/keep-common/pkg/chain/ethereum/ethutil"
 	"github.com/keep-network/keep-common/pkg/persistence"
 
-	"github.com/keep-network/keep-core/pkg/firewall"
 	"github.com/keep-network/keep-core/pkg/net/key"
 	"github.com/keep-network/keep-core/pkg/net/libp2p"
 	"github.com/keep-network/keep-core/pkg/net/retransmission"
 	"github.com/keep-network/keep-core/pkg/operator"
+	"github.com/keep-network/keep-ecdsa/pkg/firewall"
 
 	"github.com/keep-network/keep-ecdsa/internal/config"
 	"github.com/keep-network/keep-ecdsa/pkg/chain/ethereum"
@@ -128,7 +128,7 @@ func Start(c *cli.Context) error {
 		ctx,
 		config.LibP2P,
 		networkPrivateKey,
-		firewall.MinimumStakePolicy(stakeMonitor),
+		firewall.NewStakeOrActiveKeepPolicy(ethereumChain, stakeMonitor),
 		retransmission.NewTimeTicker(ctx, 1*time.Second),
 		libp2p.WithRoutingTableRefreshPeriod(routingTableRefreshPeriod),
 		libp2p.WithBootstrapMinPeerThreshold(bootstrapMinPeerThreshold),

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/gogo/protobuf v1.3.1
 	github.com/ipfs/go-log v0.0.1
 	github.com/keep-network/keep-common v0.2.0-rc
-	github.com/keep-network/keep-core v0.13.0-rc
+	github.com/keep-network/keep-core v0.13.0-rc.0.20200416001330-0347b73e812f
 	github.com/pkg/errors v0.9.1
 	github.com/urfave/cli v1.22.1
 )

--- a/go.sum
+++ b/go.sum
@@ -245,6 +245,8 @@ github.com/keep-network/keep-common v0.2.0-rc h1:dkG8qtcKINk9kXqtGg4dAFu9x0xiSZt
 github.com/keep-network/keep-common v0.2.0-rc/go.mod h1:0uY+hufkP66nFnL+3GXMwWXRiKKsFyXFQTby1xR7AwY=
 github.com/keep-network/keep-core v0.13.0-rc h1:Fl3P/qPa4eYd6Zhm4PrkxH6cYd+ssxYUeAMxi7zf5Ts=
 github.com/keep-network/keep-core v0.13.0-rc/go.mod h1:wyvHiiC+w4SJqcWlgRFMPBGdOxqlwvUxTY9svvOULc0=
+github.com/keep-network/keep-core v0.13.0-rc.0.20200416001330-0347b73e812f h1:qZTwkK+xm/vSBkeXlcqqnEJUhTVMWkSQBTXVAIcD1FQ=
+github.com/keep-network/keep-core v0.13.0-rc.0.20200416001330-0347b73e812f/go.mod h1:wyvHiiC+w4SJqcWlgRFMPBGdOxqlwvUxTY9svvOULc0=
 github.com/keep-network/toml v0.3.0 h1:G+NJwWR/ZiORqeLBsDXDchYoL29PXHdxOPcCueA7ctE=
 github.com/keep-network/toml v0.3.0/go.mod h1:Zeyd3lxbIlMYLREho3UK1dMP2xjqt2gLkQ5E5vM6K38=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=

--- a/pkg/chain/chain.go
+++ b/pkg/chain/chain.go
@@ -53,9 +53,9 @@ type BondedECDSAKeepFactory interface {
 	// pool for the given application.
 	UpdateStatusForApplication(application common.Address) error
 
-	// HasAuthorization checks if the factory has the authorization to
+	// IsOperatorAuthorized checks if the factory has the authorization to
 	// operate on stake represented by the provided operator.
-	HasAuthorization(operator common.Address) (bool, error)
+	IsOperatorAuthorized(operator common.Address) (bool, error)
 
 	// GetKeepCount returns number of keeps.
 	GetKeepCount() (*big.Int, error)

--- a/pkg/chain/chain.go
+++ b/pkg/chain/chain.go
@@ -3,11 +3,12 @@
 package eth
 
 import (
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/keep-network/keep-common/pkg/subscription"
 	"github.com/keep-network/keep-core/pkg/chain"
 	"github.com/keep-network/keep-ecdsa/pkg/ecdsa"
-	"math/big"
 )
 
 // Handle represents a handle to an ethereum blockchain.
@@ -51,6 +52,10 @@ type BondedECDSAKeepFactory interface {
 	// UpdateStatusForApplication updates the operator's status in the signers'
 	// pool for the given application.
 	UpdateStatusForApplication(application common.Address) error
+
+	// HasAuthorization checks if the factory has the authorization to
+	// operate on stake represented by the provided operator.
+	HasAuthorization(operator common.Address) (bool, error)
 
 	// GetKeepCount returns number of keeps.
 	GetKeepCount() (*big.Int, error)

--- a/pkg/chain/ethereum/ethereum.go
+++ b/pkg/chain/ethereum/ethereum.go
@@ -365,6 +365,10 @@ func (ec *EthereumChain) UpdateStatusForApplication(application common.Address) 
 	return nil
 }
 
+func (ec *EthereumChain) HasAuthorization(operator common.Address) (bool, error) {
+	return ec.bondedECDSAKeepFactoryContract.HasAuthorization(operator)
+}
+
 func (ec *EthereumChain) GetKeepCount() (*big.Int, error) {
 	return ec.bondedECDSAKeepFactoryContract.GetKeepCount()
 }

--- a/pkg/chain/ethereum/ethereum.go
+++ b/pkg/chain/ethereum/ethereum.go
@@ -365,8 +365,8 @@ func (ec *EthereumChain) UpdateStatusForApplication(application common.Address) 
 	return nil
 }
 
-func (ec *EthereumChain) HasAuthorization(operator common.Address) (bool, error) {
-	return ec.bondedECDSAKeepFactoryContract.HasAuthorization(operator)
+func (ec *EthereumChain) IsOperatorAuthorized(operator common.Address) (bool, error) {
+	return ec.bondedECDSAKeepFactoryContract.IsOperatorAuthorized(operator)
 }
 
 func (ec *EthereumChain) GetKeepCount() (*big.Int, error) {

--- a/pkg/chain/local/bonded_ecdsa_keep.go
+++ b/pkg/chain/local/bonded_ecdsa_keep.go
@@ -4,11 +4,21 @@ import (
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/keep-network/keep-ecdsa/pkg/chain"
+	eth "github.com/keep-network/keep-ecdsa/pkg/chain"
+)
+
+type keepStatus int
+
+const (
+	active     keepStatus = iota
+	closed                = iota
+	terminated            = iota
 )
 
 type localKeep struct {
 	publicKey [64]byte
+	members   []common.Address
+	status    keepStatus
 
 	signatureRequestedHandlers map[int]func(event *eth.SignatureRequestedEvent)
 }

--- a/pkg/chain/local/bonded_ecdsa_keep.go
+++ b/pkg/chain/local/bonded_ecdsa_keep.go
@@ -10,9 +10,9 @@ import (
 type keepStatus int
 
 const (
-	active     keepStatus = iota
-	closed                = iota
-	terminated            = iota
+	active keepStatus = iota
+	closed
+	terminated
 )
 
 type localKeep struct {

--- a/pkg/chain/local/local.go
+++ b/pkg/chain/local/local.go
@@ -210,6 +210,10 @@ func (lc *localChain) UpdateStatusForApplication(application common.Address) err
 	panic("implement")
 }
 
+func (lc *localChain) HasAuthorization(operator common.Address) (bool, error) {
+	panic("implement")
+}
+
 func (lc *localChain) GetKeepCount() (*big.Int, error) {
 	lc.handlerMutex.Lock()
 	defer lc.handlerMutex.Unlock()

--- a/pkg/chain/local/local.go
+++ b/pkg/chain/local/local.go
@@ -30,8 +30,8 @@ type Chain interface {
 type localChain struct {
 	handlerMutex sync.Mutex
 
-	keepIndexes []common.Address
-	keeps       map[common.Address]*localKeep
+	keepAddresses []common.Address
+	keeps         map[common.Address]*localKeep
 
 	keepCreatedHandlers map[int]func(event *eth.BondedECDSAKeepCreatedEvent)
 
@@ -58,7 +58,7 @@ func (lc *localChain) OpenKeep(keepAddress common.Address, members []common.Addr
 	lc.keeps[keepAddress] = &localKeep{
 		members: members,
 	}
-	lc.keepIndexes = append(lc.keepIndexes, keepAddress)
+	lc.keepAddresses = append(lc.keepAddresses, keepAddress)
 }
 
 func (lc *localChain) CloseKeep(keepAddress common.Address) error {
@@ -243,11 +243,11 @@ func (lc *localChain) GetKeepAtIndex(
 
 	index := int(keepIndex.Uint64())
 
-	if index > len(lc.keepIndexes) {
+	if index > len(lc.keepAddresses) {
 		return common.HexToAddress("0x0"), fmt.Errorf("out of bounds")
 	}
 
-	return lc.keepIndexes[index], nil
+	return lc.keepAddresses[index], nil
 }
 
 func (lc *localChain) OnKeepClosed(

--- a/pkg/chain/local/local.go
+++ b/pkg/chain/local/local.go
@@ -221,7 +221,7 @@ func (lc *localChain) UpdateStatusForApplication(application common.Address) err
 	panic("implement")
 }
 
-func (lc *localChain) HasAuthorization(operator common.Address) (bool, error) {
+func (lc *localChain) IsOperatorAuthorized(operator common.Address) (bool, error) {
 	lc.handlerMutex.Lock()
 	defer lc.handlerMutex.Unlock()
 

--- a/pkg/firewall/cache.go
+++ b/pkg/firewall/cache.go
@@ -43,7 +43,7 @@ func (tc *timeCache) add(item string) bool {
 		return false
 	}
 
-	// sweep old entries
+	// sweep old entries (those for which caching timespan has passed)
 	for {
 		back := tc.indexer.Back()
 		if back == nil {

--- a/pkg/firewall/cache.go
+++ b/pkg/firewall/cache.go
@@ -9,8 +9,15 @@ import (
 // timeCache provides a time cache safe for concurrent use by
 // multiple goroutines without additional locking or coordination.
 type timeCache struct {
-	indexer  *list.List
-	cache    map[string]time.Time
+	// all items in the cache in the order they were added
+	// most recent items are on the front of the indexer;
+	// it is used to optimize cache sweeping
+	indexer *list.List
+	// item in the cache with the timestamp it's been added
+	// to the cache the last time
+	cache map[string]time.Time
+	// the timespan after which entry in the cache is considered
+	// as outdated and can be removed from the cache
 	timespan time.Duration
 	mutex    sync.RWMutex
 }

--- a/pkg/firewall/cache.go
+++ b/pkg/firewall/cache.go
@@ -53,7 +53,7 @@ func (tc *timeCache) add(item string) bool {
 		item := back.Value.(string)
 		itemTime, ok := tc.cache[item]
 		if !ok {
-			logger.Panicf(
+			logger.Errorf(
 				"inconsistent cache state - expected item [%v] is not present",
 				item,
 			)

--- a/pkg/firewall/cache.go
+++ b/pkg/firewall/cache.go
@@ -1,0 +1,77 @@
+package firewall
+
+import (
+	"container/list"
+	"sync"
+	"time"
+)
+
+// timeCache provides a time cache safe for concurrent use by
+// multiple goroutines without additional locking or coordination.
+type timeCache struct {
+	indexer  *list.List
+	cache    map[string]time.Time
+	timespan time.Duration
+	mutex    sync.RWMutex
+}
+
+// NewTimeCache creates a new cache instance with provided timespan.
+func newTimeCache(timespan time.Duration) *timeCache {
+	return &timeCache{
+		indexer:  list.New(),
+		cache:    make(map[string]time.Time),
+		timespan: timespan,
+	}
+}
+
+// Add adds an entry to the cache. Returns `true` if entry was not present in
+// the cache and was successfully added into it. Returns `false` if
+// entry is already in the cache. This method is synchronized.
+func (tc *timeCache) add(item string) bool {
+	tc.mutex.Lock()
+	defer tc.mutex.Unlock()
+
+	_, ok := tc.cache[item]
+	if ok {
+		return false
+	}
+
+	// sweep old entries
+	for {
+		back := tc.indexer.Back()
+		if back == nil {
+			break
+		}
+
+		item := back.Value.(string)
+		itemTime, ok := tc.cache[item]
+		if !ok {
+			logger.Fatalf(
+				"inconsistent cache state - expected item [%v] is not present",
+				item,
+			)
+			break
+		}
+
+		if time.Since(itemTime) > tc.timespan {
+			tc.indexer.Remove(back)
+			delete(tc.cache, item)
+		} else {
+			break
+		}
+	}
+
+	tc.cache[item] = time.Now()
+	tc.indexer.PushFront(item)
+	return true
+}
+
+// Has checks presence of an entry in the cache. Returns `true` if entry is
+// present and `false` otherwise.
+func (tc *timeCache) has(item string) bool {
+	tc.mutex.RLock()
+	defer tc.mutex.RUnlock()
+
+	_, ok := tc.cache[item]
+	return ok
+}

--- a/pkg/firewall/cache.go
+++ b/pkg/firewall/cache.go
@@ -53,7 +53,7 @@ func (tc *timeCache) add(item string) bool {
 		item := back.Value.(string)
 		itemTime, ok := tc.cache[item]
 		if !ok {
-			logger.Fatalf(
+			logger.Panicf(
 				"inconsistent cache state - expected item [%v] is not present",
 				item,
 			)

--- a/pkg/firewall/cache_test.go
+++ b/pkg/firewall/cache_test.go
@@ -1,0 +1,52 @@
+package firewall
+
+import (
+	"strconv"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestAdd(t *testing.T) {
+	cache := newTimeCache(time.Minute)
+
+	cache.add("test")
+
+	if !cache.has("test") {
+		t.Fatal("should have 'test' key")
+	}
+}
+
+func TestConcurrentAdd(t *testing.T) {
+	cache := newTimeCache(time.Minute)
+
+	var wg sync.WaitGroup
+	wg.Add(10)
+
+	for i := 0; i < 10; i++ {
+		go func(item int) {
+			cache.add(strconv.Itoa(item))
+			wg.Done()
+		}(i)
+	}
+
+	wg.Wait()
+
+	for i := 0; i < 10; i++ {
+		if !cache.has(strconv.Itoa(i)) {
+			t.Fatalf("should have '%v' key", i)
+		}
+	}
+}
+
+func TestExpiration(t *testing.T) {
+	cache := newTimeCache(500 * time.Millisecond)
+	for i := 0; i < 6; i++ {
+		cache.add(strconv.Itoa(i))
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	if cache.has(strconv.Itoa(0)) {
+		t.Fatal("should have dropped '0' key from the cache already")
+	}
+}

--- a/pkg/firewall/firewall.go
+++ b/pkg/firewall/firewall.go
@@ -28,9 +28,9 @@ var errNoAuthorization = fmt.Errorf("remote peer has no authorization on the fac
 var errNoMinStakeNoActiveKeep = fmt.Errorf("remote peer has no minimum " +
 	"stake and is not a member in any of active keeps")
 
-// NewStakeOrActiveKeepPolicy if a firewall policy checking if the remote peer
-// has a minimum stake and if it has no minimum stake if it is a member in at
-// least one active keep.
+// NewStakeOrActiveKeepPolicy is a firewall policy checking if the remote peer
+// has a minimum stake and in case it has no minimum stake if it is a member of
+// at least one active keep.
 func NewStakeOrActiveKeepPolicy(
 	chain eth.Handle,
 	stakeMonitor coreChain.StakeMonitor,

--- a/pkg/firewall/firewall.go
+++ b/pkg/firewall/firewall.go
@@ -119,7 +119,7 @@ func (soakp *stakeOrActiveKeepPolicy) validateActiveKeepMembership(
 	lastIndex := new(big.Int).Sub(keepCount, one)
 
 	for keepIndex := new(big.Int).Set(lastIndex); keepIndex.Cmp(zero) != -1; keepIndex.Sub(keepIndex, one) {
-		keep, err := soakp.chain.GetKeepAtIndex(keepIndex)
+		keepAddress, err := soakp.chain.GetKeepAtIndex(keepIndex)
 		if err != nil {
 			logger.Errorf(
 				"could not get keep at index [%v]: [%v]",
@@ -133,11 +133,11 @@ func (soakp *stakeOrActiveKeepPolicy) validateActiveKeepMembership(
 		// active, we skip it. We still need to process the rest of the keeps
 		// because it's possible that although this keep is not active some
 		// peers created before this one are still active.
-		isActive, err := soakp.chain.IsActive(keep)
+		isActive, err := soakp.chain.IsActive(keepAddress)
 		if err != nil {
 			logger.Errorf(
 				"could not check if keep [%x] is active: [%v]",
-				keepIndex,
+				keepAddress,
 				err,
 			)
 			continue
@@ -148,11 +148,11 @@ func (soakp *stakeOrActiveKeepPolicy) validateActiveKeepMembership(
 
 		// Get all the members of the active keep and store them in the active
 		// keep members cache.
-		members, err := soakp.chain.GetMembers(keep)
+		members, err := soakp.chain.GetMembers(keepAddress)
 		if err != nil {
 			logger.Errorf(
 				"could not get members of keep [%x]: [%v]",
-				keepIndex,
+				keepAddress,
 				err,
 			)
 			continue

--- a/pkg/firewall/firewall.go
+++ b/pkg/firewall/firewall.go
@@ -21,7 +21,7 @@ var logger = log.Logger("keep-firewall")
 
 // KeepCacheLifetime is the time the cache maintains the list of active keep
 // members. We use the cache to minimize calls to Ethereum client.
-const KeepCacheLifetime = 24 * time.Hour
+const KeepCacheLifetime = 168 * time.Hour // one week
 
 var errNoAuthorization = fmt.Errorf("remote peer has no authorization on the factory")
 

--- a/pkg/firewall/firewall.go
+++ b/pkg/firewall/firewall.go
@@ -65,7 +65,7 @@ func (soakp *stakeOrActiveKeepPolicy) Validate(
 	// If peer has no authorization on the factory it means it has never
 	// participated in any group selection so there is no chance it can be
 	// a member of any keep.
-	hasAuthorization, err := soakp.chain.HasAuthorization(
+	isAuthorized, err := soakp.chain.IsOperatorAuthorized(
 		common.HexToAddress(remotePeerAddress),
 	)
 	if err != nil {
@@ -76,7 +76,7 @@ func (soakp *stakeOrActiveKeepPolicy) Validate(
 		)
 	}
 
-	if !hasAuthorization {
+	if !isAuthorized {
 		return errNoAuthorization
 	}
 

--- a/pkg/firewall/firewall.go
+++ b/pkg/firewall/firewall.go
@@ -17,7 +17,7 @@ import (
 	eth "github.com/keep-network/keep-ecdsa/pkg/chain"
 )
 
-var logger = log.Logger("keep-ecdsa-firewall")
+var logger = log.Logger("keep-firewall")
 
 // KeepCacheLifetime is the time the cache maintains the list of active keep
 // members. We use the cache to minimize calls to Ethereum client.

--- a/pkg/firewall/firewall.go
+++ b/pkg/firewall/firewall.go
@@ -1,0 +1,150 @@
+package firewall
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+	"math/big"
+	"time"
+
+	"github.com/ipfs/go-log"
+
+	coreChain "github.com/keep-network/keep-core/pkg/chain"
+	coreFirewall "github.com/keep-network/keep-core/pkg/firewall"
+	coreNet "github.com/keep-network/keep-core/pkg/net"
+	coreKey "github.com/keep-network/keep-core/pkg/net/key"
+
+	eth "github.com/keep-network/keep-ecdsa/pkg/chain"
+)
+
+var logger = log.Logger("keep-ecdsa-firewall")
+
+// KeepCacheLifetime is the time the cache maintains the list of active keep
+// members. We use the cache to minimize calls to Ethereum client.
+const KeepCacheLifetime = 24 * time.Hour
+
+// NewStakeOrActiveKeepPolicy if a firewall policy checking if the remote peer
+// has a minimum stake and if it has no minimum stake if it is a member in at
+// least one active keep.
+func NewStakeOrActiveKeepPolicy(
+	chain eth.Handle,
+	stakeMonitor coreChain.StakeMonitor,
+) coreNet.Firewall {
+	return &stakeOrActiveKeepPolicy{
+		chain:                  chain,
+		minimumStakePolicy:     coreFirewall.MinimumStakePolicy(stakeMonitor),
+		activeKeepMembersCache: newTimeCache(KeepCacheLifetime),
+	}
+}
+
+type stakeOrActiveKeepPolicy struct {
+	chain                  eth.Handle
+	minimumStakePolicy     coreNet.Firewall
+	activeKeepMembersCache *timeCache
+}
+
+func (soakp *stakeOrActiveKeepPolicy) Validate(
+	remotePeerPublicKey *ecdsa.PublicKey,
+) error {
+	// Validate minimum stake policy. If the remote peer has the minimum stake,
+	// we are fine and we should let to connect.
+	if err := soakp.minimumStakePolicy.Validate(remotePeerPublicKey); err == nil {
+		return nil
+	}
+
+	// In case the remote peer has no minimum stake, we need to check if it is
+	// a member in at least one active keep. If so, we let to connect.
+	// Otherwise, we do not let to connect.
+	return soakp.validateActiveKeepMembership(remotePeerPublicKey)
+}
+
+func (soakp *stakeOrActiveKeepPolicy) validateActiveKeepMembership(
+	remotePeerPublicKey *ecdsa.PublicKey,
+) error {
+	remotePeerNetworkPublicKey := coreKey.NetworkPublic(*remotePeerPublicKey)
+	remotePeerAddress := coreKey.NetworkPubKeyToEthAddress(&remotePeerNetworkPublicKey)
+
+	// First, check in the in-memory time cache to minimize hits to ETH client.
+	// If the Keep client with the given chain address is in the cache it means
+	// it's been a member in at least one active keep the last time
+	// validateActiveKeepMembership was executed and caching period has not
+	// elapsed yet.
+	//
+	// If the caching period elapsed, this check will return false and we
+	// have to ask the chain about the current status.
+	//
+	// Similarly, if the client was not a member of an active keep the last time
+	// validateActiveKeepMembership was executed, we have to ask the chain
+	// about the current status.
+	if soakp.activeKeepMembersCache.has(remotePeerAddress) {
+		return nil
+	}
+
+	zero := big.NewInt(0)
+	one := big.NewInt(1)
+
+	// Start iterating through all keeps known to the factory starting from the
+	// ones most recently created as there is a higher chance they are active.
+	keepCount, err := soakp.chain.GetKeepCount()
+	if err != nil {
+		return fmt.Errorf("could not get keep count: [%v]", err)
+	}
+
+	lastIndex := new(big.Int).Sub(keepCount, one)
+
+	for keepIndex := new(big.Int).Set(lastIndex); keepIndex.Cmp(zero) != -1; keepIndex.Sub(keepIndex, one) {
+		keep, err := soakp.chain.GetKeepAtIndex(keepIndex)
+		if err != nil {
+			logger.Errorf(
+				"could not get keep at index [%v]: [%v]",
+				keepIndex,
+				err,
+			)
+			continue
+		}
+
+		// We are interested only in active keeps. If the current keep is not
+		// active, we skip it. We still need to process the rest of the keeps
+		// because it's possible that although this keep is not active some
+		// peers created before this one are still active.
+		isActive, err := soakp.chain.IsActive(keep)
+		if err != nil {
+			logger.Warningf(
+				"could not check if keep [%x] is active: [%v]",
+				keepIndex,
+				err,
+			)
+			continue
+		}
+		if !isActive {
+			continue
+		}
+
+		// Get all the members of the active keep and store them in the active
+		// keep members cache.
+		members, err := soakp.chain.GetMembers(keep)
+		if err != nil {
+			logger.Errorf(
+				"could not get members of keep [%x]: [%v]",
+				keepIndex,
+				err,
+			)
+			continue
+		}
+		for _, member := range members {
+			soakp.activeKeepMembersCache.add(member.String())
+		}
+
+		// If the remote peer address has been added to the cache we can
+		// connect with this client as it's a member of an active keep.
+		if soakp.activeKeepMembersCache.has(remotePeerAddress) {
+			return nil
+		}
+	}
+
+	// If we are here, it means that the client is not a member in any of
+	// active keeps and it's minimum stake check failed as well. We are not
+	// allowing to connect with that peer.
+	return fmt.Errorf(
+		"remote peer has no minimum stake and is not a member in any of active keeps",
+	)
+}

--- a/pkg/firewall/firewall.go
+++ b/pkg/firewall/firewall.go
@@ -22,6 +22,9 @@ var logger = log.Logger("keep-ecdsa-firewall")
 // members. We use the cache to minimize calls to Ethereum client.
 const KeepCacheLifetime = 24 * time.Hour
 
+var errNoMinStakeNoActiveKeep = fmt.Errorf("remote peer has no minimum " +
+	"stake and is not a member in any of active keeps")
+
 // NewStakeOrActiveKeepPolicy if a firewall policy checking if the remote peer
 // has a minimum stake and if it has no minimum stake if it is a member in at
 // least one active keep.
@@ -108,7 +111,7 @@ func (soakp *stakeOrActiveKeepPolicy) validateActiveKeepMembership(
 		// peers created before this one are still active.
 		isActive, err := soakp.chain.IsActive(keep)
 		if err != nil {
-			logger.Warningf(
+			logger.Errorf(
 				"could not check if keep [%x] is active: [%v]",
 				keepIndex,
 				err,
@@ -144,7 +147,5 @@ func (soakp *stakeOrActiveKeepPolicy) validateActiveKeepMembership(
 	// If we are here, it means that the client is not a member in any of
 	// active keeps and it's minimum stake check failed as well. We are not
 	// allowing to connect with that peer.
-	return fmt.Errorf(
-		"remote peer has no minimum stake and is not a member in any of active keeps",
-	)
+	return errNoMinStakeNoActiveKeep
 }

--- a/pkg/firewall/firewall_test.go
+++ b/pkg/firewall/firewall_test.go
@@ -1,0 +1,228 @@
+package firewall
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/keep-network/keep-core/pkg/net/key"
+	"github.com/keep-network/keep-ecdsa/pkg/chain/local"
+)
+
+var cacheLifeTime = time.Second
+
+func TestHasMinimumStake(t *testing.T) {
+	chain := local.Connect()
+	coreFirewall := newMockCoreFirewall()
+	policy := &stakeOrActiveKeepPolicy{
+		chain:                  chain,
+		minimumStakePolicy:     coreFirewall,
+		activeKeepMembersCache: newTimeCache(cacheLifeTime),
+	}
+
+	_, remotePeerPublicKey, err := key.GenerateStaticNetworkKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	coreFirewall.updatePeer(remotePeerPublicKey, true)
+
+	if err := policy.Validate(
+		key.NetworkKeyToECDSAKey(remotePeerPublicKey),
+	); err != nil {
+		t.Fatalf("validation should pass: [%v]", err)
+	}
+}
+
+func TestNoMinimumStakeNoKeepsExist(t *testing.T) {
+	chain := local.Connect()
+	coreFirewall := newMockCoreFirewall()
+	policy := &stakeOrActiveKeepPolicy{
+		chain:                  chain,
+		minimumStakePolicy:     coreFirewall,
+		activeKeepMembersCache: newTimeCache(cacheLifeTime),
+	}
+
+	_, remotePeerPublicKey, err := key.GenerateStaticNetworkKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := policy.Validate(
+		key.NetworkKeyToECDSAKey(remotePeerPublicKey),
+	); err != errNoMinStakeNoActiveKeep {
+		t.Fatalf(
+			"unexpected validation error\nactual:   [%v]\nexpected: [%v]",
+			err,
+			errNoMinStakeNoActiveKeep,
+		)
+	}
+}
+
+func TestNoMinimumStakeIsNotKeepMember(t *testing.T) {
+	chain := local.Connect()
+	coreFirewall := newMockCoreFirewall()
+	policy := &stakeOrActiveKeepPolicy{
+		chain:                  chain,
+		minimumStakePolicy:     coreFirewall,
+		activeKeepMembersCache: newTimeCache(cacheLifeTime),
+	}
+
+	_, remotePeerPublicKey, err := key.GenerateStaticNetworkKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	chain.OpenKeep(
+		common.HexToAddress("0xD6e148Be1E36Fc4Be9FE5a1abD7b3103ED527256"),
+		[]common.Address{
+			common.HexToAddress("0x4f7C771Ab173bEc2BbE980497111866383a21172"),
+			common.HexToAddress("0x65ea55c1f10491038425725dc00dffeab2a1e28a"),
+		},
+	)
+
+	if err := policy.Validate(
+		key.NetworkKeyToECDSAKey(remotePeerPublicKey),
+	); err != errNoMinStakeNoActiveKeep {
+		t.Fatalf(
+			"unexpected validation error\nactual:   [%v]\nexpected: [%v]",
+			err,
+			errNoMinStakeNoActiveKeep,
+		)
+	}
+}
+
+func TestNoMinimumStakeIsActiveKeepMember(t *testing.T) {
+	chain := local.Connect()
+	coreFirewall := newMockCoreFirewall()
+	policy := &stakeOrActiveKeepPolicy{
+		chain:                  chain,
+		minimumStakePolicy:     coreFirewall,
+		activeKeepMembersCache: newTimeCache(cacheLifeTime),
+	}
+
+	_, remotePeerPublicKey, err := key.GenerateStaticNetworkKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	chain.OpenKeep(
+		common.HexToAddress("0xD6e148Be1E36Fc4Be9FE5a1abD7b3103ED527256"),
+		[]common.Address{
+			common.HexToAddress("0x4f7C771Ab173bEc2BbE980497111866383a21172"),
+			common.HexToAddress(key.NetworkPubKeyToEthAddress(remotePeerPublicKey)),
+		},
+	)
+
+	if err := policy.Validate(
+		key.NetworkKeyToECDSAKey(remotePeerPublicKey),
+	); err != nil {
+		t.Fatalf("validation should pass: [%v]", err)
+	}
+}
+
+func TestNoMinimumStakeIsClosedKeepMember(t *testing.T) {
+	chain := local.Connect()
+	coreFirewall := newMockCoreFirewall()
+	policy := &stakeOrActiveKeepPolicy{
+		chain:                  chain,
+		minimumStakePolicy:     coreFirewall,
+		activeKeepMembersCache: newTimeCache(cacheLifeTime),
+	}
+
+	_, remotePeerPublicKey, err := key.GenerateStaticNetworkKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	keepAddress := common.HexToAddress("0xD6e148Be1E36Fc4Be9FE5a1abD7b3103ED527256")
+	chain.OpenKeep(
+		keepAddress,
+		[]common.Address{
+			common.HexToAddress("0x4f7C771Ab173bEc2BbE980497111866383a21172"),
+			common.HexToAddress(key.NetworkPubKeyToEthAddress(remotePeerPublicKey)),
+		},
+	)
+	if err := chain.CloseKeep(keepAddress); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := policy.Validate(
+		key.NetworkKeyToECDSAKey(remotePeerPublicKey),
+	); err != errNoMinStakeNoActiveKeep {
+		t.Fatalf(
+			"unexpected validation error\nactual:   [%v]\nexpected: [%v]",
+			err,
+			errNoMinStakeNoActiveKeep,
+		)
+	}
+}
+
+func TestNoMinimumStakeMultipleKeepsMember(t *testing.T) {
+	chain := local.Connect()
+	coreFirewall := newMockCoreFirewall()
+	policy := &stakeOrActiveKeepPolicy{
+		chain:                  chain,
+		minimumStakePolicy:     coreFirewall,
+		activeKeepMembersCache: newTimeCache(cacheLifeTime),
+	}
+
+	_, remotePeerPublicKey, err := key.GenerateStaticNetworkKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	keep1Address := common.HexToAddress("0xD6e148Be1E36Fc4Be9FE5a1abD7b3103ED527256")
+	chain.OpenKeep(
+		keep1Address,
+		[]common.Address{
+			common.HexToAddress("0x4f7C771Ab173bEc2BbE980497111866383a21172"),
+			common.HexToAddress(key.NetworkPubKeyToEthAddress(remotePeerPublicKey)),
+		},
+	)
+	keep2Address := common.HexToAddress("0x1Ca1EB1CafF6B3784Fe28a1b12266a10D04626A0")
+	chain.OpenKeep(
+		keep2Address,
+		[]common.Address{
+			common.HexToAddress("0xF9798F39CfEf21931d3B5F73aF67718ae569a73e"),
+			common.HexToAddress(key.NetworkPubKeyToEthAddress(remotePeerPublicKey)),
+		},
+	)
+
+	if err := chain.CloseKeep(keep1Address); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := policy.Validate(
+		key.NetworkKeyToECDSAKey(remotePeerPublicKey),
+	); err != nil {
+		t.Fatalf("validation should pass: [%v]", err)
+	}
+}
+
+func newMockCoreFirewall() *mockCoreFirewall {
+	return &mockCoreFirewall{
+		meetsCriteria: make(map[uint64]bool),
+	}
+}
+
+type mockCoreFirewall struct {
+	meetsCriteria map[uint64]bool
+}
+
+func (mf *mockCoreFirewall) Validate(remotePeerPublicKey *ecdsa.PublicKey) error {
+	if !mf.meetsCriteria[remotePeerPublicKey.X.Uint64()] {
+		return fmt.Errorf("remote peer does not meet firewall criteria")
+	}
+	return nil
+}
+
+func (mf *mockCoreFirewall) updatePeer(
+	remotePeerPublicKey *key.NetworkPublic,
+	meetsCriteria bool,
+) {
+	x := key.NetworkKeyToECDSAKey(remotePeerPublicKey).X.Uint64()
+	mf.meetsCriteria[x] = meetsCriteria
+}

--- a/solidity/contracts/BondedECDSAKeepFactory.sol
+++ b/solidity/contracts/BondedECDSAKeepFactory.sol
@@ -450,7 +450,11 @@ contract BondedECDSAKeepFactory is
     /// @param _operator operator's address
     /// @return True if the factory has access to the staked token balance of
     /// the provided operator and can slash that stake. False otherwise.
-    function hasAuthorization(address _operator) public view returns (bool) {
+    function isOperatorAuthorized(address _operator)
+        public
+        view
+        returns (bool)
+    {
         return tokenStaking.isAuthorizedForOperator(_operator, address(this));
     }
 

--- a/solidity/contracts/BondedECDSAKeepFactory.sol
+++ b/solidity/contracts/BondedECDSAKeepFactory.sol
@@ -429,7 +429,7 @@ contract BondedECDSAKeepFactory is
         reseedPool = reseedPool.sub(beaconFee);
     }
 
-    /// @dev Checks if the specified account has enough active stake to become
+    /// @notice Checks if the specified account has enough active stake to become
     /// network operator and that this contract has been authorized for potential
     /// slashing.
     ///
@@ -444,7 +444,17 @@ contract BondedECDSAKeepFactory is
         return tokenStaking.hasMinimumStake(_operator, address(this));
     }
 
-    /// @dev Gets the stake balance of the specified operator.
+    /// @notice Checks if the factory has the authorization to operate on stake
+    /// represented by the provided operator.
+    ///
+    /// @param _operator operator's address
+    /// @return True if the factory has access to the staked token balance of
+    /// the provided operator and can slash that stake. False otherwise.
+    function hasAuthorization(address _operator) public view returns (bool) {
+        return tokenStaking.isAuthorizedForOperator(_operator, address(this));
+    }
+
+    /// @notice Gets the stake balance of the specified operator.
     /// @param _operator The operator to query the balance of.
     /// @return An uint256 representing the amount staked by the passed operator.
     function balanceOf(address _operator) public view returns (uint256) {

--- a/solidity/test/BondedECDSAKeepFactoryTest.js
+++ b/solidity/test/BondedECDSAKeepFactoryTest.js
@@ -1368,7 +1368,7 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
     })
   })
 
-  describe("hasAuthorization", async () => {
+  describe("isOperatorAuthorized", async () => {
     before(async () => {
       await initializeNewFactory()
       await initializeMemberCandidates()
@@ -1376,14 +1376,14 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
 
     it("returns true if operator authorized the factory", async () => {
       assert.isTrue(
-        await keepFactory.hasAuthorization(members[0]),
+        await keepFactory.isOperatorAuthorized(members[0]),
         "the operator has authorized the factory"
       )
     })
 
     it("returns false if operator has not authorized the factory", async () => {
       assert.isFalse(
-        await keepFactory.hasAuthorization(notMember),
+        await keepFactory.isOperatorAuthorized(notMember),
         "the operator has not authorized the factory"
       )
     })

--- a/solidity/test/BondedECDSAKeepFactoryTest.js
+++ b/solidity/test/BondedECDSAKeepFactoryTest.js
@@ -38,8 +38,9 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
   const application = accounts[1]
   const members = [accounts[2], accounts[3], accounts[4]]
   const authorizers = [members[0], members[1], members[2]]
+  const notMember = accounts[5]
 
-  const keepOwner = accounts[5]
+  const keepOwner = accounts[6]
 
   const groupSize = new BN(members.length)
   const threshold = groupSize
@@ -1363,6 +1364,27 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
         keep1.address,
         atIndex1,
         "incorrect keep address returned for index 1"
+      )
+    })
+  })
+
+  describe("hasAuthorization", async () => {
+    before(async () => {
+      await initializeNewFactory()
+      await initializeMemberCandidates()
+    })
+
+    it("returns true if operator authorized the factory", async () => {
+      assert.isTrue(
+        await keepFactory.hasAuthorization(members[0]),
+        "the operator has authorized the factory"
+      )
+    })
+
+    it("returns false if operator has not authorized the factory", async () => {
+      assert.isFalse(
+        await keepFactory.hasAuthorization(notMember),
+        "the operator has not authorized the factory"
       )
     })
   })

--- a/solidity/test/BondedECDSAKeepFactoryTest.js
+++ b/solidity/test/BondedECDSAKeepFactoryTest.js
@@ -1374,17 +1374,17 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
       await initializeMemberCandidates()
     })
 
-    it("returns true if operator authorized the factory", async () => {
+    it("returns true if operator is authorized for the factory", async () => {
       assert.isTrue(
         await keepFactory.isOperatorAuthorized(members[0]),
-        "the operator has authorized the factory"
+        "the operator is authorized for the factory"
       )
     })
 
-    it("returns false if operator has not authorized the factory", async () => {
+    it("returns false if operator is not authorized for the factory", async () => {
       assert.isFalse(
         await keepFactory.isOperatorAuthorized(notMember),
-        "the operator has not authorized the factory"
+        "the operator is not authorized for the factory"
       )
     })
   })


### PR DESCRIPTION
Closes https://github.com/keep-network/keep-core/issues/1588
Depends on https://github.com/keep-network/keep-core/pull/1612

For ECDSA keep client, we always connect with another client if it has a minimum stake. In a situation when the remote client has no minimum stake we should check if it is a member in at least one active keep. If so, we should allow establishing the connection.

The reason for that is to allow the client to participate in any outstanding signing in case it's been slashed, most probably by the beacon. The client with no minimum stake is not eligible to be selected to new ECDSA keeps but it can still participate in signing in existing keeps it's a member of.

Figuring out if the given client is a member in at least one active keep will take a bunch of calls to Ethereum client and to minimize them for every single firewall check tick, we cache the result in-memory for 24 hours.