### PR TITLE
Catch unsupported keep size and threshold in client

### DIFF
--- a/pkg/chain/chain.go
+++ b/pkg/chain/chain.go
@@ -138,6 +138,9 @@ type BondedECDSAKeep interface {
 	// GetPublicKey returns keep's members.
 	GetMembers(keepAddress common.Address) ([]common.Address, error)
 
+	// GetHonestThreshold returns keep's honest threshold.
+	GetHonestThreshold(keepAddress common.Address) (*big.Int, error)
+
 	// HasKeyGenerationTimedOut returns whether key generation
 	// has timed out for the given keep.
 	HasKeyGenerationTimedOut(keepAddress common.Address) (bool, error)

--- a/pkg/chain/chain.go
+++ b/pkg/chain/chain.go
@@ -139,7 +139,7 @@ type BondedECDSAKeep interface {
 	GetMembers(keepAddress common.Address) ([]common.Address, error)
 
 	// GetHonestThreshold returns keep's honest threshold.
-	GetHonestThreshold(keepAddress common.Address) (*big.Int, error)
+	GetHonestThreshold(keepAddress common.Address) (uint64, error)
 
 	// HasKeyGenerationTimedOut returns whether key generation
 	// has timed out for the given keep.

--- a/pkg/chain/chain.go
+++ b/pkg/chain/chain.go
@@ -135,7 +135,7 @@ type BondedECDSAKeep interface {
 	// an empty slice is returned.
 	GetPublicKey(keepAddress common.Address) ([]uint8, error)
 
-	// GetPublicKey returns keep's members.
+	// GetMembers returns keep's members.
 	GetMembers(keepAddress common.Address) ([]common.Address, error)
 
 	// GetHonestThreshold returns keep's honest threshold.

--- a/pkg/chain/ethereum/ethereum.go
+++ b/pkg/chain/ethereum/ethereum.go
@@ -58,7 +58,7 @@ func (ec *EthereumChain) OnBondedECDSAKeepCreated(
 			handler(&eth.BondedECDSAKeepCreatedEvent{
 				KeepAddress:     KeepAddress,
 				Members:         Members,
-				HonestThreshold: HonestThreshold,
+				HonestThreshold: HonestThreshold.Uint64(),
 			})
 		},
 		func(err error) error {
@@ -459,13 +459,18 @@ func (ec *EthereumChain) GetMembers(
 // GetHonestThreshold returns keep's honest threshold.
 func (ec *EthereumChain) GetHonestThreshold(
 	keepAddress common.Address,
-) (*big.Int, error) {
+) (uint64, error) {
 	keepContract, err := ec.getKeepContract(keepAddress)
 	if err != nil {
-		return nil, err
+		return 0, err
 	}
 
-	return keepContract.HonestThreshold()
+	threshold, err := keepContract.HonestThreshold()
+	if err != nil {
+		return 0, err
+	}
+
+	return threshold.Uint64(), nil
 }
 
 // HasKeyGenerationTimedOut returns whether key generation

--- a/pkg/chain/ethereum/ethereum.go
+++ b/pkg/chain/ethereum/ethereum.go
@@ -433,6 +433,17 @@ func (ec *EthereumChain) GetMembers(
 	return keepContract.GetMembers()
 }
 
+func (ec *EthereumChain) GetHonestThreshold(
+	keepAddress common.Address,
+) (*big.Int, error) {
+	keepContract, err := ec.getKeepContract(keepAddress)
+	if err != nil {
+		return nil, err
+	}
+
+	return keepContract.HonestThreshold()
+}
+
 func (ec *EthereumChain) HasKeyGenerationTimedOut(
 	keepAddress common.Address,
 ) (bool, error) {

--- a/pkg/chain/ethereum/ethereum.go
+++ b/pkg/chain/ethereum/ethereum.go
@@ -335,10 +335,13 @@ func (ec *EthereumChain) BalanceOf(address common.Address) (*big.Int, error) {
 	return ec.bondedECDSAKeepFactoryContract.BalanceOf(address)
 }
 
+// BlockCounter returns a block counter.
 func (ec *EthereumChain) BlockCounter() chain.BlockCounter {
 	return ec.blockCounter
 }
 
+// IsRegisteredForApplication checks if the operator is registered
+// as a signer candidate in the factory for the given application.
 func (ec *EthereumChain) IsRegisteredForApplication(application common.Address) (bool, error) {
 	return ec.bondedECDSAKeepFactoryContract.IsOperatorRegistered(
 		ec.Address(),
@@ -346,6 +349,8 @@ func (ec *EthereumChain) IsRegisteredForApplication(application common.Address) 
 	)
 }
 
+// IsEligibleForApplication checks if the operator is eligible to register
+// as a signer candidate for the given application.
 func (ec *EthereumChain) IsEligibleForApplication(application common.Address) (bool, error) {
 	return ec.bondedECDSAKeepFactoryContract.IsOperatorEligible(
 		ec.Address(),
@@ -353,6 +358,8 @@ func (ec *EthereumChain) IsEligibleForApplication(application common.Address) (b
 	)
 }
 
+// IsStatusUpToDateForApplication checks if the operator's status
+// is up to date in the signers' pool of the given application.
 func (ec *EthereumChain) IsStatusUpToDateForApplication(application common.Address) (bool, error) {
 	return ec.bondedECDSAKeepFactoryContract.IsOperatorUpToDate(
 		ec.Address(),
@@ -360,6 +367,8 @@ func (ec *EthereumChain) IsStatusUpToDateForApplication(application common.Addre
 	)
 }
 
+// UpdateStatusForApplication updates the operator's status in the signers'
+// pool for the given application.
 func (ec *EthereumChain) UpdateStatusForApplication(application common.Address) error {
 	transaction, err := ec.bondedECDSAKeepFactoryContract.UpdateOperatorStatus(
 		ec.Address(),
@@ -377,16 +386,19 @@ func (ec *EthereumChain) UpdateStatusForApplication(application common.Address) 
 	return nil
 }
 
+// GetKeepCount returns number of keeps.
 func (ec *EthereumChain) GetKeepCount() (*big.Int, error) {
 	return ec.bondedECDSAKeepFactoryContract.GetKeepCount()
 }
 
+// GetKeepAtIndex returns the address of the keep at the given index.
 func (ec *EthereumChain) GetKeepAtIndex(
 	keepIndex *big.Int,
 ) (common.Address, error) {
 	return ec.bondedECDSAKeepFactoryContract.GetKeepAtIndex(keepIndex)
 }
 
+// LatestDigest returns the latest digest requested to be signed.
 func (ec *EthereumChain) LatestDigest(keepAddress common.Address) ([32]byte, error) {
 	keepContract, err := ec.getKeepContract(keepAddress)
 	if err != nil {
@@ -396,6 +408,9 @@ func (ec *EthereumChain) LatestDigest(keepAddress common.Address) ([32]byte, err
 	return keepContract.Digest()
 }
 
+// SignatureRequestedBlock returns block number from the moment when a
+// signature was requested for the given digest from a keep.
+// If a signature was not requested for the given digest, returns 0.
 func (ec *EthereumChain) SignatureRequestedBlock(
 	keepAddress common.Address,
 	digest [32]byte,
@@ -413,6 +428,8 @@ func (ec *EthereumChain) SignatureRequestedBlock(
 	return blockNumber.Uint64(), nil
 }
 
+// GetPublicKey returns keep's public key. If there is no public key yet,
+// an empty slice is returned.
 func (ec *EthereumChain) GetPublicKey(keepAddress common.Address) ([]uint8, error) {
 	keepContract, err := ec.getKeepContract(keepAddress)
 	if err != nil {
@@ -422,6 +439,7 @@ func (ec *EthereumChain) GetPublicKey(keepAddress common.Address) ([]uint8, erro
 	return keepContract.GetPublicKey()
 }
 
+// GetMembers returns keep's members.
 func (ec *EthereumChain) GetMembers(
 	keepAddress common.Address,
 ) ([]common.Address, error) {
@@ -433,6 +451,7 @@ func (ec *EthereumChain) GetMembers(
 	return keepContract.GetMembers()
 }
 
+// GetHonestThreshold returns keep's honest threshold.
 func (ec *EthereumChain) GetHonestThreshold(
 	keepAddress common.Address,
 ) (*big.Int, error) {
@@ -444,6 +463,8 @@ func (ec *EthereumChain) GetHonestThreshold(
 	return keepContract.HonestThreshold()
 }
 
+// HasKeyGenerationTimedOut returns whether key generation
+// has timed out for the given keep.
 func (ec *EthereumChain) HasKeyGenerationTimedOut(
 	keepAddress common.Address,
 ) (bool, error) {

--- a/pkg/chain/ethereum/ethereum.go
+++ b/pkg/chain/ethereum/ethereum.go
@@ -52,11 +52,13 @@ func (ec *EthereumChain) OnBondedECDSAKeepCreated(
 			Members []common.Address,
 			Owner common.Address,
 			Application common.Address,
+			HonestThreshold *big.Int,
 			blockNumber uint64,
 		) {
 			handler(&eth.BondedECDSAKeepCreatedEvent{
-				KeepAddress: KeepAddress,
-				Members:     Members,
+				KeepAddress:     KeepAddress,
+				Members:         Members,
+				HonestThreshold: HonestThreshold,
 			})
 		},
 		func(err error) error {

--- a/pkg/chain/ethereum/ethereum.go
+++ b/pkg/chain/ethereum/ethereum.go
@@ -64,6 +64,9 @@ func (ec *EthereumChain) OnBondedECDSAKeepCreated(
 		func(err error) error {
 			return fmt.Errorf("watch keep created failed: [%v]", err)
 		},
+		nil,
+		nil,
+		nil,
 	)
 }
 
@@ -157,6 +160,7 @@ func (ec *EthereumChain) OnConflictingPublicKeySubmitted(
 		func(err error) error {
 			return fmt.Errorf("keep created callback failed: [%v]", err)
 		},
+		nil,
 	)
 }
 
@@ -184,6 +188,7 @@ func (ec *EthereumChain) OnSignatureRequested(
 		func(err error) error {
 			return fmt.Errorf("keep signature requested callback failed: [%v]", err)
 		},
+		nil,
 	)
 }
 

--- a/pkg/chain/event.go
+++ b/pkg/chain/event.go
@@ -1,8 +1,6 @@
 package eth
 
 import (
-	"math/big"
-
 	"github.com/ethereum/go-ethereum/common"
 )
 
@@ -10,7 +8,7 @@ import (
 type BondedECDSAKeepCreatedEvent struct {
 	KeepAddress     common.Address   // keep contract address
 	Members         []common.Address // keep members addresses
-	HonestThreshold *big.Int
+	HonestThreshold uint64
 }
 
 // ConflictingPublicKeySubmittedEvent is an event emitted each time when one of

--- a/pkg/chain/event.go
+++ b/pkg/chain/event.go
@@ -1,13 +1,16 @@
 package eth
 
 import (
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common"
 )
 
 // BondedECDSAKeepCreatedEvent is an event emitted on a new keep creation.
 type BondedECDSAKeepCreatedEvent struct {
-	KeepAddress common.Address   // keep contract address
-	Members     []common.Address // keep members addresses
+	KeepAddress     common.Address   // keep contract address
+	Members         []common.Address // keep members addresses
+	HonestThreshold *big.Int
 }
 
 // ConflictingPublicKeySubmittedEvent is an event emitted each time when one of

--- a/pkg/chain/local/local.go
+++ b/pkg/chain/local/local.go
@@ -234,6 +234,12 @@ func (lc *localChain) GetMembers(
 	panic("implement")
 }
 
+func (lc *localChain) GetHonestThreshold(
+	keepAddress common.Address,
+) (*big.Int, error) {
+	panic("implement")
+}
+
 func (lc *localChain) HasKeyGenerationTimedOut(
 	keepAddress common.Address,
 ) (bool, error) {

--- a/pkg/chain/local/local.go
+++ b/pkg/chain/local/local.go
@@ -236,7 +236,7 @@ func (lc *localChain) GetMembers(
 
 func (lc *localChain) GetHonestThreshold(
 	keepAddress common.Address,
-) (*big.Int, error) {
+) (uint64, error) {
 	panic("implement")
 }
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -339,7 +339,7 @@ func generateKeyForKeep(
 	requestedSignatures *requestedSignaturesTrack,
 	keepAddress common.Address,
 	members []common.Address,
-	honestThreshold *big.Int,
+	honestThreshold uint64,
 ) {
 	if len(members) < 2 {
 		// TODO: #408 Implement single signer support.
@@ -351,7 +351,7 @@ func generateKeyForKeep(
 		return
 	}
 
-	if honestThreshold.Cmp(big.NewInt(int64(len(members)))) != 0 {
+	if honestThreshold != uint64(len(members)) {
 		// TODO: #325 Implement threshold support.
 		logger.Errorf(
 			"keep [%s] has honest threshold [%s] and [%d] members; "+

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -333,6 +333,16 @@ func generateKeyForKeep(
 	keepAddress common.Address,
 	members []common.Address,
 ) {
+	if len(members) < 2 {
+		// TODO: #408 Implement single signer support.
+		logger.Errorf(
+			"keep [%s] has [%d] members; only keeps with at least 2 members are supported",
+			keepAddress.String(),
+			len(members),
+		)
+		return
+	}
+
 	logger.Infof(
 		"member [%s] is starting signer generation for keep [%s]...",
 		ethereumChain.Address().String(),

--- a/solidity/contracts/BondedECDSAKeep.sol
+++ b/solidity/contracts/BondedECDSAKeep.sol
@@ -88,14 +88,14 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
     Status internal status;
 
     // Notification that the keep was requested to sign a digest.
-    event SignatureRequested(bytes32 digest);
+    event SignatureRequested(bytes32 indexed digest);
 
     // Notification that the submitted public key does not match a key submitted
     // by other member. The event contains address of the member who tried to
     // submit a public key and a conflicting public key submitted already by other
     // member.
     event ConflictingPublicKeySubmitted(
-        address submittingMember,
+        address indexed submittingMember,
         bytes conflictingPublicKey
     );
 
@@ -123,7 +123,7 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
     // `v` to be calculated by increasing recovery id by 27. Please consult the
     // documentation about what the particular chain expects.
     event SignatureSubmitted(
-        bytes32 digest,
+        bytes32 indexed digest,
         bytes32 r,
         bytes32 s,
         uint8 recoveryID

--- a/solidity/contracts/BondedECDSAKeep.sol
+++ b/solidity/contracts/BondedECDSAKeep.sol
@@ -38,7 +38,7 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
     address[] internal members;
 
     // Minimum number of honest keep members required to produce a signature.
-    uint256 honestThreshold;
+    uint256 public honestThreshold;
 
     // Stake that was required from each keep member on keep creation.
     // The value is used for keep members slashing.

--- a/solidity/contracts/BondedECDSAKeepFactory.sol
+++ b/solidity/contracts/BondedECDSAKeepFactory.sol
@@ -36,14 +36,17 @@ contract BondedECDSAKeepFactory is
     using SafeMath for uint256;
 
     // Notification that a new sortition pool has been created.
-    event SortitionPoolCreated(address application, address sortitionPool);
+    event SortitionPoolCreated(
+        address indexed application,
+        address sortitionPool
+    );
 
     // Notification that a new keep has been created.
     event BondedECDSAKeepCreated(
-        address keepAddress,
+        address indexed keepAddress,
         address[] members,
-        address owner,
-        address application,
+        address indexed owner,
+        address indexed application,
         uint256 honestThreshold
     );
 

--- a/solidity/contracts/BondedECDSAKeepFactory.sol
+++ b/solidity/contracts/BondedECDSAKeepFactory.sol
@@ -43,7 +43,8 @@ contract BondedECDSAKeepFactory is
         address keepAddress,
         address[] members,
         address owner,
-        address application
+        address application,
+        uint256 honestThreshold
     );
 
     // Holds the address of the bonded ECDSA keep contract that will be used as a
@@ -311,7 +312,13 @@ contract BondedECDSAKeepFactory is
 
         keeps.push(address(keep));
 
-        emit BondedECDSAKeepCreated(keepAddress, members, _owner, application);
+        emit BondedECDSAKeepCreated(
+            keepAddress,
+            members,
+            _owner,
+            application,
+            _honestThreshold
+        );
     }
 
     /// @notice Gets how many keeps have been opened by this contract.

--- a/solidity/test/BondedECDSAKeepFactoryTest.js
+++ b/solidity/test/BondedECDSAKeepFactoryTest.js
@@ -42,7 +42,7 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
   const keepOwner = accounts[5]
 
   const groupSize = new BN(members.length)
-  const threshold = groupSize
+  const threshold = new BN(groupSize - 1)
 
   const singleBond = new BN(1)
   const bond = singleBond.mul(groupSize)
@@ -567,8 +567,20 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
       )
     })
 
-    it("opens keep with multiple members", async () => {
+    it("opens keep with multiple members and emits event", async () => {
       const blockNumber = await web3.eth.getBlockNumber()
+
+      const keepAddress = await keepFactory.openKeep.call(
+        groupSize,
+        threshold,
+        keepOwner,
+        bond,
+        stakeLockDuration,
+        {
+          from: application,
+          value: feeEstimate,
+        }
+      )
 
       await keepFactory.openKeep(
         groupSize,
@@ -592,11 +604,19 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
 
       assert.equal(eventList.length, 1, "incorrect number of emitted events")
 
+      const ev = eventList[0].returnValues
+
+      assert.equal(ev.keepAddress, keepAddress, "incorrect keep address")
+      assert.equal(ev.owner, keepOwner, "incorrect keep owner")
+      assert.equal(ev.application, application, "incorrect application")
+
       assert.sameMembers(
-        eventList[0].returnValues.members,
+        ev.members,
         [members[0], members[1], members[2]],
-        "incorrect keep member in emitted event"
+        "incorrect keep members"
       )
+
+      expect(ev.honestThreshold).to.eq.BN(threshold, "incorrect threshold")
     })
 
     it("opens bonds for keep", async () => {


### PR DESCRIPTION
Currently, the client supports keep size of at least 2 members and threshold equal to keep size. In this PR we catch requests with unsupported values, log an error and don't start the key generation process.

I also noticed that we were missing the threshold parameter passing to the event on keep creation or being able to read threshold of already created keep - fixed it in this PR.

Also added some parameters indexation for events as these may be helpful later for events filtering.

Closes: https://github.com/keep-network/keep-ecdsa/issues/392