### PR TITLE
Bumping up keep-core contracts dependency to >1.1.0-rc <1.1.0

### DIFF
--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -879,9 +879,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "0.15.0-pre.5",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-0.15.0-pre.5.tgz",
-      "integrity": "sha512-Q9esf2IOtgsHbVaSHQJtjOqWZPLwb7KQhC7KYSFd6tP7q74haK312TSP/Xz9s4oi4XQdi08JY2uz6lKNGq01dQ==",
+      "version": "1.1.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.1.0-rc.0.tgz",
+      "integrity": "sha512-sXusNLPAPJFq9mYR5/eOYxgJKa0Kg4ezSvTtLaPjX0ul24rIPZ67kvpfbR5ePx4MCeD/XQisHvRmp/rEsXFAig==",
       "requires": {
         "@openzeppelin/contracts-ethereum-package": "^2.4.0",
         "@openzeppelin/upgrades": "^2.7.2",

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/keep-network/keep-ecdsa",
   "dependencies": {
-    "@keep-network/keep-core": ">0.15.0-pre <0.15.0-rc",
+    "@keep-network/keep-core": ">1.1.0-rc <1.1.0",
     "@keep-network/sortition-pools": "0.3.0",
     "@openzeppelin/upgrades": "^2.7.2",
     "openzeppelin-solidity": "2.3.0",


### PR DESCRIPTION
Just like in the description. We are setting `keep-core` dependency to the most recent RC version.