### PR TITLE
1.0.0 preparation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/gogo/protobuf v1.3.1
 	github.com/google/gofuzz v1.1.0
 	github.com/ipfs/go-log v0.0.1
-	github.com/keep-network/keep-common v0.3.2
+	github.com/keep-network/keep-common v1.0.0
 	github.com/keep-network/keep-core v1.1.3
 	github.com/pkg/errors v0.9.1
 	github.com/urfave/cli v1.22.1

--- a/go.mod
+++ b/go.mod
@@ -18,8 +18,8 @@ require (
 	github.com/gogo/protobuf v1.3.1
 	github.com/google/gofuzz v1.1.0
 	github.com/ipfs/go-log v0.0.1
-	github.com/keep-network/keep-common v0.3.1-rc
-	github.com/keep-network/keep-core v1.1.0-rc
+	github.com/keep-network/keep-common v0.3.2
+	github.com/keep-network/keep-core v1.1.3
 	github.com/pkg/errors v0.9.1
 	github.com/urfave/cli v1.22.1
 )

--- a/go.sum
+++ b/go.sum
@@ -245,6 +245,8 @@ github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec h
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec/go.mod h1:xR8jf3/VJAjh3nWu5tFe8Yxnt2HvWsqZHfGef1P5oDk=
 github.com/keep-network/keep-common v0.3.2 h1:Yty+rgBXLD2yfWvqG4r45SIHUbyTfuQeFtZDonz9kBs=
 github.com/keep-network/keep-common v0.3.2/go.mod h1:0uY+hufkP66nFnL+3GXMwWXRiKKsFyXFQTby1xR7AwY=
+github.com/keep-network/keep-common v1.0.0 h1:buLpkvahX5oJc6DIQZe7aAxTJqyWx61xM1uSUD8UVCY=
+github.com/keep-network/keep-common v1.0.0/go.mod h1:0uY+hufkP66nFnL+3GXMwWXRiKKsFyXFQTby1xR7AwY=
 github.com/keep-network/keep-core v1.1.3 h1:YWJfs6dCImWlGYV8JP9lHunDDfk48ngp0e8fCEWKF68=
 github.com/keep-network/keep-core v1.1.3/go.mod h1:xhPlO1jYmapYwR9uKWWAubDdfaZ5NMru7XqxWRyrmq4=
 github.com/keep-network/toml v0.3.0 h1:G+NJwWR/ZiORqeLBsDXDchYoL29PXHdxOPcCueA7ctE=

--- a/go.sum
+++ b/go.sum
@@ -243,10 +243,10 @@ github.com/keep-network/cli v1.20.0 h1:mEufpPsovOVdduTTkk+a2CxS3crIrGFqUsvs58gSi
 github.com/keep-network/cli v1.20.0/go.mod h1:nzsst4JjU+rGE8Q5J839fYxectxWHpLhxKNohQWtQhA=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec h1:2pXAsi4OUUjZKr5ds5UOF2IxXN+jVW0WetVO+czkf+A=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec/go.mod h1:xR8jf3/VJAjh3nWu5tFe8Yxnt2HvWsqZHfGef1P5oDk=
-github.com/keep-network/keep-common v0.3.1-rc h1:5JHj/PLmafqdJNh+pI5F5rUKUHhAuo2YllPcWSoA/rc=
-github.com/keep-network/keep-common v0.3.1-rc/go.mod h1:0uY+hufkP66nFnL+3GXMwWXRiKKsFyXFQTby1xR7AwY=
-github.com/keep-network/keep-core v1.1.0-rc h1:h1XgNQdrQgUYdn4mydBHU591Qq6X4GRQu6xwRyEyPr4=
-github.com/keep-network/keep-core v1.1.0-rc/go.mod h1:QdXPqPhIhexCcO98FVHmgr5BSJc59IrAV2ouCHQC4nw=
+github.com/keep-network/keep-common v0.3.2 h1:Yty+rgBXLD2yfWvqG4r45SIHUbyTfuQeFtZDonz9kBs=
+github.com/keep-network/keep-common v0.3.2/go.mod h1:0uY+hufkP66nFnL+3GXMwWXRiKKsFyXFQTby1xR7AwY=
+github.com/keep-network/keep-core v1.1.3 h1:YWJfs6dCImWlGYV8JP9lHunDDfk48ngp0e8fCEWKF68=
+github.com/keep-network/keep-core v1.1.3/go.mod h1:xhPlO1jYmapYwR9uKWWAubDdfaZ5NMru7XqxWRyrmq4=
 github.com/keep-network/toml v0.3.0 h1:G+NJwWR/ZiORqeLBsDXDchYoL29PXHdxOPcCueA7ctE=
 github.com/keep-network/toml v0.3.0/go.mod h1:Zeyd3lxbIlMYLREho3UK1dMP2xjqt2gLkQ5E5vM6K38=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=

--- a/pkg/chain/ethereum/ethereum.go
+++ b/pkg/chain/ethereum/ethereum.go
@@ -253,6 +253,7 @@ func (ec *EthereumChain) getKeepContract(address common.Address) (*contract.Bond
 		address,
 		ec.accountKey,
 		ec.client,
+		ec.nonceManager,
 		ec.transactionMutex,
 	)
 	if err != nil {

--- a/pkg/registry/storage.go
+++ b/pkg/registry/storage.go
@@ -34,9 +34,9 @@ func (ps *persistentStorage) save(keepAddress common.Address, signer *tss.Thresh
 	return ps.handle.Save(
 		signerBytes,
 		keepAddress.String(),
-		// TODO: Currently we support only single signer, we should use
-		// different signer IDs when multi-party group is available.
-		fmt.Sprintf("/membership_%s", signer.MemberID().String()),
+		// Take just the first 20 bytes of member ID so that we don't produce
+		// too long file names.
+		fmt.Sprintf("/membership_%s", signer.MemberID().String()[0:40]),
 	)
 }
 

--- a/pkg/registry/storage.go
+++ b/pkg/registry/storage.go
@@ -36,7 +36,7 @@ func (ps *persistentStorage) save(keepAddress common.Address, signer *tss.Thresh
 		keepAddress.String(),
 		// Take just the first 20 bytes of member ID so that we don't produce
 		// too long file names.
-		fmt.Sprintf("/membership_%s", signer.MemberID().String()[0:40]),
+		fmt.Sprintf("/membership_%.40s", signer.MemberID().String()),
 	)
 }
 

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "0.15.0-pre",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -879,9 +879,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "1.1.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.1.0-rc.0.tgz",
-      "integrity": "sha512-sXusNLPAPJFq9mYR5/eOYxgJKa0Kg4ezSvTtLaPjX0ul24rIPZ67kvpfbR5ePx4MCeD/XQisHvRmp/rEsXFAig==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.1.2.tgz",
+      "integrity": "sha512-BEpq/hdqmPZeGc3/EMdbgGeQQgspf41UYsDaFJxOb86UxpKe59aAqOV8eJYFGNec28KFa5l7bl7ucMWqilrbww==",
       "requires": {
         "@openzeppelin/contracts-ethereum-package": "^2.4.0",
         "@openzeppelin/upgrades": "^2.7.2",

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -896,9 +896,9 @@
       }
     },
     "@keep-network/sortition-pools": {
-      "version": "0.3.1-pre.1",
-      "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-0.3.1-pre.1.tgz",
-      "integrity": "sha512-bkanQlTD6+aFgG3EM3I6lxJbVhDfvGrHCHNdFPO+sqqziEzHXBJAEzEKWvi56f8EN8CwcqlrIizp/TAn9X9X/A==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-1.0.0.tgz",
+      "integrity": "sha512-wPOjqQphGtIBTGpGmw8gwBDbvMeq/9wf+HCsD6Vhvd7bcY5lPT/oWFFqhiExhuaLyISwr1fl6Jgm4RkN6Cispg==",
       "requires": {
         "@openzeppelin/contracts": "^2.4.0"
       }

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/keep-network/keep-ecdsa",
   "dependencies": {
-    "@keep-network/keep-core": ">1.1.0-rc <1.1.0",
+    "@keep-network/keep-core": "1.1.2",
     "@keep-network/sortition-pools": "1.0.0",
     "@openzeppelin/upgrades": "^2.7.2",
     "openzeppelin-solidity": "2.3.0",

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "0.15.0-pre",
+  "version": "1.0.0",
   "description": "Smart contracts for ECDSA Keep",
   "repository": {
     "type": "git",

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -33,7 +33,7 @@
   "homepage": "https://github.com/keep-network/keep-ecdsa",
   "dependencies": {
     "@keep-network/keep-core": ">1.1.0-rc <1.1.0",
-    "@keep-network/sortition-pools": "0.3.1-pre.1",
+    "@keep-network/sortition-pools": "1.0.0",
     "@openzeppelin/upgrades": "^2.7.2",
     "openzeppelin-solidity": "2.3.0",
     "solidity-bytes-utils": "0.0.7"


### PR DESCRIPTION
Versions updated:
- `keep-core` go dependency updated to `v1.1.3`. This is the latest release of the client available.
- `keep-common` go dependency updated to `v1.0.0`. This is the lastest version of the library available.
- `sortition-pools` contracts dependency updated to `v1.0.0`. This is the latest version of the library available.
- `keep-core` contracts dependency updated to `v1.1.2`. This is the latest version of contracts available.

There are two additional changes I had to make because of `keep-common` update:
- We are instantiating the nonce manager and use it for all contracts.
- We use the first 20 bytes of member ID when constructing the file name to respect 128 characters limit.

Finally, bumped up contracts version to `1.0.0` :tada: