### PR TITLE
Updated keep-core dependency to v1.2.0-rc.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,8 +18,8 @@ require (
 	github.com/gogo/protobuf v1.3.1
 	github.com/google/gofuzz v1.1.0
 	github.com/ipfs/go-log v0.0.1
-	github.com/keep-network/keep-common v1.0.1-0.20200515214626-9036c7c35946
-	github.com/keep-network/keep-core v0.14.1-rc.0.20200516202120-19889483db36
+	github.com/keep-network/keep-common v1.1.0
+	github.com/keep-network/keep-core v1.2.0-rc.1
 	github.com/pkg/errors v0.9.1
 	github.com/urfave/cli v1.22.1
 )

--- a/go.sum
+++ b/go.sum
@@ -243,10 +243,10 @@ github.com/keep-network/cli v1.20.0 h1:mEufpPsovOVdduTTkk+a2CxS3crIrGFqUsvs58gSi
 github.com/keep-network/cli v1.20.0/go.mod h1:nzsst4JjU+rGE8Q5J839fYxectxWHpLhxKNohQWtQhA=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec h1:2pXAsi4OUUjZKr5ds5UOF2IxXN+jVW0WetVO+czkf+A=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec/go.mod h1:xR8jf3/VJAjh3nWu5tFe8Yxnt2HvWsqZHfGef1P5oDk=
-github.com/keep-network/keep-common v1.0.1-0.20200515214626-9036c7c35946 h1:fvkIlIuuEd42K2U4E2cYFlTpBt0F6JysDg6zBkxXRPM=
-github.com/keep-network/keep-common v1.0.1-0.20200515214626-9036c7c35946/go.mod h1:0uY+hufkP66nFnL+3GXMwWXRiKKsFyXFQTby1xR7AwY=
-github.com/keep-network/keep-core v0.14.1-rc.0.20200516202120-19889483db36 h1:cAlN9bA+6/qiYxGawvu8PzQBut+MRF8RevkmTO+selg=
-github.com/keep-network/keep-core v0.14.1-rc.0.20200516202120-19889483db36/go.mod h1:nDEcqn7EBbTsn0RhGFqJMRKU0X7mYdrlE/XPUGM1YI4=
+github.com/keep-network/keep-common v1.1.0 h1:m5ZDfUpH+DVqQz3qIi+E53utWHv7kVSooPD01kVG3n8=
+github.com/keep-network/keep-common v1.1.0/go.mod h1:0uY+hufkP66nFnL+3GXMwWXRiKKsFyXFQTby1xR7AwY=
+github.com/keep-network/keep-core v1.2.0-rc.1 h1:wLGulrR33ivFczdhtfp3J774htpIsUEQVbVUbhzBCyo=
+github.com/keep-network/keep-core v1.2.0-rc.1/go.mod h1:+8wx+DsRXczgc0By80PecvDTVu9HRh2Ti671/uFdGsQ=
 github.com/keep-network/toml v0.3.0 h1:G+NJwWR/ZiORqeLBsDXDchYoL29PXHdxOPcCueA7ctE=
 github.com/keep-network/toml v0.3.0/go.mod h1:Zeyd3lxbIlMYLREho3UK1dMP2xjqt2gLkQ5E5vM6K38=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=


### PR DESCRIPTION
Updated `keep-core` dependency to tagged version. The code is the same as
in the previously referenced commit hash but since we are preparing for
a new RC we are replacing commit hash with the appropriate version.

`keep-core` update entails `keep-common` update to a tagged version, no code
changes here as well compared to the previously referenced commit hash.