### PR TITLE
Release: v0.16.0-rc (Ropsten)

### DIFF
--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "0.15.0-pre",
+  "version": "0.16.0-rc",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -879,9 +879,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "1.1.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.1.0-rc.0.tgz",
-      "integrity": "sha512-sXusNLPAPJFq9mYR5/eOYxgJKa0Kg4ezSvTtLaPjX0ul24rIPZ67kvpfbR5ePx4MCeD/XQisHvRmp/rEsXFAig==",
+      "version": "1.2.0-rc.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.2.0-rc.0.tgz",
+      "integrity": "sha512-x4Lv5OhY7/qLwjRYLufls6Fpd/DcExH+HHkL/FvKOa4caqLDikcdnMH7xzXtrDitwqepn57Qvhjboo1MO7A/Sw==",
       "requires": {
         "@openzeppelin/contracts-ethereum-package": "^2.4.0",
         "@openzeppelin/upgrades": "^2.7.2",

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "0.15.0-pre",
+  "version": "0.16.0-rc",
   "description": "Smart contracts for ECDSA Keep",
   "repository": {
     "type": "git",
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/keep-network/keep-ecdsa",
   "dependencies": {
-    "@keep-network/keep-core": ">1.1.0-rc <1.1.0",
+    "@keep-network/keep-core": ">1.2.0-rc <1.2.0",
     "@keep-network/sortition-pools": "0.3.0",
     "@openzeppelin/upgrades": "^2.7.2",
     "openzeppelin-solidity": "2.3.0",


### PR DESCRIPTION
Rolled keep-core dependency forward to the new rc.