### PR TITLE
Do not revert signature fraud submission TX if slashing failed

### DIFF
--- a/solidity/contracts/BondedECDSAKeep.sol
+++ b/solidity/contracts/BondedECDSAKeep.sol
@@ -129,6 +129,13 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
         uint8 recoveryID
     );
 
+    // Emitted when KEEP token slashing failed when submitting signature
+    // fraud proof. In practice, this situation should never happen but we want
+    // to be very explicit in this contract and protect the owner that even if
+    // it happens, the transaction submitting fraud proof is not going to fail
+    // and keep owner can seize and liquidate bonds in the same transaction.
+    event SlashingFailed();
+
     TokenStaking tokenStaking;
     KeepBonding keepBonding;
     BondedECDSAKeepFactory keepFactory;
@@ -328,11 +335,14 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
     }
 
     /// @notice Submits a fraud proof for a valid signature from this keep that was
-    /// not first approved via a call to sign. If fraud is detected it slashes
-    /// members' KEEP tokens.
+    /// not first approved via a call to sign. If fraud is detected it tries to
+    /// slash members' KEEP tokens. For each keep member tries slashing amount
+    /// equal to the member stake set by the factory when keep was created.
     /// @dev The function expects the signed digest to be calculated as a sha256
     /// hash of the preimage: `sha256(_preimage))`. The function reverts if the
-    /// signature is not fraudulent.
+    /// signature is not fraudulent. The function does not revert if KEEP slashing
+    /// failed but emits an event instead. In practice, KEEP slashing should
+    /// never fail.
     /// @param _v Signature's header byte: `27 + recoveryID`.
     /// @param _r R part of ECDSA signature.
     /// @param _s S part of ECDSA signature.
@@ -346,7 +356,7 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
         bytes32 _s,
         bytes32 _signedDigest,
         bytes calldata _preimage
-    ) external returns (bool _isFraud) {
+    ) external onlyWhenActive returns (bool _isFraud) {
         bool isFraud = checkSignatureFraud(
             _v,
             _r,
@@ -357,7 +367,20 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
 
         require(isFraud, "Signature is not fraudulent");
 
-        slashSignerStakes();
+        /* solium-disable-next-line */
+        (bool success, ) = address(tokenStaking).call(
+            abi.encodeWithSignature(
+                "slash(uint256,address[])",
+                memberStake,
+                members
+            )
+        );
+        // Should never happen but we want to protect the owner and make sure the
+        // fraud submission transaction does not fail so that the owner can
+        // seize and liquidate bonds in the same transaction.
+        if (!success) {
+            emit SlashingFailed();
+        }
 
         return isFraud;
     }
@@ -605,12 +628,6 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
         returns (bool)
     {
         return submittedPublicKeys[_member].length != 0;
-    }
-
-    /// @notice Slashes keep members' KEEP tokens. For each keep member it slashes
-    /// amount equal to the member stake set by the factory when keep was created.
-    function slashSignerStakes() internal onlyWhenActive {
-        tokenStaking.slash(memberStake, members);
     }
 
     /// @notice Returns true if signing of a digest is currently in progress.

--- a/solidity/test/BondedECDSAKeepTest.js
+++ b/solidity/test/BondedECDSAKeepTest.js
@@ -1189,8 +1189,6 @@ contract("BondedECDSAKeep", (accounts) => {
         "Caller is not the keep member"
       )
     })
-
-    it("does not fail if slashing failed", async () => {})
   })
 
   describe("closeKeep", () => {

--- a/solidity/test/BondedECDSAKeepTest.js
+++ b/solidity/test/BondedECDSAKeepTest.js
@@ -986,46 +986,60 @@ contract("BondedECDSAKeep", (accounts) => {
         )
       }
     })
-  })
 
-  describe("slashSignerStakes", async () => {
-    it("is not public", async () => {
-      try {
-        await keep.slashSignerStakes()
-      } catch (err) {
-        assert.equal(err, "TypeError: keep.slashSignerStakes is not a function")
-      }
-    })
-
-    it("reverts if called by closed keep", async () => {
+    it("reverts if called for closed keep", async () => {
       await keep.publicMarkAsClosed()
 
-      await expectRevert(keep.publicSlashSignerStakes(), "Keep is not active")
+      await expectRevert(
+        keep.submitSignatureFraud(
+          signature1.V,
+          signature1.R,
+          signature1.S,
+          hash256Digest1,
+          preimage1
+        ),
+        "Keep is not active"
+      )
     })
 
-    it("reverts if called by terminated keep", async () => {
+    it("reverts if called for terminated keep", async () => {
       await keep.publicMarkAsTerminated()
 
-      await expectRevert(keep.publicSlashSignerStakes(), "Keep is not active")
+      await expectRevert(
+        keep.submitSignatureFraud(
+          signature1.V,
+          signature1.R,
+          signature1.S,
+          hash256Digest1,
+          preimage1
+        ),
+        "Keep is not active"
+      )
     })
 
-    it("slashes keep members stakes", async () => {
-      const remainingStake = new BN(10)
-      const stakeBalance = memberStake.add(remainingStake)
-      await stakeOperators(members, stakeBalance)
+    it("does not revert if slashing failed", async () => {
+      await submitMembersPublicKeys(publicKey1)
 
-      await keep.publicSlashSignerStakes()
+      await tokenStaking.setSlashingShouldFail(true)
 
-      for (let i = 0; i < members.length; i++) {
-        const actualStake = await tokenStaking.eligibleStake(
-          members[i],
-          constants.ZERO_ADDRESS
-        )
-        expect(actualStake).to.eq.BN(
-          remainingStake,
-          `incorrect stake for member ${i}`
-        )
-      }
+      const res = await keep.submitSignatureFraud.call(
+        signature1.V,
+        signature1.R,
+        signature1.S,
+        hash256Digest1,
+        preimage1
+      )
+
+      const tx = await keep.submitSignatureFraud(
+        signature1.V,
+        signature1.R,
+        signature1.S,
+        hash256Digest1,
+        preimage1
+      )
+
+      assert.isTrue(res, "incorrect returned result")
+      truffleAssert.eventEmitted(tx, "SlashingFailed")
     })
   })
 
@@ -1175,6 +1189,8 @@ contract("BondedECDSAKeep", (accounts) => {
         "Caller is not the keep member"
       )
     })
+
+    it("does not fail if slashing failed", async () => {})
   })
 
   describe("closeKeep", () => {

--- a/solidity/test/contracts/BondedECDSAKeepStub.sol
+++ b/solidity/test/contracts/BondedECDSAKeepStub.sol
@@ -2,13 +2,10 @@ pragma solidity 0.5.17;
 
 import "../../contracts/BondedECDSAKeep.sol";
 
+
 /// @title Bonded ECDSA Keep Stub
 /// @dev This contract is for testing purposes only.
 contract BondedECDSAKeepStub is BondedECDSAKeep {
-    function publicSlashSignerStakes() public {
-        slashSignerStakes();
-    }
-
     function publicMarkAsClosed() public {
         markAsClosed();
     }

--- a/solidity/test/contracts/TokenStakingStub.sol
+++ b/solidity/test/contracts/TokenStakingStub.sol
@@ -25,6 +25,12 @@ contract TokenStakingStub is IStaking {
 
     address public delegatedAuthority;
 
+    bool slashingShouldFail;
+
+    function setSlashingShouldFail(bool _shouldFail) public {
+        slashingShouldFail = _shouldFail;
+    }
+
     /// @dev Sets balance variable value.
     function setBalance(address _operator, uint256 _balance) public {
         stakes[_operator] = _balance;
@@ -54,6 +60,10 @@ contract TokenStakingStub is IStaking {
     function slash(uint256 _amount, address[] memory _misbehavedOperators)
         public
     {
+        if (slashingShouldFail) {
+            // THIS SHOULD NEVER HAPPEN WITH REAL TOKEN STAKING
+            revert("slashing failed");
+        }
         for (uint256 i = 0; i < _misbehavedOperators.length; i++) {
             address operator = _misbehavedOperators[i];
             stakes[operator] = stakes[operator].sub(_amount);


### PR DESCRIPTION
Closes: https://github.com/keep-network/keep-ecdsa/issues/356

In practice, the situation when KEEP token slashing failed should never happen (see https://github.com/keep-network/keep-core/pull/1625). However, we want to be very explicit in this contract and protect the owner that even if it happens, the transaction submitting fraud proof is not going to fail and keep owner can seize and liquidate bonds in the same transaction.