### PR TITLE
Ethereum Commands: Add ethereum subcommand to keep-ecdsa client

### DIFF
--- a/cmd/ethereum.go
+++ b/cmd/ethereum.go
@@ -1,0 +1,26 @@
+package cmd
+
+import (
+	chaincmd "github.com/keep-network/keep-ecdsa/pkg/chain/gen/cmd"
+	"github.com/urfave/cli"
+)
+
+// EthereumCommand contains the definition of the ethereum command-line
+// subcommand and its own subcommands.
+var EthereumCommand cli.Command
+
+const ethereumDescription = `The ethereum command allows interacting with Keep's Ethereum
+	contracts directly. Each subcommand corresponds to one contract, and has
+	subcommands corresponding to each method on that contract, which respectively
+	each take parameters based on the contract method's parameters.
+
+    See the subcommand help for additional details.`
+
+func init() {
+	EthereumCommand = cli.Command{
+		Name:        "ethereum",
+		Usage:       `Provides access to Keep network Ethereum contracts.`,
+		Description: ethereumDescription,
+		Subcommands: chaincmd.AvailableCommands,
+	}
+}

--- a/main.go
+++ b/main.go
@@ -19,10 +19,20 @@ const (
 )
 
 var (
+	version  string
+	revision string
+
 	configPath string
 )
 
 func main() {
+	if version == "" {
+		version = "unknown"
+	}
+	if revision == "" {
+		revision = "unknown"
+	}
+
 	err := logging.Configure(os.Getenv("LOG_LEVEL"))
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "failed to configure logging: [%v]\n", err)
@@ -38,6 +48,7 @@ func main() {
 			Email: "info@keep.network",
 		},
 	}
+	app.Version = fmt.Sprintf("%s (revision %s)", version, revision)
 	app.Flags = []cli.Flag{
 		cli.StringFlag{
 			Name:        "config,c",

--- a/main.go
+++ b/main.go
@@ -48,6 +48,7 @@ func main() {
 	}
 	app.Commands = []cli.Command{
 		cmd.StartCommand,
+		cmd.EthereumCommand,
 	}
 
 	err = app.Run(os.Args)


### PR DESCRIPTION
This was really just wiring up the already-generated commands to the main command. Also added version/revision anchors while I was in there.