### PR TITLE
Circle: Kill Docker image tagging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -222,8 +222,8 @@ jobs:
       - run:
           name: Tag Docker images
           command: |
-            docker tag keep-ecdsa $GCR_REGISTRY_URL/$GOOGLE_PROJECT_ID/keep-ecdsa:$DOCKER_IMAGE_TAG
-            docker tag initcontainer-provision-keep-ecdsa $GCR_REGISTRY_URL/$GOOGLE_PROJECT_ID/initcontainer-provision-keep-ecdsa:$DOCKER_IMAGE_TAG
+            docker tag keep-ecdsa $GCR_REGISTRY_URL/$GOOGLE_PROJECT_ID/keep-ecdsa
+            docker tag initcontainer-provision-keep-ecdsa $GCR_REGISTRY_URL/$GOOGLE_PROJECT_ID/initcontainer-provision-keep-ecdsa
       - gcp-gcr/gcr-auth:
           google-project-id: GOOGLE_PROJECT_ID
           google-compute-zone: GOOGLE_COMPUTE_ZONE_A
@@ -233,12 +233,12 @@ jobs:
           google-project-id: GOOGLE_PROJECT_ID
           registry-url: $GCR_REGISTRY_URL
           image: keep-ecdsa
-          tag: $DOCKER_IMAGE_TAG
+          tag: latest
       - gcp-gcr/push-image:
           google-project-id: GOOGLE_PROJECT_ID
           registry-url: $GCR_REGISTRY_URL
           image: initcontainer-provision-keep-ecdsa
-          tag: $DOCKER_IMAGE_TAG
+          tag: latest
   publish_contract_data:
     executor: gcp-cli/default
     steps:


### PR DESCRIPTION
This doesn't work the way we expect with tag builds, so I'm nuking it for now.  Will look at it again soon for a proper solution.

This one is really on me for not testing the tag build path with the original PR.