### PR TITLE
Abort signing when signing timeout has passed

### DIFF
--- a/pkg/chain/chain.go
+++ b/pkg/chain/chain.go
@@ -3,11 +3,12 @@
 package eth
 
 import (
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/keep-network/keep-common/pkg/subscription"
 	"github.com/keep-network/keep-core/pkg/chain"
 	"github.com/keep-network/keep-ecdsa/pkg/ecdsa"
-	"math/big"
 )
 
 // Handle represents a handle to an ethereum blockchain.
@@ -112,6 +113,9 @@ type BondedECDSAKeep interface {
 	// IsAwaitingSignature checks if the keep is waiting for a signature to be
 	// calculated for the given digest.
 	IsAwaitingSignature(keepAddress common.Address, digest [32]byte) (bool, error)
+
+	// HasSigningTimedOut checks if signing has timed out for keep.
+	HasSigningTimedOut(keepAddress common.Address) (bool, error)
 
 	// IsActive checks if the keep with the given address is active and responds
 	// to signing request. This function returns false only for closed keeps.

--- a/pkg/chain/chain.go
+++ b/pkg/chain/chain.go
@@ -114,7 +114,9 @@ type BondedECDSAKeep interface {
 	// calculated for the given digest.
 	IsAwaitingSignature(keepAddress common.Address, digest [32]byte) (bool, error)
 
-	// HasSigningTimedOut checks if signing has timed out for keep.
+	// HasSigningTimedOut checks if the ongoing signing process timed out for
+	// the keep. If there is no ongoing signing for the keep or if the ongoing
+	// signing process has not timed out yet, this function returns false.
 	HasSigningTimedOut(keepAddress common.Address) (bool, error)
 
 	// IsActive checks if the keep with the given address is active and responds

--- a/pkg/chain/ethereum/connect.go
+++ b/pkg/chain/ethereum/connect.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/keep-network/keep-common/pkg/chain/ethereum"
 	"github.com/keep-network/keep-common/pkg/chain/ethereum/blockcounter"
-	"github.com/keep-network/keep-ecdsa/pkg/chain"
+	eth "github.com/keep-network/keep-ecdsa/pkg/chain"
 	"github.com/keep-network/keep-ecdsa/pkg/chain/gen/contract"
 )
 

--- a/pkg/chain/ethereum/ethereum.go
+++ b/pkg/chain/ethereum/ethereum.go
@@ -301,6 +301,16 @@ func (ec *EthereumChain) IsAwaitingSignature(keepAddress common.Address, digest 
 	return keepContract.IsAwaitingSignature(digest)
 }
 
+// HasSigningTimedOut checks if signing has timed out for keep.
+func (ec *EthereumChain) HasSigningTimedOut(keepAddress common.Address) (bool, error) {
+	keepContract, err := ec.getKeepContract(keepAddress)
+	if err != nil {
+		return false, err
+	}
+
+	return keepContract.HasSigningTimedOut()
+}
+
 // IsActive checks for current state of a keep on-chain.
 func (ec *EthereumChain) IsActive(keepAddress common.Address) (bool, error) {
 	keepContract, err := ec.getKeepContract(keepAddress)

--- a/pkg/chain/local/local.go
+++ b/pkg/chain/local/local.go
@@ -145,6 +145,11 @@ func (lc *localChain) IsAwaitingSignature(
 	panic("implement")
 }
 
+// HasSigningTimedOut checks if signing has timed out for keep.
+func (lc *localChain) HasSigningTimedOut(keepAddress common.Address) (bool, error) {
+	panic("implement")
+}
+
 // IsActive checks for current state of a keep on-chain.
 func (lc *localChain) IsActive(keepAddress common.Address) (bool, error) {
 	panic("implement")

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -542,7 +542,17 @@ func checkAwaitingSignature(
 			ethereumChain,
 			currentBlock,
 			func() (bool, error) {
-				return ethereumChain.IsAwaitingSignature(keepAddress, latestDigest)
+				isAwaitingSignature, err := ethereumChain.IsAwaitingSignature(keepAddress, latestDigest)
+				if err != nil {
+					return false, err
+				}
+
+				hasSigningTimedOut, err := ethereumChain.HasSigningTimedOut(keepAddress)
+				if err != nil {
+					return false, err
+				}
+
+				return (isAwaitingSignature && !hasSigningTimedOut), nil
 			},
 		)
 		if err != nil {

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -310,7 +310,7 @@ func (n *Node) publishSignature(
 			)
 			continue
 		}
-		if !hasSigningTimedOut {
+		if hasSigningTimedOut {
 			return fmt.Errorf("on-chain timeout exceeded")
 		}
 

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -295,7 +295,23 @@ func (n *Node) publishSignature(
 		// Global timeout for generating a signature exceeded.
 		// We are giving up and leaving this function.
 		if ctx.Err() != nil {
-			return fmt.Errorf("signing timeout exceeded")
+			return fmt.Errorf("context timeout exceeded")
+		}
+
+		// Timeout for generating a signature defined in the contract exceeded.
+		// There is no point in submitting the request as it will be rejected
+		// by the chain. We are giving up and leaving this function.
+		hasSigningTimedOut, err := n.ethereumChain.HasSigningTimedOut(keepAddress)
+		if err != nil {
+			logger.Errorf(
+				"failed to verify if signing has timed out for keep [%s]: [%v]",
+				keepAddress.String(),
+				err,
+			)
+			continue
+		}
+		if !hasSigningTimedOut {
+			return fmt.Errorf("on-chain timeout exceeded")
 		}
 
 		// Check if keep still awaits a signature for this digest.

--- a/solidity/contracts/BondedECDSAKeep.sol
+++ b/solidity/contracts/BondedECDSAKeep.sol
@@ -584,6 +584,16 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
             keyGenerationStartTimestamp + keyGenerationTimeout;
     }
 
+    /// @notice Returns true if the ongoing signing process timed out.
+    /// @dev There is a certain timeout for a signature to be produced, see
+    /// `signingTimeout`.
+    function hasSigningTimedOut() public view returns (bool) {
+        return
+            signingStartTimestamp != 0 &&
+            /* solium-disable-next-line */
+            block.timestamp > signingStartTimestamp + signingTimeout;
+    }
+
     /// @notice Checks if the member already submitted a public key.
     /// @param _member Address of the member.
     /// @return True if member already submitted a public key, else false.
@@ -604,16 +614,6 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
     /// @notice Returns true if signing of a digest is currently in progress.
     function isSigningInProgress() internal view returns (bool) {
         return signingStartTimestamp != 0;
-    }
-
-    /// @notice Returns true if the ongoing signing process timed out.
-    /// @dev There is a certain timeout for a signature to be produced, see
-    /// `signingTimeout`.
-    function hasSigningTimedOut() internal view returns (bool) {
-        return
-            signingStartTimestamp != 0 &&
-            /* solium-disable-next-line */
-            block.timestamp > signingStartTimestamp + signingTimeout;
     }
 
     /// @notice Marks the keep as closed.

--- a/solidity/test/BondedECDSAKeepTest.js
+++ b/solidity/test/BondedECDSAKeepTest.js
@@ -319,6 +319,61 @@ contract("BondedECDSAKeep", (accounts) => {
     })
   })
 
+  describe("hasSigningTimedOut", async () => {
+    const digest1 =
+      "0x54a6483b8aca55c9df2a35baf71d9965ddfd623468d81d51229bd5eb7d1e1c1b"
+    const publicKey =
+      "0x657282135ed640b0f5a280874c7e7ade110b5c3db362e0552e6b7fff2cc8459328850039b734db7629c31567d7fc5677536b7fc504e967dc11f3f2289d3d4051"
+    const signatureR =
+      "0x9b32c3623b6a16e87b4d3a56cd67c666c9897751e24a51518136185403b1cba2"
+    const signatureS =
+      "0x6f7c776efde1e382f2ecc99ec0db13534a70ee86bd91d7b3a4059bccbed5d70c"
+    const signatureRecoveryID = 1
+
+    const digest2 =
+      "0xca071ca92644f1f2c4ae1bf71b6032e5eff4f78f3aa632b27cbc5f84104a32da"
+
+    let signingTimeout
+
+    beforeEach(async () => {
+      signingTimeout = await keep.signingTimeout.call()
+
+      await submitMembersPublicKeys(publicKey)
+    })
+
+    it("returns false if signing was not requested", async () => {
+      assert.isFalse(await keep.hasSigningTimedOut())
+    })
+
+    it("returns false if signing was requested and have not timed out yet", async () => {
+      await keep.sign(digest1, {from: owner})
+
+      await increaseTime(duration.seconds(signingTimeout - 1))
+
+      assert.isFalse(await keep.hasSigningTimedOut())
+    })
+
+    it("returns true if signing was requested and have timed out", async () => {
+      await keep.sign(digest2, {from: owner})
+
+      await increaseTime(duration.seconds(signingTimeout))
+
+      assert.isTrue(await keep.hasSigningTimedOut())
+    })
+
+    it("returns false if signing was requested and signature have been submitted", async () => {
+      await keep.sign(digest1, {from: owner})
+
+      await keep.submitSignature(signatureR, signatureS, signatureRecoveryID, {
+        from: members[0],
+      })
+
+      await increaseTime(duration.seconds(signingTimeout))
+
+      assert.isFalse(await keep.hasSigningTimedOut())
+    })
+  })
+
   describe("public key", () => {
     const publicKey0 =
       "0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
@@ -800,6 +855,31 @@ contract("BondedECDSAKeep", (accounts) => {
       await submitMembersPublicKeys(publicKey1)
 
       await keep.sign(hash256Digest1, {from: owner})
+
+      assert.isFalse(
+        await keep.checkSignatureFraud.call(
+          signature1.V,
+          signature1.R,
+          signature1.S,
+          hash256Digest1,
+          preimage1
+        ),
+        "signature is not fraudulent"
+      )
+    })
+
+    it("should return false when signature is valid, was requested and was submitted", async () => {
+      await submitMembersPublicKeys(publicKey1)
+
+      await keep.sign(hash256Digest1, {from: owner})
+      await keep.submitSignature(
+        signature1.R,
+        signature1.S,
+        signature1.V - 27,
+        {
+          from: members[0],
+        }
+      )
 
       assert.isFalse(
         await keep.checkSignatureFraud.call(


### PR DESCRIPTION
The client was not checking if signing has timed out so it was trying to publish the signature over and over. Here we update the client to check if the signing timeout has been hit in the contract so there is no point in publishing the signature or starting signature calculation on client start.

Closes: https://github.com/keep-network/keep-ecdsa/issues/404