### PR TITLE
Adding a delay of 1 sec in retry loops

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -312,6 +312,7 @@ func (n *Node) publishSignature(
 				keepAddress.String(),
 				err,
 			)
+			time.Sleep(retryDelay)
 			continue
 		}
 		if hasSigningTimedOut {
@@ -332,6 +333,7 @@ func (n *Node) publishSignature(
 				keepAddress.String(),
 				err,
 			)
+			time.Sleep(retryDelay)
 			continue
 		}
 
@@ -360,6 +362,7 @@ func (n *Node) publishSignature(
 					keepAddress.String(),
 					err,
 				)
+				time.Sleep(retryDelay)
 				continue
 			}
 

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -24,6 +24,7 @@ import (
 var logger = log.Logger("keep-ecdsa")
 
 const monitorKeepPublicKeySubmissionTimeout = 30 * time.Minute
+const retryDelay = time.Second
 
 // Node holds interfaces to interact with the blockchain and network messages
 // transport layer.
@@ -154,7 +155,7 @@ func (n *Node) GenerateSignerForKeep(
 		)
 		if err != nil {
 			logger.Warningf("failed to announce signer presence: [%v]", err)
-			time.Sleep(time.Second)
+			time.Sleep(retryDelay)
 			continue
 		}
 
@@ -173,7 +174,7 @@ func (n *Node) GenerateSignerForKeep(
 		)
 		if err != nil {
 			logger.Errorf("failed to generate threshold signer: [%v]", err)
-			time.Sleep(time.Second)
+			time.Sleep(retryDelay)
 			continue
 		}
 
@@ -257,7 +258,7 @@ func (n *Node) CalculateSignature(
 				keepAddress.String(),
 				err,
 			)
-			time.Sleep(time.Second)
+			time.Sleep(retryDelay)
 			continue
 		}
 

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -154,6 +154,7 @@ func (n *Node) GenerateSignerForKeep(
 		)
 		if err != nil {
 			logger.Warningf("failed to announce signer presence: [%v]", err)
+			time.Sleep(time.Second)
 			continue
 		}
 
@@ -172,6 +173,7 @@ func (n *Node) GenerateSignerForKeep(
 		)
 		if err != nil {
 			logger.Errorf("failed to generate threshold signer: [%v]", err)
+			time.Sleep(time.Second)
 			continue
 		}
 
@@ -255,6 +257,7 @@ func (n *Node) CalculateSignature(
 				keepAddress.String(),
 				err,
 			)
+			time.Sleep(time.Second)
 			continue
 		}
 

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -24,7 +24,7 @@ import (
 var logger = log.Logger("keep-ecdsa")
 
 const monitorKeepPublicKeySubmissionTimeout = 30 * time.Minute
-const retryDelay = time.Second
+const retryDelay = 1 * time.Second
 
 // Node holds interfaces to interact with the blockchain and network messages
 // transport layer.

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -155,7 +155,7 @@ func (n *Node) GenerateSignerForKeep(
 		)
 		if err != nil {
 			logger.Warningf("failed to announce signer presence: [%v]", err)
-			time.Sleep(retryDelay)
+			time.Sleep(retryDelay) // TODO: #413 Replace with backoff.
 			continue
 		}
 
@@ -174,7 +174,7 @@ func (n *Node) GenerateSignerForKeep(
 		)
 		if err != nil {
 			logger.Errorf("failed to generate threshold signer: [%v]", err)
-			time.Sleep(retryDelay)
+			time.Sleep(retryDelay) // TODO: #413 Replace with backoff.
 			continue
 		}
 
@@ -258,7 +258,7 @@ func (n *Node) CalculateSignature(
 				keepAddress.String(),
 				err,
 			)
-			time.Sleep(retryDelay)
+			time.Sleep(retryDelay) // TODO: #413 Replace with backoff.
 			continue
 		}
 
@@ -312,7 +312,7 @@ func (n *Node) publishSignature(
 				keepAddress.String(),
 				err,
 			)
-			time.Sleep(retryDelay)
+			time.Sleep(retryDelay) // TODO: #413 Replace with backoff.
 			continue
 		}
 		if hasSigningTimedOut {
@@ -333,7 +333,7 @@ func (n *Node) publishSignature(
 				keepAddress.String(),
 				err,
 			)
-			time.Sleep(retryDelay)
+			time.Sleep(retryDelay) // TODO: #413 Replace with backoff.
 			continue
 		}
 
@@ -362,7 +362,7 @@ func (n *Node) publishSignature(
 					keepAddress.String(),
 					err,
 				)
-				time.Sleep(retryDelay)
+				time.Sleep(retryDelay) // TODO: #413 Replace with backoff.
 				continue
 			}
 


### PR DESCRIPTION
Closes: https://github.com/keep-network/keep-ecdsa/issues/395

Adding a short delay interval of 1 sec. upon failure when calculating a signature and signer generation.