### PR TITLE
Run the container as a user without privileges

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -71,5 +71,8 @@ FROM runtime
 
 COPY --from=gobuild $BIN_PATH/$APP_NAME $BIN_PATH
 
+# Run as a user without privileges.
+USER nobody
+
 # docker caches more when using CMD [] resulting in a faster build.
 CMD []


### PR DESCRIPTION
Currently the client runs as root by default:
```bash
user@host:~/keep-core$ sudo docker run --entrypoint "" keepnetwork/keep-ecdsa-client:latest whoami
root
```
Per https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user it's better to run as a non-root user when possible.  This copies the approach from https://github.com/prometheus/prometheus/pull/2859, which defaults to using `nobody` and allows overrides using the `--user` flag (for more discussion see https://github.com/prometheus/prometheus/issues/3441).

After the change:
```bash
user@host:~/keep-core$ sudo docker run --entrypoint "" keep-ecdsa-nobody:latest whoami
nobody
```

Tested by building the image from source and running my testnet node with it and the `--user $UID:$GID` flag (node was originally setup using these [instructions](https://medium.com/@novysf/run-a-keep-network-testnet-node-37096946af35)).

**NOTE: This is a breaking change and after landing users will need to ensure the mounted persistent directory has the correct ownership and/or they set `--user` correctly.**

Same thing as https://github.com/keep-network/keep-core/pull/1826.