### PR TITLE
keep-dev/test: Reduce unbonded deposit on init

### DIFF
--- a/infrastructure/kube/templates/keep-ecdsa/initcontainer/provision-keep-ecdsa/provision-keep-ecdsa.js
+++ b/infrastructure/kube/templates/keep-ecdsa/initcontainer/provision-keep-ecdsa/provision-keep-ecdsa.js
@@ -74,7 +74,7 @@ async function provisionKeepTecdsa() {
     await fundOperator(operatorAddress, purse, '10')
 
     console.log(`\n<<<<<<<<<<<< Deposit to KeepBondingContract ${keepBondingContract.address} >>>>>>>>>>>>`)
-    await depositUnbondedValue(operatorAddress, purse, '50')
+    await depositUnbondedValue(operatorAddress, purse, '10')
 
     console.log(`\n<<<<<<<<<<<< Staking Operator Account ${operatorAddress} >>>>>>>>>>>>`)
     await stakeOperator(operatorAddress, contractOwnerAddress, authorizer)


### PR DESCRIPTION
This is a backport for a change we made against the `v0.13.0` tag after it was deployed.

Reducing the unbonded deposit amount from 50 to 10, to reduce overall ETH need on each new deploy.