### PR TITLE
Do not attempt to generate key if it is available in the registry

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -299,6 +299,22 @@ func checkAwaitingKeyGenerationForKeep(
 		return nil
 	}
 
+	// If the key material is stored in the registry it means that the key
+	// generation succeeded and public key transaction has been submitted.
+	// There are two scenarios possible:
+	// - public key submission transactions are still mining,
+	// - conflicting public key has been submitted.
+	// In both cases, the client should not attempt to generate the key again.
+	if keepsRegistry.HasSigner(keep) {
+		logger.Warningf(
+			"keep public key is not registered on-chain but key material "+
+				"is stored on disk; skipping key generation; PLEASE INSPECT "+
+				"PUBLIC KEY SUBMISSION TRANSACTION FOR KEEP [%v]",
+			keep.String(),
+		)
+		return nil
+	}
+
 	members, err := ethereumChain.GetMembers(keep)
 	if err != nil {
 		return err

--- a/pkg/registry/keeps.go
+++ b/pkg/registry/keeps.go
@@ -67,6 +67,16 @@ func (k *Keeps) GetSigners(keepAddress common.Address) ([]*tss.ThresholdSigner, 
 	return signers, nil
 }
 
+// HasSigner returns true if at least one signer exists in the registry
+// for the keep with the given addres.
+func (k *Keeps) HasSigner(keepAddress common.Address) bool {
+	k.myKeepsMutex.RLock()
+	defer k.myKeepsMutex.RUnlock()
+
+	_, has := k.myKeeps[keepAddress]
+	return has
+}
+
 // GetKeepsAddresses returns addresses of all registered keeps.
 func (k *Keeps) GetKeepsAddresses() []common.Address {
 	k.myKeepsMutex.RLock()


### PR DESCRIPTION
We recently had an interesting situation when all three clients in the signing group have been restarted before public key submission transactions were mined. Clients started key generation again, submitted new keys to the chain (those transactions were later reverted) and replaced key material stored on disk.

This situation is very unlikely to happen but it happened.

Here we update the code to never start key generation again if the key material is available in the registry. There are two scenarios possible:
- public key submission transactions are still mining,
- the conflicting public key has been submitted.

In both cases, the client should not attempt to generate the key again.

Also, worth mentioning, that the other changes to keep client we have in the queue are making public key submission process faster by automatically increasing gas price for the transaction if it has not been mined in a reasonable time.