### PR TITLE
Check for signing request confirmations from the block it was requested

### DIFF
--- a/pkg/chain/chain.go
+++ b/pkg/chain/chain.go
@@ -121,8 +121,9 @@ type BondedECDSAKeep interface {
 	// LatestDigest returns the latest digest requested to be signed.
 	LatestDigest(keepAddress common.Address) ([32]byte, error)
 
-	// SignatureRequestedBlock returns block number from the moment when a signature
-	// was requested for the given digest from a keep.
+	// SignatureRequestedBlock returns block number from the moment when a
+	// signature was requested for the given digest from a keep.
+	// If a signature was not requested for the given digest, returns 0.
 	SignatureRequestedBlock(keepAddress common.Address, digest [32]byte) (uint64, error)
 
 	// GetPublicKey returns keep's public key. If there is no public key yet,

--- a/pkg/chain/chain.go
+++ b/pkg/chain/chain.go
@@ -3,11 +3,12 @@
 package eth
 
 import (
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/keep-network/keep-common/pkg/subscription"
 	"github.com/keep-network/keep-core/pkg/chain"
 	"github.com/keep-network/keep-ecdsa/pkg/ecdsa"
-	"math/big"
 )
 
 // Handle represents a handle to an ethereum blockchain.
@@ -119,6 +120,10 @@ type BondedECDSAKeep interface {
 
 	// LatestDigest returns the latest digest requested to be signed.
 	LatestDigest(keepAddress common.Address) ([32]byte, error)
+
+	// SignatureRequestedBlock returns block number from the moment when a signature
+	// was requested for the given digest from a keep.
+	SignatureRequestedBlock(keepAddress common.Address, digest [32]byte) (uint64, error)
 
 	// GetPublicKey returns keep's public key. If there is no public key yet,
 	// an empty slice is returned.

--- a/pkg/chain/ethereum/ethereum.go
+++ b/pkg/chain/ethereum/ethereum.go
@@ -384,6 +384,23 @@ func (ec *EthereumChain) LatestDigest(keepAddress common.Address) ([32]byte, err
 	return keepContract.Digest()
 }
 
+func (ec *EthereumChain) SignatureRequestedBlock(
+	keepAddress common.Address,
+	digest [32]byte,
+) (uint64, error) {
+	keepContract, err := ec.getKeepContract(keepAddress)
+	if err != nil {
+		return 0, err
+	}
+
+	blockNumber, err := keepContract.Digests(digest)
+	if err != nil {
+		return 0, err
+	}
+
+	return blockNumber.Uint64(), nil
+}
+
 func (ec *EthereumChain) GetPublicKey(keepAddress common.Address) ([]uint8, error) {
 	keepContract, err := ec.getKeepContract(keepAddress)
 	if err != nil {

--- a/pkg/chain/local/local.go
+++ b/pkg/chain/local/local.go
@@ -212,6 +212,13 @@ func (lc *localChain) LatestDigest(keepAddress common.Address) ([32]byte, error)
 	panic("implement")
 }
 
+func (lc *localChain) SignatureRequestedBlock(
+	keepAddress common.Address,
+	digest [32]byte,
+) (uint64, error) {
+	panic("implement")
+}
+
 func (lc *localChain) GetPublicKey(keepAddress common.Address) ([]uint8, error) {
 	panic("implement")
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -532,15 +532,15 @@ func checkAwaitingSignature(
 		}
 		defer requestedSignatures.remove(keepAddress, latestDigest)
 
-		currentBlock, err := ethereumChain.BlockCounter().CurrentBlock()
+		startBlock, err := ethereumChain.SignatureRequestedBlock(keepAddress, latestDigest)
 		if err != nil {
-			logger.Errorf("failed to get current block height: [%v]", err)
+			logger.Errorf("failed to get signature request block height: [%v]", err)
 			return
 		}
 
 		isStillAwaitingSignature, err := waitForChainConfirmation(
 			ethereumChain,
-			currentBlock,
+			startBlock,
 			func() (bool, error) {
 				return ethereumChain.IsAwaitingSignature(keepAddress, latestDigest)
 			},

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -534,7 +534,12 @@ func checkAwaitingSignature(
 
 		startBlock, err := ethereumChain.SignatureRequestedBlock(keepAddress, latestDigest)
 		if err != nil {
-			logger.Errorf("failed to get signature request block height: [%v]", err)
+			logger.Errorf(
+				"failed to get signature request block height for keep [%s] and digest [%x]: [%v]",
+				keepAddress.String(),
+				latestDigest,
+				err,
+			)
 			return
 		}
 

--- a/solidity/contracts/BondedECDSAKeep.sol
+++ b/solidity/contracts/BondedECDSAKeep.sol
@@ -51,8 +51,9 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
     // Latest digest requested to be signed. Used to validate submitted signature.
     bytes32 public digest;
 
-    // Map of all digests requested to be signed. Used to validate submitted signature.
-    // Holds block number from the moment when a signature was requested.
+    // Map of all digests requested to be signed. Used to validate submitted
+    // signature. Holds the block number at which the signature over the given
+    // digest was requested
     mapping(bytes32 => uint256) public digests;
 
     // Timeout for the keep public key to appear on the chain. Time is counted

--- a/solidity/contracts/BondedECDSAKeep.sol
+++ b/solidity/contracts/BondedECDSAKeep.sol
@@ -52,7 +52,8 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
     bytes32 public digest;
 
     // Map of all digests requested to be signed. Used to validate submitted signature.
-    mapping(bytes32 => bool) digests;
+    // Holds block number from the moment when a signature was requested.
+    mapping(bytes32 => uint256) public digests;
 
     // Timeout for the keep public key to appear on the chain. Time is counted
     // from the moment keep has been created.
@@ -210,7 +211,7 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
         /* solium-disable-next-line */
         signingStartTimestamp = block.timestamp;
 
-        digests[_digest] = true;
+        digests[_digest] = block.number;
         digest = _digest;
 
         emit SignatureRequested(_digest);
@@ -571,7 +572,7 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
             ecrecover(_signedDigest, _v, _r, _s);
 
         // Check if the signature is valid but was not requested.
-        return isSignatureValid && !digests[_signedDigest];
+        return isSignatureValid && digests[_signedDigest] == 0;
     }
 
     /// @notice Returns true if the ongoing key generation process timed out.

--- a/solidity/test/BondedECDSAKeepTest.js
+++ b/solidity/test/BondedECDSAKeepTest.js
@@ -235,6 +235,18 @@ contract("BondedECDSAKeep", (accounts) => {
       })
     })
 
+    it("sets block number for digest", async () => {
+      await submitMembersPublicKeys(publicKey)
+
+      const signTx = await keep.sign(digest, {from: owner})
+
+      const blockNumber = await keep.digests.call(digest)
+
+      expect(blockNumber, "incorrect block number").to.eq.BN(
+        signTx.receipt.blockNumber
+      )
+    })
+
     it("cannot be requested if keep is closed", async () => {
       await createMembersBonds(keep)
 


### PR DESCRIPTION
Currently, we check for signing request confirmation starting from the current block when starting the client. This may cause the client to wait too long compared to other members. In this PR we store request's block number for each digest and use it as starting point for waiting for confirmations.

Closes https://github.com/keep-network/keep-ecdsa/issues/403