### PR TITLE
Pull 0.15.0 artifacts for keep-core

### DIFF
--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -879,9 +879,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "0.14.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.14.0-rc.0.tgz",
-      "integrity": "sha512-9K2oeuCvDK4Q1BsPghouOdEF7Ad8iCiuX7RblIaka2h8sLRBs6proyrue+KDjfKTreOZgfqb938yiyaGnyMTEQ==",
+      "version": "0.15.0-pre.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.15.0-pre.0.tgz",
+      "integrity": "sha512-cfrhRJX9+zkimYQ/6ASoX3inZIQ3V1dx2YDDgmoVzctm93yDKcz++fWiGSz6PXbYOUMq8Svj+a1Sv5KJSg2WLg==",
       "requires": {
         "@openzeppelin/contracts-ethereum-package": "^2.4.0",
         "@openzeppelin/upgrades": "^2.7.2",

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/keep-network/keep-ecdsa",
   "dependencies": {
-    "@keep-network/keep-core": ">0.14.0-rc <0.14.0",
+    "@keep-network/keep-core": ">0.15.0-pre <0.15.0-rc",
     "@keep-network/sortition-pools": "0.3.0",
     "@openzeppelin/upgrades": "^2.7.2",
     "openzeppelin-solidity": "2.3.0",


### PR DESCRIPTION
Forgot to version-bump the keep-core dep in addition to the keep-ecdsa
version.