### PR TITLE
Rename magpie to beneficiary and Registry to KeepRegistry

### DIFF
--- a/solidity/contracts/BondedECDSAKeep.sol
+++ b/solidity/contracts/BondedECDSAKeep.sol
@@ -433,7 +433,7 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
         for (uint16 i = 0; i < memberCount - 1; i++) {
             token.safeTransferFrom(
                 msg.sender,
-                tokenStaking.magpieOf(members[i]),
+                tokenStaking.beneficiaryOf(members[i]),
                 dividend
             );
         }
@@ -443,7 +443,7 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
         uint256 remainder = _value.mod(memberCount);
         token.safeTransferFrom(
             msg.sender,
-            tokenStaking.magpieOf(members[memberCount - 1]),
+            tokenStaking.beneficiaryOf(members[memberCount - 1]),
             dividend.add(remainder)
         );
 
@@ -472,7 +472,7 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
         memberETHBalances[_member] = 0;
 
         /* solium-disable-next-line security/no-call-value */
-        (bool success, ) = tokenStaking.magpieOf(_member).call.value(value)("");
+        (bool success, ) = tokenStaking.beneficiaryOf(_member).call.value(value)("");
 
         require(success, "Transfer failed");
     }

--- a/solidity/contracts/BondedECDSAKeep.sol
+++ b/solidity/contracts/BondedECDSAKeep.sol
@@ -472,7 +472,9 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
         memberETHBalances[_member] = 0;
 
         /* solium-disable-next-line security/no-call-value */
-        (bool success, ) = tokenStaking.beneficiaryOf(_member).call.value(value)("");
+        (bool success, ) = tokenStaking.beneficiaryOf(_member).call.value(
+            value
+        )("");
 
         require(success, "Transfer failed");
     }

--- a/solidity/contracts/BondedECDSAKeepVendorImplV1.sol
+++ b/solidity/contracts/BondedECDSAKeepVendorImplV1.sol
@@ -2,7 +2,7 @@ pragma solidity 0.5.17;
 
 import "./api/IBondedECDSAKeepVendor.sol";
 
-import "@keep-network/keep-core/contracts/Registry.sol";
+import "@keep-network/keep-core/contracts/KeepRegistry.sol";
 
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 
@@ -16,9 +16,9 @@ contract BondedECDSAKeepVendorImplV1 is IBondedECDSAKeepVendor {
     // this contract.
     mapping(string => bool) internal _initialized;
 
-    // Registry contract with a list of approved factories (operator contracts)
+    // KeepRegistry contract with a list of approved factories (operator contracts)
     // and upgraders.
-    Registry internal registry;
+    KeepRegistry internal registry;
 
     // Upgrade time delay defines a waiting period for factory address upgrade.
     // When new factory upgrade is initialized it has to wait this period
@@ -58,7 +58,7 @@ contract BondedECDSAKeepVendorImplV1 is IBondedECDSAKeepVendor {
         require(!initialized(), "Contract is already initialized.");
         _initialized["BondedECDSAKeepVendorImplV1"] = true;
 
-        registry = Registry(registryAddress);
+        registry = KeepRegistry(registryAddress);
         keepFactory = factory;
 
         factoryUpgradeTimeDelay = 1 days;
@@ -143,7 +143,7 @@ contract BondedECDSAKeepVendorImplV1 is IBondedECDSAKeepVendor {
     modifier onlyOperatorContractUpgrader() {
         require(
             address(registry) != address(0),
-            "Registry address is not registered"
+            "KeepRegistry address is not registered"
         );
 
         address operatorContractUpgrader = registry.operatorContractUpgraderFor(

--- a/solidity/contracts/KeepBonding.sol
+++ b/solidity/contracts/KeepBonding.sol
@@ -119,7 +119,7 @@ contract KeepBonding {
 
         unbondedValue[operator] = unbondedValue[operator].sub(amount);
 
-        (bool success, ) = tokenStaking.magpieOf(operator).call.value(amount)(
+        (bool success, ) = tokenStaking.beneficiaryOf(operator).call.value(amount)(
             ""
         );
         require(success, "Transfer failed");

--- a/solidity/contracts/KeepBonding.sol
+++ b/solidity/contracts/KeepBonding.sol
@@ -1,6 +1,6 @@
 pragma solidity 0.5.17;
 
-import "@keep-network/keep-core/contracts/Registry.sol";
+import "@keep-network/keep-core/contracts/KeepRegistry.sol";
 import "@keep-network/keep-core/contracts/TokenStaking.sol";
 
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
@@ -19,7 +19,7 @@ contract KeepBonding {
     using SafeMath for uint256;
 
     // Registry contract with a list of approved factories (operator contracts).
-    Registry internal registry;
+    KeepRegistry internal registry;
 
     // KEEP token staking contract.
     TokenStaking internal tokenStaking;
@@ -62,7 +62,7 @@ contract KeepBonding {
     /// @param registryAddress Keep registry contract address.
     /// @param tokenStakingAddress KEEP Token staking contract address.
     constructor(address registryAddress, address tokenStakingAddress) public {
-        registry = Registry(registryAddress);
+        registry = KeepRegistry(registryAddress);
         tokenStaking = TokenStaking(tokenStakingAddress);
     }
 
@@ -119,9 +119,9 @@ contract KeepBonding {
 
         unbondedValue[operator] = unbondedValue[operator].sub(amount);
 
-        (bool success, ) = tokenStaking.beneficiaryOf(operator).call.value(amount)(
-            ""
-        );
+        (bool success, ) = tokenStaking.beneficiaryOf(operator).call.value(
+            amount
+        )("");
         require(success, "Transfer failed");
 
         emit UnbondedValueWithdrawn(operator, amount);

--- a/solidity/migrations/2_deploy_contracts.js
+++ b/solidity/migrations/2_deploy_contracts.js
@@ -1,4 +1,4 @@
-const Registry = artifacts.require("Registry")
+const KeepRegistry = artifacts.require("KeepRegistry")
 const KeepBonding = artifacts.require("KeepBonding")
 const BondedECDSAKeep = artifacts.require("BondedECDSAKeep")
 const BondedECDSAKeepFactory = artifacts.require("BondedECDSAKeepFactory")
@@ -30,7 +30,7 @@ module.exports = async function (deployer) {
     RandomBeaconStub = artifacts.require("RandomBeaconStub")
     RandomBeaconAddress = (await RandomBeaconStub.new()).address
 
-    RegistryAddress = (await deployer.deploy(Registry)).address
+    RegistryAddress = (await deployer.deploy(KeepRegistry)).address
   }
 
   await deployer.deploy(KeepBonding, RegistryAddress, TokenStakingAddress)

--- a/solidity/migrations/3_initialize.js
+++ b/solidity/migrations/3_initialize.js
@@ -3,7 +3,7 @@ const BondedECDSAKeepVendorImplV1 = artifacts.require(
   "BondedECDSAKeepVendorImplV1"
 )
 const BondedECDSAKeepFactory = artifacts.require("BondedECDSAKeepFactory")
-const Registry = artifacts.require("Registry")
+const KeepRegistry = artifacts.require("KeepRegistry")
 
 const {RegistryAddress} = require("./external-contracts")
 
@@ -12,9 +12,9 @@ module.exports = async function (deployer) {
 
   let registry
   if (process.env.TEST) {
-    registry = await Registry.deployed()
+    registry = await KeepRegistry.deployed()
   } else {
-    registry = await Registry.at(RegistryAddress)
+    registry = await KeepRegistry.at(RegistryAddress)
   }
 
   const proxy = await BondedECDSAKeepVendor.deployed()

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -879,9 +879,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "0.15.0-pre.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.15.0-pre.0.tgz",
-      "integrity": "sha512-cfrhRJX9+zkimYQ/6ASoX3inZIQ3V1dx2YDDgmoVzctm93yDKcz++fWiGSz6PXbYOUMq8Svj+a1Sv5KJSg2WLg==",
+      "version": "0.15.0-pre.5",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.15.0-pre.5.tgz",
+      "integrity": "sha512-Q9esf2IOtgsHbVaSHQJtjOqWZPLwb7KQhC7KYSFd6tP7q74haK312TSP/Xz9s4oi4XQdi08JY2uz6lKNGq01dQ==",
       "requires": {
         "@openzeppelin/contracts-ethereum-package": "^2.4.0",
         "@openzeppelin/upgrades": "^2.7.2",

--- a/solidity/scripts/circleci-provision-external-contracts.sh
+++ b/solidity/scripts/circleci-provision-external-contracts.sh
@@ -5,7 +5,7 @@ set -ex
 # CONTRACT_DATA_BUCKET and ETH_NETWORK_ID are configured in Circle CI Context 
 # config to values specific to given environment.
 
-REGISTRY_CONTRACT_DATA="Registry.json"
+REGISTRY_CONTRACT_DATA="KeepRegistry.json"
 REGISTRY_PROPERTY="RegistryAddress"
 
 TOKEN_STAKING_CONTRACT_DATA="TokenStaking.json"

--- a/solidity/scripts/lcl-provision-external-contracts.sh
+++ b/solidity/scripts/lcl-provision-external-contracts.sh
@@ -12,7 +12,7 @@ set -e
 # NETWORK_ID=1801 \
 #   ./lcl-provision-external-contracts.sh
 
-REGISTRY_CONTRACT_DATA="Registry.json"
+REGISTRY_CONTRACT_DATA="KeepRegistry.json"
 REGISTRY_PROPERTY="RegistryAddress"
 
 TOKEN_STAKING_CONTRACT_DATA="TokenStaking.json"

--- a/solidity/test/BondedECDSAKeepFactoryTest.js
+++ b/solidity/test/BondedECDSAKeepFactoryTest.js
@@ -6,7 +6,7 @@ import {mineBlocks} from "./helpers/mineBlocks"
 
 const truffleAssert = require("truffle-assertions")
 
-const Registry = artifacts.require("Registry")
+const KeepRegistry = artifacts.require("KeepRegistry")
 const BondedECDSAKeepFactoryStub = artifacts.require(
   "BondedECDSAKeepFactoryStub"
 )
@@ -1175,7 +1175,7 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
     const newRelayEntry = new BN(2345675)
 
     before(async () => {
-      registry = await Registry.new()
+      registry = await KeepRegistry.new()
       bondedSortitionPoolFactory = await BondedSortitionPoolFactory.new()
       tokenStaking = await TokenStakingStub.new()
       keepBonding = await KeepBonding.new(
@@ -1448,7 +1448,7 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
   })
 
   async function initializeNewFactory() {
-    registry = await Registry.new()
+    registry = await KeepRegistry.new()
     bondedSortitionPoolFactory = await BondedSortitionPoolFactory.new()
     tokenStaking = await TokenStakingStub.new()
     keepBonding = await KeepBonding.new(registry.address, tokenStaking.address)

--- a/solidity/test/BondedECDSAKeepIntegrationTest.js
+++ b/solidity/test/BondedECDSAKeepIntegrationTest.js
@@ -5,7 +5,7 @@ const {time} = require("@openzeppelin/test-helpers")
 import {mineBlocks} from "./helpers/mineBlocks"
 
 const KeepToken = artifacts.require("KeepTokenIntegration")
-const Registry = artifacts.require("Registry")
+const KeepRegistry = artifacts.require("KeepRegistry")
 const BondedECDSAKeepFactoryStub = artifacts.require(
   "BondedECDSAKeepFactoryStub"
 )
@@ -236,7 +236,7 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
 
   async function initializeNewFactory() {
     keepToken = await KeepToken.new()
-    const registry = await Registry.new()
+    const registry = await KeepRegistry.new()
 
     bondedSortitionPoolFactory = await BondedSortitionPoolFactory.new()
     tokenStaking = await TokenStaking.new(

--- a/solidity/test/BondedECDSAKeepTest.js
+++ b/solidity/test/BondedECDSAKeepTest.js
@@ -10,7 +10,7 @@ import {duration, increaseTime} from "./helpers/increaseTime"
 
 const {expectRevert, constants, time} = require("@openzeppelin/test-helpers")
 
-const Registry = artifacts.require("Registry")
+const KeepRegistry = artifacts.require("KeepRegistry")
 const BondedECDSAKeepStub = artifacts.require("BondedECDSAKeepStub")
 const TestToken = artifacts.require("TestToken")
 const KeepBonding = artifacts.require("KeepBonding")
@@ -85,7 +85,7 @@ contract("BondedECDSAKeep", (accounts) => {
   }
 
   before(async () => {
-    registry = await Registry.new()
+    registry = await KeepRegistry.new()
     tokenStaking = await TokenStakingStub.new()
     keepBonding = await KeepBonding.new(registry.address, tokenStaking.address)
     bondedECDSAKeepStubMaster = await BondedECDSAKeepStub.new()

--- a/solidity/test/BondedECDSAKeepTest.js
+++ b/solidity/test/BondedECDSAKeepTest.js
@@ -1564,8 +1564,8 @@ contract("BondedECDSAKeep", (accounts) => {
         factoryStub.address
       )
 
-      await tokenStaking.setMagpie(member1, beneficiary)
-      await tokenStaking.setMagpie(member2, beneficiary)
+      await tokenStaking.setBeneficiary(member1, beneficiary)
+      await tokenStaking.setBeneficiary(member2, beneficiary)
 
       await keep.distributeETHReward({value: valueWithRemainder})
 
@@ -1761,8 +1761,8 @@ contract("BondedECDSAKeep", (accounts) => {
 
       await initializeTokens(token, keep, accounts[0], valueWithRemainder)
 
-      await tokenStaking.setMagpie(member1, beneficiary)
-      await tokenStaking.setMagpie(member2, beneficiary)
+      await tokenStaking.setBeneficiary(member1, beneficiary)
+      await tokenStaking.setBeneficiary(member2, beneficiary)
 
       await keep.distributeERC20Reward(token.address, valueWithRemainder)
 

--- a/solidity/test/BondedECDSAKeepVendorImplV1Test.js
+++ b/solidity/test/BondedECDSAKeepVendorImplV1Test.js
@@ -2,7 +2,7 @@ import {createSnapshot, restoreSnapshot} from "./helpers/snapshot"
 
 const {constants, expectRevert} = require("@openzeppelin/test-helpers")
 
-const Registry = artifacts.require("Registry")
+const KeepRegistry = artifacts.require("KeepRegistry")
 const BondedECDSAKeepVendorImplV1Stub = artifacts.require(
   "BondedECDSAKeepVendorImplV1Stub"
 )
@@ -19,7 +19,7 @@ contract("BondedECDSAKeepVendorImplV1", async (accounts) => {
   const upgrader = accounts[2]
 
   before(async () => {
-    registry = await Registry.new()
+    registry = await KeepRegistry.new()
 
     await registry.approveOperatorContract(address0)
     await registry.approveOperatorContract(address1)
@@ -64,7 +64,7 @@ contract("BondedECDSAKeepVendorImplV1", async (accounts) => {
     it("reverts when called directly", async () => {
       await expectRevert(
         keepVendor.upgradeFactory(address1, {from: upgrader}),
-        "Registry address is not registered"
+        "KeepRegistry address is not registered"
       )
     })
   })

--- a/solidity/test/BondedECDSAKeepVendorImplV1viaProxyTest.js
+++ b/solidity/test/BondedECDSAKeepVendorImplV1viaProxyTest.js
@@ -12,7 +12,7 @@ const chai = require("chai")
 chai.use(require("bn-chai")(BN))
 const expect = chai.expect
 
-const Registry = artifacts.require("Registry")
+const KeepRegistry = artifacts.require("KeepRegistry")
 
 const BondedECDSAKeepVendor = artifacts.require("BondedECDSAKeepVendor")
 const BondedECDSAKeepVendorImplV1Stub = artifacts.require(
@@ -35,7 +35,7 @@ contract("BondedECDSAKeepVendorImplV1viaProxy", async (accounts) => {
   let keepVendor
 
   before(async () => {
-    registry = await Registry.new()
+    registry = await KeepRegistry.new()
     await registry.approveOperatorContract(address0)
     await registry.approveOperatorContract(address1)
     await registry.approveOperatorContract(address2)

--- a/solidity/test/KeepBondingTest.js
+++ b/solidity/test/KeepBondingTest.js
@@ -1,6 +1,6 @@
 import {createSnapshot, restoreSnapshot} from "./helpers/snapshot"
 
-const Registry = artifacts.require("./Registry.sol")
+const KeepRegistry = artifacts.require("./KeepRegistry.sol")
 const TokenStaking = artifacts.require("./TokenStakingStub.sol")
 const KeepBonding = artifacts.require("./KeepBonding.sol")
 const TestEtherReceiver = artifacts.require("./TestEtherReceiver.sol")
@@ -32,7 +32,7 @@ contract("KeepBonding", (accounts) => {
     bondCreator = accounts[4]
     sortitionPool = accounts[5]
 
-    registry = await Registry.new()
+    registry = await KeepRegistry.new()
     tokenStaking = await TokenStaking.new()
     keepBonding = await KeepBonding.new(registry.address, tokenStaking.address)
     etherReceiver = await TestEtherReceiver.new()

--- a/solidity/test/KeepBondingTest.js
+++ b/solidity/test/KeepBondingTest.js
@@ -87,7 +87,7 @@ contract("KeepBonding", (accounts) => {
 
     it("transfers unbonded value to beneficiary of operator", async () => {
       const expectedUnbonded = 0
-      await tokenStaking.setMagpie(operator, beneficiary)
+      await tokenStaking.setBeneficiary(operator, beneficiary)
       const expectedBeneficiaryBalance = web3.utils
         .toBN(await web3.eth.getBalance(beneficiary))
         .add(value)
@@ -138,7 +138,7 @@ contract("KeepBonding", (accounts) => {
 
     it("reverts if transfer fails", async () => {
       await etherReceiver.setShouldFail(true)
-      await tokenStaking.setMagpie(operator, etherReceiver.address)
+      await tokenStaking.setBeneficiary(operator, etherReceiver.address)
 
       await expectRevert(
         keepBonding.withdraw(value, operator, {from: operator}),

--- a/solidity/test/contracts/TokenStakingStub.sol
+++ b/solidity/test/contracts/TokenStakingStub.sol
@@ -11,7 +11,7 @@ contract TokenStakingStub is IStaking {
 
     uint256 public minimumStake = 200000 * 1e18;
 
-    mapping(address => address payable) operatorToMagpie;
+    mapping(address => address payable) operatorToBeneficiary;
 
     mapping(address => uint256) stakes;
 
@@ -45,16 +45,16 @@ contract TokenStakingStub is IStaking {
         return stakes[_operator];
     }
 
-    function setMagpie(address _operator, address payable _magpie) public {
-        operatorToMagpie[_operator] = _magpie;
+    function setBeneficiary(address _operator, address payable _beneficiary) public {
+        operatorToBeneficiary[_operator] = _beneficiary;
     }
 
-    function magpieOf(address _operator) public view returns (address payable) {
-        address payable magpie = operatorToMagpie[_operator];
-        if (magpie == address(0)) {
+    function beneficiaryOf(address _operator) public view returns (address payable) {
+        address payable beneficiary = operatorToBeneficiary[_operator];
+        if (beneficiary == address(0)) {
             return address(uint160(_operator));
         }
-        return magpie;
+        return beneficiary;
     }
 
     function slash(uint256 _amount, address[] memory _misbehavedOperators)


### PR DESCRIPTION
In https://github.com/keep-network/keep-core/pull/1681 we renamed `magpie` to `beneficiary`.
In https://github.com/keep-network/keep-core/pull/1687 we renamed `Registry` to `KeepRegistry`.

Here we are adjusting `keep-ecdsa` to accommodate these changes.