### PR TITLE
Bumping up contracts version to 0.16.0-pre

### DIFF
--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "0.15.0-pre",
+  "version": "0.16.0-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "0.15.0-pre",
+  "version": "0.16.0-pre",
   "description": "Smart contracts for ECDSA Keep",
   "repository": {
     "type": "git",


### PR DESCRIPTION
After tagging `0.15.0-rc` it's time to bump up the version to `-pre`.