### PR TITLE
Bumping up version to v0.15.0-rc

### DIFF
--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "0.15.0-pre",
+  "version": "0.15.0-rc",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "0.15.0-pre",
+  "version": "0.15.0-rc",
   "description": "Smart contracts for ECDSA Keep",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Setting smart contracts version to `v0.15.0-rc` for a new release.