### PR TITLE
Bump up keep-core dependency version

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -59,13 +59,6 @@ const (
 	// as changes in the network need some time to propagate and frequent
 	// refreshes can increase resource consumption and network congestion.
 	routingTableRefreshPeriod = 5 * time.Minute
-
-	// bootstrapMinPeerThreshold determines the minimum number of peers
-	// that the node will try to keep connections with. Number of active
-	// connections is checked during core bootstrap rounds and if this number
-	// is less than the minimum, new connection attempts will be performed
-	// against peers listed in config (`LibP2P.Peers`).
-	bootstrapMinPeerThreshold = 10
 )
 
 func init() {
@@ -136,7 +129,6 @@ func Start(c *cli.Context) error {
 		firewall.NewStakeOrActiveKeepPolicy(ethereumChain, stakeMonitor),
 		retransmission.NewTimeTicker(ctx, 1*time.Second),
 		libp2p.WithRoutingTableRefreshPeriod(routingTableRefreshPeriod),
-		libp2p.WithBootstrapMinPeerThreshold(bootstrapMinPeerThreshold),
 	)
 	if err != nil {
 		return err

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/gofuzz v1.1.0
 	github.com/ipfs/go-log v0.0.1
 	github.com/keep-network/keep-common v0.2.0-rc
-	github.com/keep-network/keep-core v0.13.0-rc.0.20200416001330-0347b73e812f
+	github.com/keep-network/keep-core v0.13.0-rc.0.20200421120218-078ba65e911e
 	github.com/pkg/errors v0.9.1
 	github.com/urfave/cli v1.22.1
 )

--- a/go.sum
+++ b/go.sum
@@ -243,12 +243,16 @@ github.com/keep-network/cli v1.20.0 h1:mEufpPsovOVdduTTkk+a2CxS3crIrGFqUsvs58gSi
 github.com/keep-network/cli v1.20.0/go.mod h1:nzsst4JjU+rGE8Q5J839fYxectxWHpLhxKNohQWtQhA=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20190611114437-e92bd71e8199 h1:4EmAF2XUHK1kwXBhg75OO9hgTkJGK7snwJZlpbu+Yy8=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20190611114437-e92bd71e8199/go.mod h1:MtZSKNavpxpPY0VLt2sl118IxptrGQDUb/MBu+j2Yow=
+github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200420163504-f5aa53962524 h1:iOBE6U3YmgJ+VB2DnO5bNH9rmVWSiGUY1xgyjKOEGH8=
+github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200420163504-f5aa53962524/go.mod h1:MtZSKNavpxpPY0VLt2sl118IxptrGQDUb/MBu+j2Yow=
 github.com/keep-network/keep-common v0.2.0-rc h1:dkG8qtcKINk9kXqtGg4dAFu9x0xiSZtP3Jzj2sxqd2g=
 github.com/keep-network/keep-common v0.2.0-rc/go.mod h1:0uY+hufkP66nFnL+3GXMwWXRiKKsFyXFQTby1xR7AwY=
 github.com/keep-network/keep-core v0.13.0-rc h1:Fl3P/qPa4eYd6Zhm4PrkxH6cYd+ssxYUeAMxi7zf5Ts=
 github.com/keep-network/keep-core v0.13.0-rc/go.mod h1:wyvHiiC+w4SJqcWlgRFMPBGdOxqlwvUxTY9svvOULc0=
 github.com/keep-network/keep-core v0.13.0-rc.0.20200416001330-0347b73e812f h1:qZTwkK+xm/vSBkeXlcqqnEJUhTVMWkSQBTXVAIcD1FQ=
 github.com/keep-network/keep-core v0.13.0-rc.0.20200416001330-0347b73e812f/go.mod h1:wyvHiiC+w4SJqcWlgRFMPBGdOxqlwvUxTY9svvOULc0=
+github.com/keep-network/keep-core v0.13.0-rc.0.20200421120218-078ba65e911e h1:MHIWI/4AlthYESxw+8tqYs+zB/+X90EK09R0k9Cly5c=
+github.com/keep-network/keep-core v0.13.0-rc.0.20200421120218-078ba65e911e/go.mod h1:loLXlnfgjMR5qATb/5mTVJWHCZ3hf5G0Jue+Le4tV6Q=
 github.com/keep-network/toml v0.3.0 h1:G+NJwWR/ZiORqeLBsDXDchYoL29PXHdxOPcCueA7ctE=
 github.com/keep-network/toml v0.3.0/go.mod h1:Zeyd3lxbIlMYLREho3UK1dMP2xjqt2gLkQ5E5vM6K38=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=


### PR DESCRIPTION
Refs https://github.com/keep-network/keep-core/issues/1639

Bumping up `keep-core` dependency version to incorporate last network layer changes.

From https://github.com/keep-network/keep-core/pull/1643:
- Reduced the DHT refresh round period from `1 hour` to `30 minutes`. This change should make peer discovery a bit faster especially for edge peers. Also, this value should not harm performance with too frequent refreshes.
- Increased bootstrap round period from `10 seconds` to the default value of `30 seconds`. This change should help for problems with `libp2p` dial backoffs which can occur when an offline peer is dialled to often by frequent bootstrap rounds. Also, there are no benefits from running bootstrap round every `10 seconds` so `30 seconds` seems to be a reasonable value.
- Adjusted code to the new`go-libp2p-bootstrap` library version. 