### PR TITLE
Log messages improvements

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -90,8 +90,9 @@ func Initialize(
 			isActive, err := ethereumChain.IsActive(keepAddress)
 			if err != nil {
 				logger.Errorf(
-					"failed to verify if keep is still active: [%v]; "+
+					"failed to verify if keep [%s] is still active: [%v]; "+
 						"subscriptions for keep signing and closing events are skipped",
+					keepAddress.String(),
 					err,
 				)
 				return
@@ -246,8 +247,7 @@ func checkAwaitingKeyGeneration(
 		keygenTimeout, err := ethereumChain.HasKeyGenerationTimedOut(keep)
 		if err != nil {
 			logger.Warningf(
-				"could not check key generation timeout "+
-					"for keep [%v]: [%v]",
+				"could not check key generation timeout for keep [%s]: [%v]",
 				keep.String(),
 				err,
 			)
@@ -272,8 +272,7 @@ func checkAwaitingKeyGeneration(
 		)
 		if err != nil {
 			logger.Warningf(
-				"could not check awaiting key generation "+
-					"for keep [%s]: [%v]",
+				"could not check awaiting key generation for keep [%s]: [%v]",
 				keep.String(),
 				err,
 			)
@@ -583,7 +582,11 @@ func generateSignatureForKeep(
 		signer,
 		digest,
 	); err != nil {
-		logger.Errorf("signature calculation failed: [%v]", err)
+		logger.Errorf(
+			"signature calculation failed for keep [%s]: [%v]",
+			keepAddress.String(),
+			err,
+		)
 	}
 }
 
@@ -634,7 +637,8 @@ func monitorKeepClosedEvents(
 	)
 	if err != nil {
 		logger.Errorf(
-			"failed on registering for keep closed event: [%v]",
+			"failed on registering for closed event for keep [%s]: [%v]",
+			keepAddress.String(),
 			err,
 		)
 
@@ -696,7 +700,8 @@ func monitorKeepTerminatedEvent(
 	)
 	if err != nil {
 		logger.Errorf(
-			"failed on registering for keep terminated event: [%v]",
+			"failed on registering for terminated event for keep [%s]: [%v]",
+			keepAddress.String(),
 			err,
 		)
 

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -332,7 +332,7 @@ func (n *Node) publishSignature(
 			attemptCounter,
 		)
 
-		if err := n.ethereumChain.SubmitSignature(keepAddress, signature); err != nil {
+		if submissionErr := n.ethereumChain.SubmitSignature(keepAddress, signature); submissionErr != nil {
 			isAwaitingSignature, err := n.ethereumChain.IsAwaitingSignature(keepAddress, digest)
 			if err != nil {
 				logger.Errorf(
@@ -360,7 +360,7 @@ func (n *Node) publishSignature(
 				"failed to submit signature for keep [%s]: [%v]; "+
 					"will retry after 1 minute",
 				keepAddress.String(),
-				err,
+				submissionErr,
 			)
 			time.Sleep(1 * time.Minute)
 			continue


### PR DESCRIPTION
Two major changes in this PR:
1. Added keep address to logged messages
  Having a keep address in these logs is useful for tracking processes
execution.
2. Fixed logging of submission signature error
  If there was an error for `SubmitSignature` we were checking `IsAwaitingSignature` and the result had been overwriting the error received from the `SubmitSignature` function call. If execution got up to `failed to submit signature for keep` to log the error logged, the logged error was `nil` as it was replaced by `IsAwaitingSignature` error. Here we update the variable name so it is unique and won't get overwritten.