### PR TITLE
Allow grantee withdraw unbonded value from KeepBonding

### DIFF
--- a/solidity/contracts/KeepBonding.sol
+++ b/solidity/contracts/KeepBonding.sol
@@ -356,6 +356,9 @@ contract KeepBonding {
         return authorizedPools[_operator][_poolAddress];
     }
 
+    /// @notice Withdraws the provided amount from unbonded value of the
+    /// provided operator to operator's beneficiary. If there is no enough
+    /// unbonded value or the transfer failed, function fails.
     function withdrawBond(uint256 amount, address operator) internal {
         require(
             unbondedValue[operator] >= amount,

--- a/solidity/contracts/KeepBonding.sol
+++ b/solidity/contracts/KeepBonding.sol
@@ -16,6 +16,8 @@ pragma solidity 0.5.17;
 
 import "@keep-network/keep-core/contracts/KeepRegistry.sol";
 import "@keep-network/keep-core/contracts/TokenStaking.sol";
+import "@keep-network/keep-core/contracts/TokenGrant.sol";
+import "@keep-network/keep-core/contracts/libraries/RolesLookup.sol";
 
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 
@@ -24,12 +26,16 @@ import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 /// @notice Contract holding deposits from keeps' operators.
 contract KeepBonding {
     using SafeMath for uint256;
+    using RolesLookup for address payable;
 
     // Registry contract with a list of approved factories (operator contracts).
     KeepRegistry internal registry;
 
     // KEEP token staking contract.
     TokenStaking internal tokenStaking;
+
+    // KEEP token grant contract.
+    TokenGrant internal tokenGrant;
 
     // Unassigned value in wei deposited by operators.
     mapping(address => uint256) public unbondedValue;
@@ -67,10 +73,16 @@ contract KeepBonding {
 
     /// @notice Initializes Keep Bonding contract.
     /// @param registryAddress Keep registry contract address.
-    /// @param tokenStakingAddress KEEP Token staking contract address.
-    constructor(address registryAddress, address tokenStakingAddress) public {
+    /// @param tokenStakingAddress KEEP token staking contract address.
+    /// @param tokenGrantAddress KEEP token grant contract address.
+    constructor(
+        address registryAddress,
+        address tokenStakingAddress,
+        address tokenGrantAddress
+    ) public {
         registry = KeepRegistry(registryAddress);
         tokenStaking = TokenStaking(tokenStakingAddress);
+        tokenGrant = TokenGrant(tokenGrantAddress);
     }
 
     /// @notice Add the provided value to operator's pool available for bonding.
@@ -109,29 +121,43 @@ contract KeepBonding {
     }
 
     /// @notice Withdraws amount from operator's value available for bonding.
-    /// Can be called only by the operator or by the stake owner.
+    /// Can be called only by:
+    /// - operator
+    /// - staked tokens owner
+    /// - direct staked tokens grantee (not a managed grant).
     /// @param amount Value to withdraw in wei.
     /// @param operator Address of the operator.
     function withdraw(uint256 amount, address operator) public {
         require(
             msg.sender == operator ||
-                msg.sender == tokenStaking.ownerOf(operator),
+                msg.sender.isTokenOwnerForOperator(operator, tokenStaking) ||
+                msg.sender.isGranteeForOperator(operator, tokenGrant),
             "Only operator or the owner is allowed to withdraw bond"
         );
 
+        withdrawBond(amount, operator);
+    }
+
+    /// @notice Withdraws amount from operator's value available for bonding.
+    /// Can be called only by staked tokens managed grantee.
+    /// @param amount Value to withdraw in wei.
+    /// @param operator Address of the operator.
+    /// @param managedGrant Address of the managed grant contract.
+    function withdrawAsManagedGrantee(
+        uint256 amount,
+        address operator,
+        address managedGrant
+    ) public {
         require(
-            unbondedValue[operator] >= amount,
-            "Insufficient unbonded value"
+            msg.sender.isManagedGranteeForOperator(
+                operator,
+                managedGrant,
+                tokenGrant
+            ),
+            "Only grantee is allowed to withdraw bond"
         );
 
-        unbondedValue[operator] = unbondedValue[operator].sub(amount);
-
-        (bool success, ) = tokenStaking.beneficiaryOf(operator).call.value(
-            amount
-        )("");
-        require(success, "Transfer failed");
-
-        emit UnbondedValueWithdrawn(operator, amount);
+        withdrawBond(amount, operator);
     }
 
     /// @notice Create bond for the given operator, holder, reference and amount.
@@ -328,5 +354,21 @@ contract KeepBonding {
         returns (bool)
     {
         return authorizedPools[_operator][_poolAddress];
+    }
+
+    function withdrawBond(uint256 amount, address operator) internal {
+        require(
+            unbondedValue[operator] >= amount,
+            "Insufficient unbonded value"
+        );
+
+        unbondedValue[operator] = unbondedValue[operator].sub(amount);
+
+        (bool success, ) = tokenStaking.beneficiaryOf(operator).call.value(
+            amount
+        )("");
+        require(success, "Transfer failed");
+
+        emit UnbondedValueWithdrawn(operator, amount);
     }
 }

--- a/solidity/contracts/KeepBonding.sol
+++ b/solidity/contracts/KeepBonding.sol
@@ -121,10 +121,14 @@ contract KeepBonding {
     }
 
     /// @notice Withdraws amount from operator's value available for bonding.
-    /// Can be called only by:
-    /// - operator
-    /// - staked tokens owner
+    /// Should not be used by grantee of managed grants. For this case,
+    /// please use `withdrawAsManagedGrantee`.
+    ///
+    /// This function can be called only by:
+    /// - operator,
+    /// - liquid, staked tokens owner (not a grant),
     /// - direct staked tokens grantee (not a managed grant).
+    ///
     /// @param amount Value to withdraw in wei.
     /// @param operator Address of the operator.
     function withdraw(uint256 amount, address operator) public {

--- a/solidity/migrations/2_deploy_contracts.js
+++ b/solidity/migrations/2_deploy_contracts.js
@@ -17,6 +17,7 @@ const BondedSortitionPoolFactory = artifacts.require(
 let {
   RandomBeaconAddress,
   TokenStakingAddress,
+  TokenGrantAddress,
   RegistryAddress,
 } = require("./external-contracts")
 
@@ -27,13 +28,21 @@ module.exports = async function (deployer) {
     TokenStakingStub = artifacts.require("TokenStakingStub")
     TokenStakingAddress = (await TokenStakingStub.new()).address
 
+    TokenGrantStub = artifacts.require("TokenGrantStub")
+    TokenGrantAddress = (await TokenGrantStub.new()).address
+
     RandomBeaconStub = artifacts.require("RandomBeaconStub")
     RandomBeaconAddress = (await RandomBeaconStub.new()).address
 
     RegistryAddress = (await deployer.deploy(KeepRegistry)).address
   }
 
-  await deployer.deploy(KeepBonding, RegistryAddress, TokenStakingAddress)
+  await deployer.deploy(
+    KeepBonding,
+    RegistryAddress,
+    TokenStakingAddress,
+    TokenGrantAddress
+  )
 
   await deployer.deploy(BondedECDSAKeep)
 

--- a/solidity/migrations/external-contracts.js
+++ b/solidity/migrations/external-contracts.js
@@ -1,12 +1,14 @@
 // Addresses of externally deployed smart contracts
 const RegistryAddress = "0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
 const TokenStakingAddress = "0xBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB"
-const RandomBeaconAddress = "0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"
-const TBTCSystemAddress = "0xDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD"
+const TokenGrantAddress = "0xCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC"
+const RandomBeaconAddress = "0xDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDDD"
+const TBTCSystemAddress = "0xEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEEE"
 
 module.exports = {
   RegistryAddress,
   TokenStakingAddress,
+  TokenGrantAddress,
   RandomBeaconAddress,
   TBTCSystemAddress,
 }

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -879,9 +879,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.1.2.tgz",
-      "integrity": "sha512-BEpq/hdqmPZeGc3/EMdbgGeQQgspf41UYsDaFJxOb86UxpKe59aAqOV8eJYFGNec28KFa5l7bl7ucMWqilrbww==",
+      "version": "1.2.3-rc.1",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.2.3-rc.1.tgz",
+      "integrity": "sha512-W/Nu4JvGb5/1BBW0gBFyXEPAs7f43ctdeU/ZFRa7IupqPE2vKp2KcW8rmr8BeOqOWY+MvRly02yjaulUBwb9DA==",
       "requires": {
         "@openzeppelin/contracts-ethereum-package": "^2.4.0",
         "@openzeppelin/upgrades": "^2.7.2",

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -879,9 +879,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "1.2.3-rc.1",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.2.3-rc.1.tgz",
-      "integrity": "sha512-W/Nu4JvGb5/1BBW0gBFyXEPAs7f43ctdeU/ZFRa7IupqPE2vKp2KcW8rmr8BeOqOWY+MvRly02yjaulUBwb9DA==",
+      "version": "1.2.3-pre.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.2.3-pre.0.tgz",
+      "integrity": "sha512-acnELPecyPbk4pkcsPHqCnXyMntG0qS2e1I1gTeqWLE/VOkcgvgv2QnCCQY31lwP9Ne0J7Vmq0upqmJtrH9/Gg==",
       "requires": {
         "@openzeppelin/contracts-ethereum-package": "^2.4.0",
         "@openzeppelin/upgrades": "^2.7.2",

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/keep-network/keep-ecdsa",
   "dependencies": {
-    "@keep-network/keep-core": "1.2.3-rc.1",
+    "@keep-network/keep-core": "1.2.3-pre.0",
     "@keep-network/sortition-pools": "1.0.0",
     "@openzeppelin/upgrades": "^2.7.2",
     "openzeppelin-solidity": "2.3.0",

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/keep-network/keep-ecdsa",
   "dependencies": {
-    "@keep-network/keep-core": "1.1.2",
+    "@keep-network/keep-core": "1.2.3-rc.1",
     "@keep-network/sortition-pools": "1.0.0",
     "@openzeppelin/upgrades": "^2.7.2",
     "openzeppelin-solidity": "2.3.0",

--- a/solidity/scripts/lcl-provision-external-contracts.sh
+++ b/solidity/scripts/lcl-provision-external-contracts.sh
@@ -18,6 +18,9 @@ REGISTRY_PROPERTY="RegistryAddress"
 TOKEN_STAKING_CONTRACT_DATA="TokenStaking.json"
 TOKEN_STAKING_PROPERTY="TokenStakingAddress"
 
+TOKEN_GRANT_CONTRACT_DATA="TokenGrant.json"
+TOKEN_GRANT_PROPERTY="TokenGrantAddress"
+
 RANDOM_BEACON_CONTRACT_DATA="KeepRandomBeaconService.json"
 RANDOM_BEACON_PROPERTY="RandomBeaconAddress"
 
@@ -61,6 +64,21 @@ function fetch_token_staking_contract_address() {
   fi
 }
 
+function fetch_token_grant_contract_address() {
+  echo "Fetching value for ${TOKEN_GRANT_PROPERTY}..."
+
+  local contractDataPath=$(realpath $KEEP_CORE_SOL_ARTIFACTS_PATH/$TOKEN_GRANT_CONTRACT_DATA)
+  local ADDRESS=$(cat ${contractDataPath} | jq "${JSON_QUERY}" | tr -d '"')
+
+  if [[ !($ADDRESS =~ $ADDRESS_REGEXP) ]]; then
+    echo "Invalid address: ${ADDRESS}"
+    FAILED=true
+  else 
+    echo "Found value for ${TOKEN_GRANT_PROPERTY} = ${ADDRESS}"
+    sed -i -e "/${TOKEN_GRANT_PROPERTY}/s/${SED_SUBSTITUTION_REGEXP}/\"${ADDRESS}\"/" $DESTINATION_FILE
+  fi
+}
+
 function fetch_random_beacon_contract_address() {
   echo "Fetching value for ${RANDOM_BEACON_PROPERTY}..."
 
@@ -78,6 +96,7 @@ function fetch_random_beacon_contract_address() {
 
 fetch_registry_contract_address
 fetch_token_staking_contract_address
+fetch_token_grant_contract_address
 fetch_random_beacon_contract_address
 
 if $FAILED; then

--- a/solidity/test/BondedECDSAKeepFactoryTest.js
+++ b/solidity/test/BondedECDSAKeepFactoryTest.js
@@ -12,6 +12,7 @@ const BondedECDSAKeepFactoryStub = artifacts.require(
 )
 const KeepBonding = artifacts.require("KeepBonding")
 const TokenStakingStub = artifacts.require("TokenStakingStub")
+const TokenGrantStub = artifacts.require("TokenGrantStub")
 const BondedSortitionPool = artifacts.require("BondedSortitionPool")
 const BondedSortitionPoolFactory = artifacts.require(
   "BondedSortitionPoolFactory"
@@ -28,6 +29,7 @@ const expect = chai.expect
 contract("BondedECDSAKeepFactory", async (accounts) => {
   let registry
   let tokenStaking
+  let tokenGrant
   let keepFactory
   let bondedSortitionPoolFactory
   let keepBonding
@@ -1178,9 +1180,11 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
       registry = await KeepRegistry.new()
       bondedSortitionPoolFactory = await BondedSortitionPoolFactory.new()
       tokenStaking = await TokenStakingStub.new()
+      tokenGrant = await TokenGrantStub.new()
       keepBonding = await KeepBonding.new(
         registry.address,
-        tokenStaking.address
+        tokenStaking.address,
+        tokenGrant.address
       )
       randomBeacon = accounts[1]
       const bondedECDSAKeepMasterContract = await BondedECDSAKeep.new()
@@ -1477,7 +1481,12 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
     registry = await KeepRegistry.new()
     bondedSortitionPoolFactory = await BondedSortitionPoolFactory.new()
     tokenStaking = await TokenStakingStub.new()
-    keepBonding = await KeepBonding.new(registry.address, tokenStaking.address)
+    tokenGrant = await TokenGrantStub.new()
+    keepBonding = await KeepBonding.new(
+      registry.address,
+      tokenStaking.address,
+      tokenGrant.address
+    )
     randomBeacon = await RandomBeaconStub.new()
     const bondedECDSAKeepMasterContract = await BondedECDSAKeep.new()
     keepFactory = await BondedECDSAKeepFactoryStub.new(

--- a/solidity/test/BondedECDSAKeepIntegrationTest.js
+++ b/solidity/test/BondedECDSAKeepIntegrationTest.js
@@ -11,6 +11,7 @@ const BondedECDSAKeepFactoryStub = artifacts.require(
 )
 const KeepBonding = artifacts.require("KeepBonding")
 const TokenStaking = artifacts.require("TokenStaking")
+const TokenGrant = artifacts.require("TokenGrant")
 const BondedSortitionPool = artifacts.require("BondedSortitionPool")
 const BondedSortitionPoolFactory = artifacts.require(
   "BondedSortitionPoolFactory"
@@ -27,6 +28,7 @@ const expect = chai.expect
 contract("BondedECDSAKeepFactory", async (accounts) => {
   let keepToken
   let tokenStaking
+  let tokenGrant
   let keepFactory
   let bondedSortitionPoolFactory
   let keepBonding
@@ -245,8 +247,13 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
       initializationPeriod,
       undelegationPeriod
     )
+    tokenGrant = await TokenGrant.new(keepToken.address)
 
-    keepBonding = await KeepBonding.new(registry.address, tokenStaking.address)
+    keepBonding = await KeepBonding.new(
+      registry.address,
+      tokenStaking.address,
+      tokenGrant.address
+    )
     randomBeacon = await RandomBeaconStub.new()
     const bondedECDSAKeepMasterContract = await BondedECDSAKeep.new()
     keepFactory = await BondedECDSAKeepFactoryStub.new(

--- a/solidity/test/BondedECDSAKeepTest.js
+++ b/solidity/test/BondedECDSAKeepTest.js
@@ -16,6 +16,7 @@ const TestToken = artifacts.require("TestToken")
 const KeepBonding = artifacts.require("KeepBonding")
 const TestEtherReceiver = artifacts.require("TestEtherReceiver")
 const TokenStakingStub = artifacts.require("TokenStakingStub")
+const TokenGrantStub = artifacts.require("TokenGrantStub")
 const BondedECDSAKeepCloneFactory = artifacts.require(
   "BondedECDSAKeepCloneFactory"
 )
@@ -42,6 +43,7 @@ contract("BondedECDSAKeep", (accounts) => {
   let registry
   let keepBonding
   let tokenStaking
+  let tokenGrant
   let bondedECDSAKeepStubMaster
   let keep
   let factoryStub
@@ -87,7 +89,12 @@ contract("BondedECDSAKeep", (accounts) => {
   before(async () => {
     registry = await KeepRegistry.new()
     tokenStaking = await TokenStakingStub.new()
-    keepBonding = await KeepBonding.new(registry.address, tokenStaking.address)
+    tokenGrant = await TokenGrantStub.new()
+    keepBonding = await KeepBonding.new(
+      registry.address,
+      tokenStaking.address,
+      tokenGrant.address
+    )
     bondedECDSAKeepStubMaster = await BondedECDSAKeepStub.new()
     factoryStub = await BondedECDSAKeepCloneFactory.new(
       bondedECDSAKeepStubMaster.address

--- a/solidity/test/KeepBondingTest.js
+++ b/solidity/test/KeepBondingTest.js
@@ -2,6 +2,8 @@ import {createSnapshot, restoreSnapshot} from "./helpers/snapshot"
 
 const KeepRegistry = artifacts.require("./KeepRegistry.sol")
 const TokenStaking = artifacts.require("./TokenStakingStub.sol")
+const TokenGrant = artifacts.require("./TokenGrantStub.sol")
+const ManagedGrant = artifacts.require("./ManagedGrantStub.sol")
 const KeepBonding = artifacts.require("./KeepBonding.sol")
 const TestEtherReceiver = artifacts.require("./TestEtherReceiver.sol")
 
@@ -16,6 +18,7 @@ const expect = chai.expect
 contract("KeepBonding", (accounts) => {
   let registry
   let tokenStaking
+  let tokenGrant
   let keepBonding
   let etherReceiver
 
@@ -34,7 +37,12 @@ contract("KeepBonding", (accounts) => {
 
     registry = await KeepRegistry.new()
     tokenStaking = await TokenStaking.new()
-    keepBonding = await KeepBonding.new(registry.address, tokenStaking.address)
+    tokenGrant = await TokenGrant.new()
+    keepBonding = await KeepBonding.new(
+      registry.address,
+      tokenStaking.address,
+      tokenGrant.address
+    )
     etherReceiver = await TestEtherReceiver.new()
 
     await registry.approveOperatorContract(bondCreator)
@@ -85,7 +93,40 @@ contract("KeepBonding", (accounts) => {
       await keepBonding.deposit(operator, {value: value})
     })
 
-    it("transfers unbonded value to beneficiary of operator", async () => {
+    it("can be called by operator", async () => {
+      const tokenOwner = accounts[2]
+      await tokenStaking.setOwner(operator, tokenOwner)
+
+      await keepBonding.withdraw(value, operator, {from: operator})
+      // ok, no reverts
+    })
+
+    it("can be called by token owner", async () => {
+      const tokenOwner = accounts[2]
+      await tokenStaking.setOwner(operator, tokenOwner)
+
+      await keepBonding.withdraw(value, operator, {from: tokenOwner})
+      // ok, no reverts
+    })
+
+    it("can be called by grantee", async () => {
+      const grantee = accounts[2]
+      await tokenGrant.setGranteeOperator(grantee, operator)
+
+      await keepBonding.withdraw(value, operator, {from: grantee})
+      // ok, no reverts
+    })
+
+    it("cannot be called by third party", async () => {
+      const thirdParty = accounts[2]
+
+      await expectRevert(
+        keepBonding.withdraw(value, operator, {from: thirdParty}),
+        "Only operator or the owner is allowed to withdraw bond"
+      )
+    })
+
+    it("transfers unbonded value to beneficiary", async () => {
       const expectedUnbonded = 0
       await tokenStaking.setBeneficiary(operator, beneficiary)
       const expectedBeneficiaryBalance = web3.utils
@@ -106,13 +147,6 @@ contract("KeepBonding", (accounts) => {
         expectedBeneficiaryBalance,
         "invalid beneficiary balance"
       )
-    })
-
-    it("succeeds when called by owner", async () => {
-      const owner = accounts[2]
-      await tokenStaking.setOwner(operator, owner)
-
-      await keepBonding.withdraw(value, operator, {from: owner})
     })
 
     it("emits event", async () => {
@@ -145,14 +179,155 @@ contract("KeepBonding", (accounts) => {
         "Transfer failed"
       )
     })
+  })
 
-    it("reverts if neither operator nor the owner is trying to withdraw bond", async () => {
-      const owner = accounts[2]
-      await tokenStaking.setOwner(operator, owner)
+  describe("withdrawAsManagedGrantee", async () => {
+    const value = new BN(1000)
+    const managedGrantee = accounts[2]
+    let managedGrant
+
+    beforeEach(async () => {
+      await keepBonding.deposit(operator, {value: value})
+
+      managedGrant = await ManagedGrant.new(managedGrantee)
+      await tokenGrant.setGranteeOperator(managedGrant.address, operator)
+    })
+
+    it("can be called by managed grantee", async () => {
+      await keepBonding.withdrawAsManagedGrantee(
+        value,
+        operator,
+        managedGrant.address,
+        {from: managedGrantee}
+      )
+      // ok, no reverts
+    })
+
+    it("cannot be called by operator", async () => {
+      await expectRevert(
+        keepBonding.withdrawAsManagedGrantee(
+          value,
+          operator,
+          managedGrant.address,
+          {from: operator}
+        ),
+        "Not a grantee of the provided contract"
+      )
+    })
+
+    it("cannot be called by token owner", async () => {
+      const tokenOwner = accounts[0]
+      await tokenStaking.setOwner(operator, tokenOwner)
 
       await expectRevert(
-        keepBonding.withdraw(value, operator, {from: accounts[3]}),
-        "Only operator or the owner is allowed to withdraw bond"
+        keepBonding.withdrawAsManagedGrantee(
+          value,
+          operator,
+          managedGrant.address,
+          {from: tokenOwner}
+        ),
+        "Not a grantee of the provided contract"
+      )
+    })
+
+    it("cannot be called by a standard grantee", async () => {
+      const standardGrantee = accounts[0]
+      await tokenGrant.setGranteeOperator(standardGrantee, operator)
+
+      await expectRevert(
+        keepBonding.withdrawAsManagedGrantee(
+          value,
+          operator,
+          managedGrant.address,
+          {from: standardGrantee}
+        ),
+        "Not a grantee of the provided contract"
+      )
+    })
+
+    it("cannot be called by third party", async () => {
+      const thirdParty = accounts[0]
+
+      await expectRevert(
+        keepBonding.withdrawAsManagedGrantee(
+          value,
+          operator,
+          managedGrant.address,
+          {from: thirdParty}
+        ),
+        "Not a grantee of the provided contract"
+      )
+    })
+
+    it("transfers unbonded value to beneficiary", async () => {
+      const expectedUnbonded = 0
+      await tokenStaking.setBeneficiary(operator, beneficiary)
+      const expectedBeneficiaryBalance = web3.utils
+        .toBN(await web3.eth.getBalance(beneficiary))
+        .add(value)
+
+      await keepBonding.withdrawAsManagedGrantee(
+        value,
+        operator,
+        managedGrant.address,
+        {from: managedGrantee}
+      )
+
+      const unbonded = await keepBonding.availableUnbondedValue(
+        operator,
+        bondCreator,
+        sortitionPool
+      )
+      expect(unbonded).to.eq.BN(expectedUnbonded, "invalid unbonded value")
+
+      const actualBeneficiaryBalance = await web3.eth.getBalance(beneficiary)
+      expect(actualBeneficiaryBalance).to.eq.BN(
+        expectedBeneficiaryBalance,
+        "invalid beneficiary balance"
+      )
+    })
+
+    it("emits event", async () => {
+      const value = new BN(90)
+
+      const receipt = await keepBonding.withdrawAsManagedGrantee(
+        value,
+        operator,
+        managedGrant.address,
+        {from: managedGrantee}
+      )
+      expectEvent(receipt, "UnbondedValueWithdrawn", {
+        operator: operator,
+        amount: value,
+      })
+    })
+
+    it("reverts if insufficient unbonded value", async () => {
+      const invalidValue = value.add(new BN(1))
+
+      await expectRevert(
+        keepBonding.withdrawAsManagedGrantee(
+          invalidValue,
+          operator,
+          managedGrant.address,
+          {from: managedGrantee}
+        ),
+        "Insufficient unbonded value"
+      )
+    })
+
+    it("reverts if transfer fails", async () => {
+      await etherReceiver.setShouldFail(true)
+      await tokenStaking.setBeneficiary(operator, etherReceiver.address)
+
+      await expectRevert(
+        keepBonding.withdrawAsManagedGrantee(
+          value,
+          operator,
+          managedGrant.address,
+          {from: managedGrantee}
+        ),
+        "Transfer failed"
       )
     })
   })

--- a/solidity/test/contracts/ManagedGrantStub.sol
+++ b/solidity/test/contracts/ManagedGrantStub.sol
@@ -1,0 +1,9 @@
+pragma solidity 0.5.17;
+
+contract ManagedGrantStub {
+    address public grantee;
+
+    constructor(address _grantee) public {
+        grantee = _grantee;
+    }
+}

--- a/solidity/test/contracts/TokenGrantStub.sol
+++ b/solidity/test/contracts/TokenGrantStub.sol
@@ -1,0 +1,17 @@
+pragma solidity 0.5.17;
+
+contract TokenGrantStub {
+    mapping(address => address[]) granteeOperators;
+
+    function getGranteeOperators(
+        address grantee
+    ) public view returns(address[] memory) {
+        return granteeOperators[grantee];
+    }
+
+    function setGranteeOperator(address grantee, address operator) public {
+        address[] memory operators = new address[](1);
+        operators[0] = operator;
+        granteeOperators[grantee] = operators;
+    }
+}


### PR DESCRIPTION
Depends on: https://github.com/keep-network/keep-core/pull/1834
Once https://github.com/keep-network/keep-core/pull/1834 is merged and new `1.2.0-pre` version of `keep-core` is published to NPM registry, please update `"@keep-network/keep-core" version referenced in `package.json`.

The previous construction allowed only the operator or token owner to withdraw the unbonded value. We were not allowing the token grantee to do that.

There are four valid cases for unbonded value withdrawal:
- operator withdraws,
- token owner withdraws (when the delegated stake are tokens owned by the delegating party),
- grantee withdraws (when the delegated stake are tokens granted to the delegating party),
- managed grantee withdraws (when the delegated stake are tokens granted to the delegating party via `ManagedGrant` contract).

All those cases are now supported in `KeepBonding` contract. The last case requires separate function since it is not possible to lookup `ManagedGrant` contract address in another way than by using an event.