### PR TITLE
Load balancer

### DIFF
--- a/solidity/contracts/BondedECDSAKeepLoadBalancerFactory.sol
+++ b/solidity/contracts/BondedECDSAKeepLoadBalancerFactory.sol
@@ -83,7 +83,7 @@ contract BondedECDSAKeepLoadBalancerFactory is
                 factoryB.openKeepFeeEstimate()
             );
         }
-    };
+    }
 
     function _chooseFactory(address application)
         internal returns (IBondedECDSAKeepSubFactory factory) {

--- a/solidity/contracts/BondedECDSAKeepLoadBalancerFactory.sol
+++ b/solidity/contracts/BondedECDSAKeepLoadBalancerFactory.sol
@@ -17,13 +17,17 @@ contract BondedECDSAKeepLoadBalancerFactory is
 
     mapping(address => uint256) applicationRequestCounter;
 
-    address public owner;
+    address public factoryUpgrader;
 
     constructor() public {
-        owner = msg.sender;
+        factoryUpgrader = msg.sender;
     };
 
-    function addFactory(address factoryAddress) public onlyOwner {
+    function addFactory(address factoryAddress) public {
+        require(
+            msg.sender == factoryUpgrader,
+            "Only callable by factory upgrader"
+        );
         require(
             address(factoryB) == address(0),
             "Both factories already set"

--- a/solidity/contracts/BondedECDSAKeepLoadBalancerFactory.sol
+++ b/solidity/contracts/BondedECDSAKeepLoadBalancerFactory.sol
@@ -1,0 +1,107 @@
+pragma solidity 0.5.17;
+
+import "./api/IBondedECDSAKeepFactory.sol";
+
+import "./api/IBondedECDSAKeepSubFactory.sol";
+
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+import "openzeppelin-solidity/contracts/math/Math.sol";
+
+contract BondedECDSAKeepLoadBalancerFactory is
+    IBondedECDSAKeepFactory
+{
+    using SafeMath for uint256;
+
+    IBondedECDSAKeepSubFactory factoryA;
+    IBondedECDSAKeepSubFactory factoryB;
+
+    mapping(address => uint256) applicationRequestCounter;
+
+    address public owner;
+
+    constructor() public {
+        owner = msg.sender;
+    };
+
+    function addFactory(address factoryAddress) public onlyOwner {
+        require(
+            address(factoryB) == address(0),
+            "Both factories already set"
+        );
+        if (address(factoryA) == address(0)) {
+            factoryA = IBondedECDSAKeepSubFactory(factoryAddress);
+        } else {
+            factoryB = IBondedECDSAKeepSubFactory(factoryAddress);
+        }
+    }
+
+    /// @notice Open a new ECDSA Keep.
+    /// @param _groupSize Number of members in the keep.
+    /// @param _honestThreshold Minimum number of honest keep members.
+    /// @param _owner Address of the keep owner.
+    /// @param _bond Value of ETH bond required from the keep.
+    /// @param _stakeLockDuration Stake lock duration in seconds.
+    /// @return Address of the opened keep.
+    function openKeep(
+        uint256 _groupSize,
+        uint256 _honestThreshold,
+        address _owner,
+        uint256 _bond,
+        uint256 _stakeLockDuration
+    ) external payable returns (address keepAddress) {
+        require(
+            address(factoryA) != address(0),
+            "At least one factory must be set"
+        );
+
+        address application = msg.sender;
+
+        IBondedECDSAKeepSubFactory factory = _chooseFactory(application);
+
+        return factory.indirectOpenKeep(
+            application,
+            _groupSize,
+            _honestThreshold,
+            _owner,
+            _bond,
+            _stakeLockDuration
+        );
+    }
+
+    /// @notice Gets a fee estimate for opening a new keep.
+    /// @return Uint256 estimate.
+    function openKeepFeeEstimate() external view returns (uint256) {
+        if (address(factoryB) == address(0)) {
+            return factoryA.openKeepFeeEstimate();
+        } else {
+            return Math.max(
+                factoryA.openKeepFeeEstimate(),
+                factoryB.openKeepFeeEstimate()
+            );
+        }
+    };
+
+    function _chooseFactory(address application)
+        internal returns (IBondedECDSAKeepSubFactory factory) {
+        uint256 counter = applicationRequestCounter[application];
+        applicationRequestCounter[application] = counter + 1;
+
+        uint256 weightA = factoryA.getSortitionPoolWeight(application);
+        uint256 weightB = factoryB.getSortitionPoolWeight(application);
+
+        uint256 seed = uint256(
+            keccak256(abi.encodePacked(application, counter))
+        );
+
+        if (_choiceFunction(seed, weightA, weightB)) {
+            factory = factoryA;
+        } else {
+            factory = factoryB;
+        }
+    }
+
+    function _choiceFunction(uint256 seed, uint256 weightA, uint256 weightB)
+        internal returns (bool chooseA) {
+        /// TODO
+    }
+}

--- a/solidity/contracts/BondedECDSAKeepSubFactory.sol
+++ b/solidity/contracts/BondedECDSAKeepSubFactory.sol
@@ -316,14 +316,15 @@ contract BondedECDSAKeepSubFactory is
     /// @dev Selects a list of signers for the keep based on provided parameters.
     /// A caller of this function is expected to be an application for which
     /// member candidates were registered in a pool.
-    /// @
+    /// @param application The caller of a direct `openKeep`
+    /// or the original caller to the load balancer of `indirectOpenKeep`
     /// @param _groupSize Number of signers in the keep.
     /// @param _honestThreshold Minimum number of honest keep signers.
     /// @param _owner Address of the keep owner.
     /// @param _bond Value of ETH bond required from the keep in wei.
     /// @param _stakeLockDuration Stake lock duration in seconds.
     /// @return Created keep address.
-    function openKeep(
+    function _openKeep(
         address application,
         uint256 _groupSize,
         uint256 _honestThreshold,

--- a/solidity/contracts/BondedECDSAKeepSubFactory.sol
+++ b/solidity/contracts/BondedECDSAKeepSubFactory.sol
@@ -331,7 +331,7 @@ contract BondedECDSAKeepSubFactory is
         address _owner,
         uint256 _bond,
         uint256 _stakeLockDuration
-    ) internal payable returns (address keepAddress) {
+    ) internal returns (address keepAddress) {
         require(_groupSize > 0, "Minimum signing group size is 1");
         require(_groupSize <= 16, "Maximum signing group size is 16");
         require(

--- a/solidity/contracts/BondedECDSAKeepSubFactory.sol
+++ b/solidity/contracts/BondedECDSAKeepSubFactory.sol
@@ -1,0 +1,633 @@
+pragma solidity 0.5.17;
+
+import "./BondedECDSAKeep.sol";
+import "./KeepBonding.sol";
+import "./api/IBondedECDSAKeepSubFactory.sol";
+import "./CloneFactory.sol";
+
+import "@keep-network/sortition-pools/contracts/api/IStaking.sol";
+import "@keep-network/sortition-pools/contracts/api/IBonding.sol";
+import "@keep-network/sortition-pools/contracts/BondedSortitionPool.sol";
+import "@keep-network/sortition-pools/contracts/BondedSortitionPoolFactory.sol";
+
+import {
+    AuthorityDelegator,
+    TokenStaking
+} from "@keep-network/keep-core/contracts/TokenStaking.sol";
+import "@keep-network/keep-core/contracts/IRandomBeacon.sol";
+import "@keep-network/keep-core/contracts/utils/AddressArrayUtils.sol";
+
+import "openzeppelin-solidity/contracts/math/SafeMath.sol";
+
+
+/// @title Bonded ECDSA Keep Factory
+/// @notice Contract creating bonded ECDSA keeps.
+/// @dev We avoid redeployment of bonded ECDSA keep contract by using the clone factory.
+/// Proxy delegates calls to sortition pool and therefore does not affect contract's
+/// state. This means that we only need to deploy the bonded ECDSA keep contract
+/// once. The factory provides clean state for every new bonded ECDSA keep clone.
+contract BondedECDSAKeepSubFactory is
+    IBondedECDSAKeepSubFactory,
+    CloneFactory,
+    AuthorityDelegator,
+    IRandomBeaconConsumer
+{
+    using AddressArrayUtils for address[];
+    using SafeMath for uint256;
+
+    // Notification that a new sortition pool has been created.
+    event SortitionPoolCreated(
+        address indexed application,
+        address sortitionPool
+    );
+
+    // Notification that a new keep has been created.
+    event BondedECDSAKeepCreated(
+        address indexed keepAddress,
+        address[] members,
+        address indexed owner,
+        address indexed application,
+        uint256 honestThreshold
+    );
+
+    // Holds the address of the load balancer factory
+    // which is trusted to pass the `_application` argument honestly
+    // to `indirectOpenKeep` calls.
+    address public loadBalancerFactory;
+
+    // Holds the address of the bonded ECDSA keep contract that will be used as a
+    // master contract for cloning.
+    address public masterBondedECDSAKeepAddress;
+
+    // Keeps created by this factory.
+    address[] public keeps;
+
+    // Maps keep opened timestamp to each keep address
+    mapping(address => uint256) keepOpenedTimestamp;
+
+    // Mapping of pools with registered member candidates for each application.
+    mapping(address => address) candidatesPools; // application -> candidates pool
+
+    uint256 public groupSelectionSeed;
+
+    BondedSortitionPoolFactory sortitionPoolFactory;
+    TokenStaking tokenStaking;
+    KeepBonding keepBonding;
+    IRandomBeacon randomBeacon;
+
+    // Sortition pool is created with a minimum bond of 1 to avoid
+    // griefing.
+    //
+    // Anyone can create a sortition pool for an application. If a pool is
+    // created with a ridiculously high bond, nobody can join it and
+    // updating bond is not possible because trying to select a group
+    // with an empty pool reverts.
+    //
+    // We set the minimum bond value to 1 to prevent from this situation and
+    // to allow the pool adjust the minimum bond during the first signer
+    // selection.
+    uint256 public constant minimumBond = 1;
+
+    // Signer candidates in bonded sortition pool are weighted by their eligible
+    // stake divided by a constant divisor. The divisor is set to 1 KEEP so that
+    // all KEEPs in eligible stake matter when calculating operator's eligible
+    // weight for signer selection.
+    uint256 public constant poolStakeWeightDivisor = 1e18;
+
+    // Gas required for a callback from the random beacon. The value specifies
+    // gas required to call `__beaconCallback` function in the worst-case
+    // scenario with all the checks and maximum allowed uint256 relay entry as
+    // a callback parameter.
+    uint256 public constant callbackGas = 30000;
+
+    // Random beacon sends back callback surplus to the requestor. It may also
+    // decide to send additional request subsidy fee. What's more, it may happen
+    // that the beacon is busy and we will not refresh group selection seed from
+    // the beacon. We accumulate all funds received from the beacon in the
+    // reseed pool and later use this pool to reseed using a public reseed
+    // function on a manual request at any moment.
+    uint256 public reseedPool;
+
+    constructor(
+        address _masterBondedECDSAKeepAddress,
+        address _sortitionPoolFactory,
+        address _tokenStaking,
+        address _keepBonding,
+        address _randomBeacon,
+        address _loadBalancer
+    ) public {
+        masterBondedECDSAKeepAddress = _masterBondedECDSAKeepAddress;
+        sortitionPoolFactory = BondedSortitionPoolFactory(
+            _sortitionPoolFactory
+        );
+        tokenStaking = TokenStaking(_tokenStaking);
+        keepBonding = KeepBonding(_keepBonding);
+        randomBeacon = IRandomBeacon(_randomBeacon);
+
+        loadBalancerFactory = _loadBalancer;
+
+        // initial value before the random beacon updates the seed
+        // https://www.wolframalpha.com/input/?i=pi+to+78+digits
+        groupSelectionSeed = 31415926535897932384626433832795028841971693993751058209749445923078164062862;
+    }
+
+    /// @notice Adds any received funds to the factory reseed pool.
+    function() external payable {
+        reseedPool += msg.value;
+    }
+
+    /// @notice Creates new sortition pool for the application.
+    /// @dev Emits an event after sortition pool creation.
+    /// @param _application Address of the application.
+    /// @return Address of the created sortition pool contract.
+    function createSortitionPool(address _application)
+        external
+        returns (address)
+    {
+        require(
+            candidatesPools[_application] == address(0),
+            "Sortition pool already exists"
+        );
+
+        address sortitionPoolAddress = sortitionPoolFactory.createSortitionPool(
+            IStaking(address(tokenStaking)),
+            IBonding(address(keepBonding)),
+            tokenStaking.minimumStake(),
+            minimumBond,
+            poolStakeWeightDivisor
+        );
+
+        candidatesPools[_application] = sortitionPoolAddress;
+
+        emit SortitionPoolCreated(_application, sortitionPoolAddress);
+
+        return candidatesPools[_application];
+    }
+
+    /// @notice Gets the sortition pool address for the given application.
+    /// @dev Reverts if sortition does not exits for the application.
+    /// @param _application Address of the application.
+    /// @return Address of the sortition pool contract.
+    function getSortitionPool(address _application)
+        external
+        view
+        returns (address)
+    {
+        require(
+            candidatesPools[_application] != address(0),
+            "No pool found for the application"
+        );
+
+        return candidatesPools[_application];
+    }
+
+    /// @notice Gets the total weight of operators
+    /// in the sortition pool for the given application.
+    /// @dev Reverts if sortition does not exits for the application.
+    /// @param _application Address of the application.
+    /// @return The sum of all registered operators' weights in the pool.
+    function getSortitionPoolWeight(address _application)
+        external
+        view
+        returns (uint256)
+    {
+        BondedSortitionPool candidatesPool = BondedSortitionPool(
+            candidatesPools[_application]
+        );
+
+        return candidatesPool.getTotalWeight();
+    }
+
+    /// @notice Register caller as a candidate to be selected as keep member
+    /// for the provided customer application.
+    /// @dev If caller is already registered it returns without any changes.
+    /// @param _application Address of the application.
+    function registerMemberCandidate(address _application) external {
+        require(
+            candidatesPools[_application] != address(0),
+            "No pool found for the application"
+        );
+
+        BondedSortitionPool candidatesPool = BondedSortitionPool(
+            candidatesPools[_application]
+        );
+
+        address operator = msg.sender;
+        if (!candidatesPool.isOperatorInPool(operator)) {
+            candidatesPool.joinPool(operator);
+        }
+    }
+
+    /// @notice Checks if operator's details in the member candidates pool are
+    /// up to date for the given application. If not update operator status
+    /// function should be called by the one who is monitoring the status.
+    /// @param _operator Operator's address.
+    /// @param _application Customer application address.
+    function isOperatorUpToDate(address _operator, address _application)
+        external
+        view
+        returns (bool)
+    {
+        BondedSortitionPool candidatesPool = getSortitionPoolForOperator(
+            _operator,
+            _application
+        );
+
+        return candidatesPool.isOperatorUpToDate(_operator);
+    }
+
+    /// @notice Invokes update of operator's details in the member candidates pool
+    /// for the given application
+    /// @param _operator Operator's address.
+    /// @param _application Customer application address.
+    function updateOperatorStatus(address _operator, address _application)
+        external
+    {
+        BondedSortitionPool candidatesPool = getSortitionPoolForOperator(
+            _operator,
+            _application
+        );
+
+        candidatesPool.updateOperatorStatus(_operator);
+    }
+
+    /// @notice Open a new ECDSA Keep.
+    /// @param _groupSize Number of members in the keep.
+    /// @param _honestThreshold Minimum number of honest keep members.
+    /// @param _owner Address of the keep owner.
+    /// @param _bond Value of ETH bond required from the keep.
+    /// @param _stakeLockDuration Stake lock duration in seconds.
+    /// @return Address of the opened keep.
+    function openKeep(
+        uint256 _groupSize,
+        uint256 _honestThreshold,
+        address _owner,
+        uint256 _bond,
+        uint256 _stakeLockDuration
+    ) external payable returns (address keepAddress) {
+        return _openKeep(
+            msg.sender,
+            _groupSize,
+            _honestThreshold,
+            _owner,
+            _bond,
+            _stakeLockDuration
+        );
+    }
+
+    /// @notice Open a new ECDSA Keep indirectly,
+    /// only callable by the load balancer factory.
+    /// @dev Functions like `openKeep` but receives the original `msg.sender`
+    /// in a separate argument and uses that address for authorization.
+    /// @param _application The original `msg.sender`
+    /// in the call to the load balancer factory.
+    /// @param _groupSize Number of members in the keep.
+    /// @param _honestThreshold Minimum number of honest keep members.
+    /// @param _owner Address of the keep owner.
+    /// @param _bond Value of ETH bond required from the keep.
+    /// @param _stakeLockDuration Stake lock duration in seconds.
+    /// @return Address of the opened keep.
+    function indirectOpenKeep(
+        address _application,
+        uint256 _groupSize,
+        uint256 _honestThreshold,
+        address _owner,
+        uint256 _bond,
+        uint256 _stakeLockDuration
+    ) external payable returns (address keepAddress) {
+        require(
+            msg.sender == loadBalancerFactory,
+            "Only callable by the load balancer"
+        );
+        return _openKeep(
+            _application,
+            _groupSize,
+            _honestThreshold,
+            _owner,
+            _bond,
+            _stakeLockDuration
+        );
+    }
+
+    /// @notice Opens a new ECDSA keep.
+    /// @dev Selects a list of signers for the keep based on provided parameters.
+    /// A caller of this function is expected to be an application for which
+    /// member candidates were registered in a pool.
+    /// @
+    /// @param _groupSize Number of signers in the keep.
+    /// @param _honestThreshold Minimum number of honest keep signers.
+    /// @param _owner Address of the keep owner.
+    /// @param _bond Value of ETH bond required from the keep in wei.
+    /// @param _stakeLockDuration Stake lock duration in seconds.
+    /// @return Created keep address.
+    function openKeep(
+        address application,
+        uint256 _groupSize,
+        uint256 _honestThreshold,
+        address _owner,
+        uint256 _bond,
+        uint256 _stakeLockDuration
+    ) internal payable returns (address keepAddress) {
+        require(_groupSize > 0, "Minimum signing group size is 1");
+        require(_groupSize <= 16, "Maximum signing group size is 16");
+        require(
+            _honestThreshold > 0,
+            "Honest threshold must be greater than 0"
+        );
+        require(
+            _honestThreshold <= _groupSize,
+            "Honest threshold must be less or equal the group size"
+        );
+
+        address pool = candidatesPools[application];
+        require(pool != address(0), "No signer pool for this application");
+
+        // In Solidity, division rounds towards zero (down) and dividing
+        // '_bond' by '_groupSize' can leave a remainder. Even though, a remainder
+        // is very small, we want to avoid this from happening and memberBond is
+        // rounded up by: `(bond + groupSize - 1 ) / groupSize`
+        // Ex. (100 + 3 - 1) / 3 = 34
+        uint256 memberBond = (_bond.add(_groupSize).sub(1)).div(_groupSize);
+        require(memberBond > 0, "Bond per member must be greater than zero");
+
+        require(
+            msg.value >= openKeepFeeEstimate(),
+            "Insufficient payment for opening a new keep"
+        );
+
+        uint256 minimumStake = tokenStaking.minimumStake();
+
+        address[] memory members = BondedSortitionPool(pool).selectSetGroup(
+            _groupSize,
+            bytes32(groupSelectionSeed),
+            minimumStake,
+            memberBond
+        );
+
+        newGroupSelectionSeed();
+
+        keepAddress = createClone(masterBondedECDSAKeepAddress);
+        BondedECDSAKeep keep = BondedECDSAKeep(keepAddress);
+
+        // keepOpenedTimestamp value for newly created keep is required to be set
+        // before calling `keep.initialize` function as it is used to determine
+        // token staking delegation authority recognition in `__isRecognized`
+        // function.
+        /* solium-disable-next-line security/no-block-members*/
+        keepOpenedTimestamp[address(keep)] = block.timestamp;
+
+        keep.initialize(
+            _owner,
+            members,
+            _honestThreshold,
+            minimumStake,
+            _stakeLockDuration,
+            address(tokenStaking),
+            address(keepBonding),
+            address(this)
+        );
+
+        for (uint256 i = 0; i < _groupSize; i++) {
+            keepBonding.createBond(
+                members[i],
+                keepAddress,
+                uint256(keepAddress),
+                memberBond,
+                pool
+            );
+        }
+
+        keeps.push(address(keep));
+
+        emit BondedECDSAKeepCreated(
+            keepAddress,
+            members,
+            _owner,
+            application,
+            _honestThreshold
+        );
+    }
+
+    /// @notice Gets how many keeps have been opened by this contract.
+    /// @dev    Checks the size of the keeps array.
+    /// @return The number of keeps opened so far.
+    function getKeepCount() external view returns (uint256) {
+        return keeps.length;
+    }
+
+    /// @notice Gets a specific keep address at a given index.
+    /// @return The address of the keep at the given index.
+    function getKeepAtIndex(uint256 index) external view returns (address) {
+        require(index < keeps.length, "Out of bounds.");
+        return keeps[index];
+    }
+
+    /// @notice Gets the opened timestamp of the given keep.
+    /// @return Timestamp the given keep was opened at or 0 if this keep
+    /// was not created by this factory.
+    function getKeepOpenedTimestamp(address _keep)
+        external
+        view
+        returns (uint256)
+    {
+        return keepOpenedTimestamp[_keep];
+    }
+
+    /// @notice Verifies if delegates authority recipient is valid address recognized
+    /// by the factory for token staking authority delegation.
+    /// @param _delegatedAuthorityRecipient Address of the delegated authority
+    /// recipient.
+    /// @return True if provided address is recognized delegated token staking
+    /// authority for this factory contract.
+    function __isRecognized(address _delegatedAuthorityRecipient)
+        external
+        returns (bool)
+    {
+        return keepOpenedTimestamp[_delegatedAuthorityRecipient] > 0;
+    }
+
+    /// @notice Sets a new group selection seed value.
+    /// @dev The function is expected to be called in a callback by the random
+    /// beacon.
+    /// @param _relayEntry Beacon output.
+    function __beaconCallback(uint256 _relayEntry) external onlyRandomBeacon {
+        groupSelectionSeed = _relayEntry;
+    }
+
+    /// @notice Checks if operator is registered as a candidate for the given
+    /// customer application.
+    /// @param _operator Operator's address.
+    /// @param _application Customer application address.
+    /// @return True if operator is already registered in the candidates pool,
+    /// false otherwise.
+    function isOperatorRegistered(address _operator, address _application)
+        public
+        view
+        returns (bool)
+    {
+        if (candidatesPools[_application] == address(0)) {
+            return false;
+        }
+
+        BondedSortitionPool candidatesPool = BondedSortitionPool(
+            candidatesPools[_application]
+        );
+
+        return candidatesPool.isOperatorRegistered(_operator);
+    }
+
+    /// @notice Checks if given operator is eligible for the given application.
+    /// @param _operator Operator's address.
+    /// @param _application Customer application address.
+    function isOperatorEligible(address _operator, address _application)
+        public
+        view
+        returns (bool)
+    {
+        if (candidatesPools[_application] == address(0)) {
+            return false;
+        }
+
+        BondedSortitionPool candidatesPool = BondedSortitionPool(
+            candidatesPools[_application]
+        );
+
+        return candidatesPool.isOperatorEligible(_operator);
+    }
+
+    /// @notice Gets a fee estimate for opening a new keep.
+    /// @return Uint256 estimate.
+    function openKeepFeeEstimate() public view returns (uint256) {
+        return randomBeacon.entryFeeEstimate(callbackGas);
+    }
+
+    /// @notice Calculates the fee requestor has to pay to reseed the factory
+    /// for signer selection. Depending on how much value is stored in the
+    /// reseed pool and the price of a new relay entry, returned value may vary.
+    function newGroupSelectionSeedFee() public view returns (uint256) {
+        uint256 beaconFee = randomBeacon.entryFeeEstimate(callbackGas);
+        return beaconFee <= reseedPool ? 0 : beaconFee.sub(reseedPool);
+    }
+
+    /// @notice Reseeds the value used for a signer selection. Requires enough
+    /// payment to be passed. The required payment can be calculated using
+    /// reseedFee function. Factory is automatically triggering reseeding after
+    /// opening a new keep but the reseed can be also triggered at any moment
+    /// using this function.
+    function requestNewGroupSelectionSeed() public payable {
+        uint256 beaconFee = randomBeacon.entryFeeEstimate(callbackGas);
+
+        reseedPool = reseedPool.add(msg.value);
+        require(reseedPool >= beaconFee, "Not enough funds to trigger reseed");
+
+        (bool success, bytes memory returnData) = requestRelayEntry(beaconFee);
+        if (!success) {
+            revert(string(returnData));
+        }
+
+        reseedPool = reseedPool.sub(beaconFee);
+    }
+
+    /// @notice Checks if the specified account has enough active stake to become
+    /// network operator and that this contract has been authorized for potential
+    /// slashing.
+    ///
+    /// Having the required minimum of active stake makes the operator eligible
+    /// to join the network. If the active stake is not currently undelegating,
+    /// operator is also eligible for work selection.
+    ///
+    /// @param _operator operator's address
+    /// @return True if has enough active stake to participate in the network,
+    /// false otherwise.
+    function hasMinimumStake(address _operator) public view returns (bool) {
+        return tokenStaking.hasMinimumStake(_operator, address(this));
+    }
+
+    /// @notice Checks if the factory has the authorization to operate on stake
+    /// represented by the provided operator.
+    ///
+    /// @param _operator operator's address
+    /// @return True if the factory has access to the staked token balance of
+    /// the provided operator and can slash that stake. False otherwise.
+    function isOperatorAuthorized(address _operator)
+        public
+        view
+        returns (bool)
+    {
+        return tokenStaking.isAuthorizedForOperator(_operator, address(this));
+    }
+
+    /// @notice Gets the stake balance of the specified operator.
+    /// @param _operator The operator to query the balance of.
+    /// @return An uint256 representing the amount staked by the passed operator.
+    function balanceOf(address _operator) public view returns (uint256) {
+        return tokenStaking.balanceOf(_operator);
+    }
+
+    /// @notice Gets bonded sortition pool of specific application for the
+    /// operator.
+    /// @dev Reverts if the operator is not registered for the application.
+    /// @param _operator Operator's address.
+    /// @param _application Customer application address.
+    /// @return Bonded sortition pool.
+    function getSortitionPoolForOperator(
+        address _operator,
+        address _application
+    ) internal view returns (BondedSortitionPool) {
+        require(
+            isOperatorRegistered(_operator, _application),
+            "Operator not registered for the application"
+        );
+
+        return BondedSortitionPool(candidatesPools[_application]);
+    }
+
+    /// @notice Updates group selection seed.
+    /// @dev The main goal of this function is to request the random beacon to
+    /// generate a new random number. The beacon generates the number asynchronously
+    /// and will call a callback function when the number is ready. In the meantime
+    /// we update current group selection seed to a new value using a hash function.
+    /// In case of the random beacon request failure this function won't revert
+    /// but add beacon payment to factory's reseed pool.
+    function newGroupSelectionSeed() internal {
+        // Calculate new group selection seed based on the current seed.
+        // We added address of the factory as a key to calculate value different
+        // than sortition pool RNG will, so we don't end up selecting almost
+        // identical group.
+        groupSelectionSeed = uint256(
+            keccak256(abi.encodePacked(groupSelectionSeed, address(this)))
+        );
+
+        // Call the random beacon to get a random group selection seed.
+        (bool success, ) = requestRelayEntry(msg.value);
+        if (!success) {
+            reseedPool += msg.value;
+        }
+    }
+
+    /// @notice Requests for a relay entry using the beacon payment provided as
+    /// the parameter.
+    function requestRelayEntry(uint256 payment)
+        internal
+        returns (bool, bytes memory)
+    {
+        return
+            address(randomBeacon).call.value(payment)(
+                abi.encodeWithSignature(
+                    "requestRelayEntry(address,uint256)",
+                    address(this),
+                    callbackGas
+                )
+            );
+    }
+
+    /// @notice Checks if the caller is the random beacon.
+    /// @dev Throws an error if called by any account other than the random beacon.
+    modifier onlyRandomBeacon() {
+        require(
+            address(randomBeacon) == msg.sender,
+            "Caller is not the random beacon"
+        );
+        _;
+    }
+}

--- a/solidity/contracts/BondedECDSAKeepSubFactory.sol
+++ b/solidity/contracts/BondedECDSAKeepSubFactory.sol
@@ -186,16 +186,19 @@ contract BondedECDSAKeepSubFactory is
     /// @dev Reverts if sortition does not exits for the application.
     /// @param _application Address of the application.
     /// @return The sum of all registered operators' weights in the pool.
+    /// If no pool exists, returns 0.
     function getSortitionPoolWeight(address _application)
         external
         view
         returns (uint256)
     {
-        BondedSortitionPool candidatesPool = BondedSortitionPool(
-            candidatesPools[_application]
-        );
+        address poolAddress = candidatesPools[_application];
 
-        return candidatesPool.getTotalWeight();
+        if (poolAddress == address(0)) { return 0; }
+
+        BondedSortitionPool pool = BondedSortitionPool(poolAddress);
+
+        return pool.getTotalWeight();
     }
 
     /// @notice Register caller as a candidate to be selected as keep member

--- a/solidity/contracts/api/IBondedECDSAKeepSubFactory.sol
+++ b/solidity/contracts/api/IBondedECDSAKeepSubFactory.sol
@@ -1,0 +1,54 @@
+pragma solidity 0.5.17;
+
+
+/// @title Bonded ECDSA Keep Factory
+/// @notice Factory for Bonded ECDSA Keeps.
+interface IBondedECDSAKeepSubFactory {
+    /// @notice Open a new ECDSA Keep.
+    /// @param _groupSize Number of members in the keep.
+    /// @param _honestThreshold Minimum number of honest keep members.
+    /// @param _owner Address of the keep owner.
+    /// @param _bond Value of ETH bond required from the keep.
+    /// @param _stakeLockDuration Stake lock duration in seconds.
+    /// @return Address of the opened keep.
+    function openKeep(
+        uint256 _groupSize,
+        uint256 _honestThreshold,
+        address _owner,
+        uint256 _bond,
+        uint256 _stakeLockDuration
+    ) external payable returns (address keepAddress);
+
+    /// @notice Open a new ECDSA Keep indirectly,
+    /// only callable by the load balancer factory.
+    /// @dev Functions like `openKeep` but receives the original `msg.sender`
+    /// in a separate argument and uses that address for authorization.
+    /// @param _application The original `msg.sender`
+    /// in the call to the load balancer factory.
+    /// @param _groupSize Number of members in the keep.
+    /// @param _honestThreshold Minimum number of honest keep members.
+    /// @param _owner Address of the keep owner.
+    /// @param _bond Value of ETH bond required from the keep.
+    /// @param _stakeLockDuration Stake lock duration in seconds.
+    /// @return Address of the opened keep.
+    function indirectOpenKeep(
+        address _application,
+        uint256 _groupSize,
+        uint256 _honestThreshold,
+        address _owner,
+        uint256 _bond,
+        uint256 _stakeLockDuration
+    ) external payable returns (address keepAddress);
+
+    /// @notice Gets a fee estimate for opening a new keep.
+    /// @return Uint256 estimate.
+    function openKeepFeeEstimate() external view returns (uint256);
+
+    /// @notice Gets the total weight of operators
+    /// in the sortition pool for the given application.
+    /// @param _application Address of the application.
+    /// @return The sum of all registered operators' weights in the pool.
+    function getSortitionPoolWeight(
+        address _application
+    ) external view returns (uint256 poolWeight);
+}


### PR DESCRIPTION
Currently includes a basic design for how we could implement a transparent load balancer factory.

Implements subfactories that let the load balancer factory pass the calling application in an argument, and provide a function to query the weight of the sortition pool of a given application.

The load balancer has one or two subfactories that it divides work between, according to the `_choiceFunction`.