### PR TITLE
Use simple delegate authority instead of claims

### DIFF
--- a/solidity/contracts/BondedECDSAKeep.sol
+++ b/solidity/contracts/BondedECDSAKeep.sol
@@ -501,8 +501,6 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
         status = Status.Active;
         isInitialized = true;
 
-        tokenStaking.claimDelegatedAuthority(_keepFactory);
-
         for (uint256 i = 0; i < _members.length; i++) {
             tokenStaking.lockStake(_members[i], _stakeLockDuration);
         }

--- a/solidity/contracts/BondedECDSAKeepFactory.sol
+++ b/solidity/contracts/BondedECDSAKeepFactory.sol
@@ -285,12 +285,9 @@ contract BondedECDSAKeepFactory is
         keepAddress = createClone(masterBondedECDSAKeepAddress);
         BondedECDSAKeep keep = BondedECDSAKeep(keepAddress);
 
-        // keepOpenedTimestamp value for newly created keep is required to be set
-        // before calling `keep.initialize` function as it is used to determine
-        // token staking delegation authority recognition in `__isRecognized`
-        // function.
-        /* solium-disable-next-line security/no-block-members*/
         keepOpenedTimestamp[address(keep)] = block.timestamp;
+
+        tokenStaking.delegateAuthority(keepAddress);
 
         keep.initialize(
             _owner,

--- a/solidity/test/BondedECDSAKeepFactoryTest.js
+++ b/solidity/test/BondedECDSAKeepFactoryTest.js
@@ -829,6 +829,16 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
       )
     })
 
+    it("delegates authority to keep", async () => {
+      const keep = await openKeep()
+
+      assert.equal(
+        await tokenStaking.delegatedAuthority(),
+        keep.address,
+        "incorrect token staking delegated authority"
+      )
+    })
+
     it("requests new random group selection seed from random beacon", async () => {
       const expectedNewEntry = new BN(789)
 

--- a/solidity/test/BondedECDSAKeepTest.js
+++ b/solidity/test/BondedECDSAKeepTest.js
@@ -154,26 +154,6 @@ contract("BondedECDSAKeep", (accounts) => {
       )
     })
 
-    it("claims token staking delegated authority", async () => {
-      keep = await BondedECDSAKeepStub.new()
-      await keep.initialize(
-        owner,
-        members,
-        honestThreshold,
-        memberStake,
-        stakeLockDuration,
-        tokenStaking.address,
-        keepBonding.address,
-        factoryStub.address
-      )
-
-      assert.equal(
-        await tokenStaking.delegatedAuthority(),
-        factoryStub.address,
-        "incorrect token staking delegated authority"
-      )
-    })
-
     it("locks members token stakes", async () => {
       keep = await BondedECDSAKeepStub.new()
       await keep.initialize(

--- a/solidity/test/contracts/TokenStakingStub.sol
+++ b/solidity/test/contracts/TokenStakingStub.sol
@@ -96,7 +96,7 @@ contract TokenStakingStub is IStaking {
         return owners[_operator];
     }
 
-    function claimDelegatedAuthority(address delegatedAuthoritySource) public {
-        delegatedAuthority = delegatedAuthoritySource;
+    function delegateAuthority(address authorityGrantee) public {
+        delegatedAuthority = authorityGrantee;
     }
 }


### PR DESCRIPTION
Depends on https://github.com/keep-network/keep-core/pull/1628

When keep factory creates a keep it can delegate its authority to the keep directly, without having the keep claiming it. This solution is simpler and does not cause gas estimation problems like the claim path.