### PR TITLE
Removed double sha256 mention

### DIFF
--- a/solidity/contracts/BondedECDSAKeep.sol
+++ b/solidity/contracts/BondedECDSAKeep.sol
@@ -591,7 +591,7 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
         bytes32 calculatedDigest = sha256(_preimage);
         require(
             _signedDigest == calculatedDigest,
-            "Signed digest does not match double sha256 hash of the preimage"
+            "Signed digest does not match sha256 hash of the preimage"
         );
 
         bool isSignatureValid = publicKeyToAddress(publicKey) ==

--- a/solidity/contracts/api/IBondedECDSAKeep.sol
+++ b/solidity/contracts/api/IBondedECDSAKeep.sol
@@ -1,5 +1,6 @@
 pragma solidity 0.5.17;
 
+
 /// @title ECDSA Keep
 /// @notice Contract reflecting an ECDSA keep.
 contract IBondedECDSAKeep {
@@ -50,8 +51,8 @@ contract IBondedECDSAKeep {
 
     /// @notice Submits a fraud proof for a valid signature from this keep that was
     /// not first approved via a call to sign.
-    /// @dev The function expects the signed digest to be calculated as a double
-    /// sha256 hash (hash256) of the preimage: `sha256(sha256(_preimage))`.
+    /// @dev The function expects the signed digest to be calculated as a sha256
+    /// hash of the preimage: `sha256(_preimage)`.
     /// @param _v Signature's header byte: `27 + recoveryID`.
     /// @param _r R part of ECDSA signature.
     /// @param _s S part of ECDSA signature.

--- a/solidity/test/BondedECDSAKeepTest.js
+++ b/solidity/test/BondedECDSAKeepTest.js
@@ -822,7 +822,7 @@ contract("BondedECDSAKeep", (accounts) => {
           hash256Digest1,
           preimage2
         ),
-        "Signed digest does not match double sha256 hash of the preimage"
+        "Signed digest does not match sha256 hash of the preimage"
       )
     })
 


### PR DESCRIPTION
We no longer require double sha256 as per #217. We missed updating the doc for interface and error message. Here we fix this oversight.