### PR TITLE
Bumping up keep-core dependency to v1.1.0-rc

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,8 +18,8 @@ require (
 	github.com/gogo/protobuf v1.3.1
 	github.com/google/gofuzz v1.1.0
 	github.com/ipfs/go-log v0.0.1
-	github.com/keep-network/keep-common v0.3.0-rc.0.20200427145435-e24eeb9599e4
-	github.com/keep-network/keep-core v0.14.1-rc.0.20200428164847-ba505b296334
+	github.com/keep-network/keep-common v0.3.1-rc
+	github.com/keep-network/keep-core v1.1.0-rc
 	github.com/pkg/errors v0.9.1
 	github.com/urfave/cli v1.22.1
 )

--- a/go.sum
+++ b/go.sum
@@ -243,10 +243,10 @@ github.com/keep-network/cli v1.20.0 h1:mEufpPsovOVdduTTkk+a2CxS3crIrGFqUsvs58gSi
 github.com/keep-network/cli v1.20.0/go.mod h1:nzsst4JjU+rGE8Q5J839fYxectxWHpLhxKNohQWtQhA=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec h1:2pXAsi4OUUjZKr5ds5UOF2IxXN+jVW0WetVO+czkf+A=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec/go.mod h1:xR8jf3/VJAjh3nWu5tFe8Yxnt2HvWsqZHfGef1P5oDk=
-github.com/keep-network/keep-common v0.3.0-rc.0.20200427145435-e24eeb9599e4 h1:j8W6ckP0u2tr+1CB7KkVLz2EP3B4zT+wobv81DMSSxE=
-github.com/keep-network/keep-common v0.3.0-rc.0.20200427145435-e24eeb9599e4/go.mod h1:0uY+hufkP66nFnL+3GXMwWXRiKKsFyXFQTby1xR7AwY=
-github.com/keep-network/keep-core v0.14.1-rc.0.20200428164847-ba505b296334 h1:/nApz0Dcqwd7xgqiP4gMuYDtv3OepP49upggT6vxgo8=
-github.com/keep-network/keep-core v0.14.1-rc.0.20200428164847-ba505b296334/go.mod h1:v/7GduEV299AEnD+atg4wmGSB5/VY+UEm8fF7r7oR0k=
+github.com/keep-network/keep-common v0.3.1-rc h1:5JHj/PLmafqdJNh+pI5F5rUKUHhAuo2YllPcWSoA/rc=
+github.com/keep-network/keep-common v0.3.1-rc/go.mod h1:0uY+hufkP66nFnL+3GXMwWXRiKKsFyXFQTby1xR7AwY=
+github.com/keep-network/keep-core v1.1.0-rc h1:h1XgNQdrQgUYdn4mydBHU591Qq6X4GRQu6xwRyEyPr4=
+github.com/keep-network/keep-core v1.1.0-rc/go.mod h1:QdXPqPhIhexCcO98FVHmgr5BSJc59IrAV2ouCHQC4nw=
 github.com/keep-network/toml v0.3.0 h1:G+NJwWR/ZiORqeLBsDXDchYoL29PXHdxOPcCueA7ctE=
 github.com/keep-network/toml v0.3.0/go.mod h1:Zeyd3lxbIlMYLREho3UK1dMP2xjqt2gLkQ5E5vM6K38=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=


### PR DESCRIPTION
It also automatically bumps up `keep-common` dependency to `v0.3.1-rc`.