### PR TITLE
Gas price bids and protocol check during the handshake

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -126,6 +126,7 @@ func Start(c *cli.Context) error {
 		ctx,
 		config.LibP2P,
 		networkPrivateKey,
+		libp2p.ProtocolECDSA,
 		firewall.NewStakeOrActiveKeepPolicy(ethereumChain, stakeMonitor),
 		retransmission.NewTimeTicker(ctx, 1*time.Second),
 		libp2p.WithRoutingTableRefreshPeriod(routingTableRefreshPeriod),

--- a/configs/config.toml.SAMPLE
+++ b/configs/config.toml.SAMPLE
@@ -4,6 +4,21 @@
 [ethereum]
   URL = "ws://127.0.0.1:8545"
   URLRPC = "http://127.0.0.1:8546"
+  # Uncomment to override the defaults for transaction status monitoring.
+	#
+	# MiningCheckInterval is the interval in which transaction
+	# mining status is checked. If the transaction is not mined within this
+	# time, the gas price is increased and transaction is resubmitted.
+	#
+	# MiningCheckInterval = 60  # 60 sec (default value)
+	#
+	# MaxGasPrice specifies the default maximum gas price the client is
+	# willing to pay for the transaction to be mined. The offered transaction
+	# gas price can not be higher than the max gas price value. If the maximum
+	# allowed gas price is reached, no further resubmission attempts are
+	# performed.
+	#
+	# MaxGasPrice = 50000000000 # 50 gwei (default value)
 
 [ethereum.account]
   KeyFile = "/Users/someuser/ethereum/data/keystore/UTC--2018-03-11T01-37-33.202765887Z--AAAAAAAAAAAAAAAAAAAAAAAAAAAAAA8AAAAAAAAA"

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/gogo/protobuf v1.3.1
 	github.com/google/gofuzz v1.1.0
 	github.com/ipfs/go-log v0.0.1
-	github.com/keep-network/keep-common v1.0.0
+	github.com/keep-network/keep-common v1.0.1-0.20200515214626-9036c7c35946
 	github.com/keep-network/keep-core v1.1.3
 	github.com/pkg/errors v0.9.1
 	github.com/urfave/cli v1.22.1

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/gofuzz v1.1.0
 	github.com/ipfs/go-log v0.0.1
 	github.com/keep-network/keep-common v1.0.1-0.20200515214626-9036c7c35946
-	github.com/keep-network/keep-core v1.1.3
+	github.com/keep-network/keep-core v0.14.1-rc.0.20200516202120-19889483db36
 	github.com/pkg/errors v0.9.1
 	github.com/urfave/cli v1.22.1
 )

--- a/go.sum
+++ b/go.sum
@@ -243,12 +243,10 @@ github.com/keep-network/cli v1.20.0 h1:mEufpPsovOVdduTTkk+a2CxS3crIrGFqUsvs58gSi
 github.com/keep-network/cli v1.20.0/go.mod h1:nzsst4JjU+rGE8Q5J839fYxectxWHpLhxKNohQWtQhA=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec h1:2pXAsi4OUUjZKr5ds5UOF2IxXN+jVW0WetVO+czkf+A=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec/go.mod h1:xR8jf3/VJAjh3nWu5tFe8Yxnt2HvWsqZHfGef1P5oDk=
-github.com/keep-network/keep-common v0.3.2 h1:Yty+rgBXLD2yfWvqG4r45SIHUbyTfuQeFtZDonz9kBs=
-github.com/keep-network/keep-common v0.3.2/go.mod h1:0uY+hufkP66nFnL+3GXMwWXRiKKsFyXFQTby1xR7AwY=
 github.com/keep-network/keep-common v1.0.1-0.20200515214626-9036c7c35946 h1:fvkIlIuuEd42K2U4E2cYFlTpBt0F6JysDg6zBkxXRPM=
 github.com/keep-network/keep-common v1.0.1-0.20200515214626-9036c7c35946/go.mod h1:0uY+hufkP66nFnL+3GXMwWXRiKKsFyXFQTby1xR7AwY=
-github.com/keep-network/keep-core v1.1.3 h1:YWJfs6dCImWlGYV8JP9lHunDDfk48ngp0e8fCEWKF68=
-github.com/keep-network/keep-core v1.1.3/go.mod h1:xhPlO1jYmapYwR9uKWWAubDdfaZ5NMru7XqxWRyrmq4=
+github.com/keep-network/keep-core v0.14.1-rc.0.20200516202120-19889483db36 h1:cAlN9bA+6/qiYxGawvu8PzQBut+MRF8RevkmTO+selg=
+github.com/keep-network/keep-core v0.14.1-rc.0.20200516202120-19889483db36/go.mod h1:nDEcqn7EBbTsn0RhGFqJMRKU0X7mYdrlE/XPUGM1YI4=
 github.com/keep-network/toml v0.3.0 h1:G+NJwWR/ZiORqeLBsDXDchYoL29PXHdxOPcCueA7ctE=
 github.com/keep-network/toml v0.3.0/go.mod h1:Zeyd3lxbIlMYLREho3UK1dMP2xjqt2gLkQ5E5vM6K38=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=

--- a/go.sum
+++ b/go.sum
@@ -245,8 +245,8 @@ github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec h
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec/go.mod h1:xR8jf3/VJAjh3nWu5tFe8Yxnt2HvWsqZHfGef1P5oDk=
 github.com/keep-network/keep-common v0.3.2 h1:Yty+rgBXLD2yfWvqG4r45SIHUbyTfuQeFtZDonz9kBs=
 github.com/keep-network/keep-common v0.3.2/go.mod h1:0uY+hufkP66nFnL+3GXMwWXRiKKsFyXFQTby1xR7AwY=
-github.com/keep-network/keep-common v1.0.0 h1:buLpkvahX5oJc6DIQZe7aAxTJqyWx61xM1uSUD8UVCY=
-github.com/keep-network/keep-common v1.0.0/go.mod h1:0uY+hufkP66nFnL+3GXMwWXRiKKsFyXFQTby1xR7AwY=
+github.com/keep-network/keep-common v1.0.1-0.20200515214626-9036c7c35946 h1:fvkIlIuuEd42K2U4E2cYFlTpBt0F6JysDg6zBkxXRPM=
+github.com/keep-network/keep-common v1.0.1-0.20200515214626-9036c7c35946/go.mod h1:0uY+hufkP66nFnL+3GXMwWXRiKKsFyXFQTby1xR7AwY=
 github.com/keep-network/keep-core v1.1.3 h1:YWJfs6dCImWlGYV8JP9lHunDDfk48ngp0e8fCEWKF68=
 github.com/keep-network/keep-core v1.1.3/go.mod h1:xhPlO1jYmapYwR9uKWWAubDdfaZ5NMru7XqxWRyrmq4=
 github.com/keep-network/toml v0.3.0 h1:G+NJwWR/ZiORqeLBsDXDchYoL29PXHdxOPcCueA7ctE=

--- a/pkg/chain/ethereum/ethereum.go
+++ b/pkg/chain/ethereum/ethereum.go
@@ -254,6 +254,7 @@ func (ec *EthereumChain) getKeepContract(address common.Address) (*contract.Bond
 		ec.accountKey,
 		ec.client,
 		ec.nonceManager,
+		ec.miningWaiter,
 		ec.transactionMutex,
 	)
 	if err != nil {


### PR DESCRIPTION
Two unrelated but important changes are incorporated into this PR:

- The client validates protocol identifier during the handshake

  See https://github.com/keep-network/keep-core/pull/1807

  There are two protocols run by Keep network: `keep-beacon` and `keep-ecdsa`. Both initiator and responder are expected to pass the protocol identifier during the handshake. This change lets to eliminate an honest, misconfigured nodes from the subnetwork they do not support.

- Gas price automatically bumping up

  https://github.com/keep-network/keep-common/pull/36

  For every submitted transaction, we check in the predefined intervals if the transaction has been mined already and if not, we increase the gas price by 20% and try to submit again.
  The interval at which we check for transaction status, as well as the maximum gas price, can be configured.
