### PR TITLE
Requiring group size and threshold to be > 0

### DIFF
--- a/solidity/contracts/BondedECDSAKeepFactory.sol
+++ b/solidity/contracts/BondedECDSAKeepFactory.sol
@@ -239,9 +239,12 @@ contract BondedECDSAKeepFactory is
         uint256 _bond,
         uint256 _stakeLockDuration
     ) external payable returns (address keepAddress) {
-        require(_groupSize > 0, "Minimum signing group size must be greater than 0");
+        require(_groupSize > 0, "Minimum signing group size is 1");
         require(_groupSize <= 16, "Maximum signing group size is 16");
-        require(_honestThreshold > 0, "Honest threshold must be greater than 0");
+        require(
+            _honestThreshold > 0,
+            "Honest threshold must be greater than 0"
+        );
         require(
             _honestThreshold <= _groupSize,
             "Honest threshold must be less or equal the group size"

--- a/solidity/contracts/BondedECDSAKeepFactory.sol
+++ b/solidity/contracts/BondedECDSAKeepFactory.sol
@@ -239,7 +239,9 @@ contract BondedECDSAKeepFactory is
         uint256 _bond,
         uint256 _stakeLockDuration
     ) external payable returns (address keepAddress) {
+        require(_groupSize > 0, "Minimum signing group size must be greater than 0");
         require(_groupSize <= 16, "Maximum signing group size is 16");
+        require(_honestThreshold > 0, "Honest threshold must be greater than 0");
         require(
             _honestThreshold <= _groupSize,
             "Honest threshold must be less or equal the group size"

--- a/solidity/test/BondedECDSAKeepFactoryTest.js
+++ b/solidity/test/BondedECDSAKeepFactoryTest.js
@@ -926,6 +926,25 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
       )
     })
 
+    it("reverts when honest threshold is 0", async () => {
+      const honestThreshold = 0
+
+      await expectRevert(
+        keepFactory.openKeep(
+          groupSize,
+          honestThreshold,
+          keepOwner,
+          bond,
+          stakeLockDuration,
+          {
+            from: application,
+            value: feeEstimate,
+          }
+        ),
+        "Honest threshold must be greater than 0"
+      )
+    })
+
     it("works when honest threshold is equal to the group size", async () => {
       const honestThreshold = 3
       const groupSize = honestThreshold
@@ -1077,6 +1096,25 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
           }
         ),
         "Maximum signing group size is 16"
+      )
+    })
+
+    it("reverts when trying to use a group of 0 signers", async () => {
+      const groupSize = 0
+
+      await expectRevert(
+        keepFactory.openKeep(
+          groupSize,
+          threshold,
+          keepOwner,
+          bond,
+          stakeLockDuration,
+          {
+            from: application,
+            value: feeEstimate,
+          }
+        ),
+        "Minimum signing group size must be greater than 0"
       )
     })
 

--- a/solidity/test/BondedECDSAKeepFactoryTest.js
+++ b/solidity/test/BondedECDSAKeepFactoryTest.js
@@ -1114,7 +1114,7 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
             value: feeEstimate,
           }
         ),
-        "Minimum signing group size must be greater than 0"
+        "Minimum signing group size is 1"
       )
     })
 


### PR DESCRIPTION
Refs: https://github.com/keep-network/keep-ecdsa/issues/392

It is not possible to create a group with `0` members. Similarly, it is not possible to create a group with `0` honest threshold. Added appropriate validations to `openKeep` contract functions.