### PR TITLE
Circle: Tag you're it!

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,8 +222,8 @@ jobs:
       - run:
           name: Tag Docker images
           command: |
-            docker tag keep-ecdsa $GCR_REGISTRY_URL/$GOOGLE_PROJECT_ID/keep-ecdsa
-            docker tag initcontainer-provision-keep-ecdsa $GCR_REGISTRY_URL/$GOOGLE_PROJECT_ID/initcontainer-provision-keep-ecdsa
+            docker tag keep-ecdsa $GCR_REGISTRY_URL/$GOOGLE_PROJECT_ID/keep-ecdsa:$DOCKER_IMAGE_TAG
+            docker tag initcontainer-provision-keep-ecdsa $GCR_REGISTRY_URL/$GOOGLE_PROJECT_ID/initcontainer-provision-keep-ecdsa:$DOCKER_IMAGE_TAG
       - gcp-gcr/gcr-auth:
           google-project-id: GOOGLE_PROJECT_ID
           google-compute-zone: GOOGLE_COMPUTE_ZONE_A
@@ -233,12 +233,12 @@ jobs:
           google-project-id: GOOGLE_PROJECT_ID
           registry-url: $GCR_REGISTRY_URL
           image: keep-ecdsa
-          tag: latest
+          tag: $DOCKER_IMAGE_TAG
       - gcp-gcr/push-image:
           google-project-id: GOOGLE_PROJECT_ID
           registry-url: $GCR_REGISTRY_URL
           image: initcontainer-provision-keep-ecdsa
-          tag: latest
+          tag: $DOCKER_IMAGE_TAG
   publish_contract_data:
     executor: gcp-cli/default
     steps:


### PR DESCRIPTION
### Intro

We've been rolling on `latest` image publishes across our keep-dev and keep-test environments for awhile.  While this is fine for our dev environment, it's time we work against properly versioned images for our test/Ropsten environment.

### What we did

Circle builds that run against a git tag generate a Circle env var `CIRCLE_TAG`.  This is perfect for our Docker image tagging needs.  However, the `CIRCLE_TAG` environment variable isn't generated for builds that don't run on a tag.  e.g. all keep-dev / master builds.  We already use environment based Circle contexts to factor out environment specific configs from the Circle config space, so it's a natural fit to handle this in the same way.  The Circle Context environment variable is `DOCKER_IMAGE_TAG`.  For keep-dev it's set to `latest`, and for keep-test it's set to `$CIRCLE_TAG`.