### PR TITLE
keep-test: Use 0.13.0-rc.1 TBTCSystem

### DIFF
--- a/infrastructure/kube/keep-test/keep-ecdsa-0-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-ecdsa-0-statefulset.yaml
@@ -109,7 +109,7 @@ spec:
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
             - name: SANCTIONED_APPLICATIONS
-              value: '0x07c1f038Dbc00429B94d35b9237E840609d6f9eF' # Shall we extract this property to a configmap?
+              value: '0x576ad5Ced9D0030D2F26E2F08BD2E92de9fcD858' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-test/keep-ecdsa-1-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-ecdsa-1-statefulset.yaml
@@ -109,7 +109,7 @@ spec:
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
             - name: SANCTIONED_APPLICATIONS
-              value: '0x07c1f038Dbc00429B94d35b9237E840609d6f9eF' # Shall we extract this property to a configmap?
+              value: '0x576ad5Ced9D0030D2F26E2F08BD2E92de9fcD858' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-test/keep-ecdsa-2-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-ecdsa-2-statefulset.yaml
@@ -110,7 +110,7 @@ spec:
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
             - name: SANCTIONED_APPLICATIONS
-              value: '0x07c1f038Dbc00429B94d35b9237E840609d6f9eF' # Shall we extract this property to a configmap?
+              value: '0x576ad5Ced9D0030D2F26E2F08BD2E92de9fcD858' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-test/keep-ecdsa-3-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-ecdsa-3-statefulset.yaml
@@ -110,7 +110,7 @@ spec:
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
             - name: SANCTIONED_APPLICATIONS
-              value: '0x07c1f038Dbc00429B94d35b9237E840609d6f9eF' # Shall we extract this property to a configmap?
+              value: '0x576ad5Ced9D0030D2F26E2F08BD2E92de9fcD858' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-test/keep-ecdsa-4-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-ecdsa-4-statefulset.yaml
@@ -110,7 +110,7 @@ spec:
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
             - name: SANCTIONED_APPLICATIONS
-              value: '0x07c1f038Dbc00429B94d35b9237E840609d6f9eF' # Shall we extract this property to a configmap?
+              value: '0x576ad5Ced9D0030D2F26E2F08BD2E92de9fcD858' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-test/keep-ecdsa-5-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-ecdsa-5-statefulset.yaml
@@ -109,7 +109,7 @@ spec:
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
             - name: SANCTIONED_APPLICATIONS
-              value: '0x07c1f038Dbc00429B94d35b9237E840609d6f9eF' # Shall we extract this property to a configmap?
+              value: '0x576ad5Ced9D0030D2F26E2F08BD2E92de9fcD858' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-test/keep-ecdsa-6-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-ecdsa-6-statefulset.yaml
@@ -109,7 +109,7 @@ spec:
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
             - name: SANCTIONED_APPLICATIONS
-              value: '0x07c1f038Dbc00429B94d35b9237E840609d6f9eF' # Shall we extract this property to a configmap?
+              value: '0x576ad5Ced9D0030D2F26E2F08BD2E92de9fcD858' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-test/keep-ecdsa-7-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-ecdsa-7-statefulset.yaml
@@ -109,7 +109,7 @@ spec:
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
             - name: SANCTIONED_APPLICATIONS
-              value: '0x07c1f038Dbc00429B94d35b9237E840609d6f9eF' # Shall we extract this property to a configmap?
+              value: '0x576ad5Ced9D0030D2F26E2F08BD2E92de9fcD858' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-test/keep-ecdsa-8-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-ecdsa-8-statefulset.yaml
@@ -109,7 +109,7 @@ spec:
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
             - name: SANCTIONED_APPLICATIONS
-              value: '0x07c1f038Dbc00429B94d35b9237E840609d6f9eF' # Shall we extract this property to a configmap?
+              value: '0x576ad5Ced9D0030D2F26E2F08BD2E92de9fcD858' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-test/keep-ecdsa-9-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-ecdsa-9-statefulset.yaml
@@ -109,7 +109,7 @@ spec:
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
             - name: SANCTIONED_APPLICATIONS
-              value: '0x07c1f038Dbc00429B94d35b9237E840609d6f9eF' # Shall we extract this property to a configmap?
+              value: '0x576ad5Ced9D0030D2F26E2F08BD2E92de9fcD858' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config


### PR DESCRIPTION
Rolled forward to the latest Ropsten release, is deployed.