### PR TITLE
Deauthorize sortition pool

### DIFF
--- a/solidity/contracts/KeepBonding.sol
+++ b/solidity/contracts/KeepBonding.sol
@@ -295,6 +295,23 @@ contract KeepBonding {
         authorizedPools[_operator][_poolAddress] = true;
     }
 
+    /// @notice Deauthorizes sortition pool for the provided operator.
+    /// Authorizer may deauthorize individual sortition pool in case the
+    /// operator should no longer be eligible for work selection and the
+    /// application represented by the sortition pool should no longer be
+    /// eligible to create bonds for the operator.
+    /// @dev Only operator's authorizer can call this function.
+    function deauthorizeSortitionPoolContract(
+        address _operator,
+        address _poolAddress
+    ) public {
+        require(
+            tokenStaking.authorizerOf(_operator) == msg.sender,
+            "Not authorized"
+        );
+        authorizedPools[_operator][_poolAddress] = false;
+    }
+
     /// @notice Checks if the sortition pool has been authorized for the
     /// provided operator by its authorizer.
     /// @dev See authorizeSortitionPoolContract.

--- a/solidity/test/KeepBondingTest.js
+++ b/solidity/test/KeepBondingTest.js
@@ -715,7 +715,7 @@ contract("KeepBonding", (accounts) => {
       )
     })
 
-    it("should authorize sortition pool for provided operator", async () => {
+    it("should authorize sortition pool for the provided operator", async () => {
       await keepBonding.authorizeSortitionPoolContract(
         operator,
         sortitionPool,
@@ -724,7 +724,37 @@ contract("KeepBonding", (accounts) => {
 
       assert.isTrue(
         await keepBonding.hasSecondaryAuthorization(operator, sortitionPool),
-        "Sortition pool has not beeen authorized for provided operator"
+        "Sortition pool should be authorized for the provided operator"
+      )
+    })
+  })
+
+  describe("deauthorizeSortitionPoolContract", async () => {
+    it("reverts when operator is not an authorizer", async () => {
+      const authorizer1 = accounts[2]
+
+      await expectRevert(
+        keepBonding.deauthorizeSortitionPoolContract(operator, sortitionPool, {
+          from: authorizer1,
+        }),
+        "Not authorized"
+      )
+    })
+
+    it("should deauthorize sortition pool for the provided operator", async () => {
+      await keepBonding.authorizeSortitionPoolContract(
+        operator,
+        sortitionPool,
+        {from: authorizer}
+      )
+      await keepBonding.deauthorizeSortitionPoolContract(
+        operator,
+        sortitionPool,
+        {from: authorizer}
+      )
+      assert.isFalse(
+        await keepBonding.hasSecondaryAuthorization(operator, sortitionPool),
+        "Sortition pool should be deauthorized for the provided operator"
       )
     })
   })


### PR DESCRIPTION
There is currently no way to withdraw the second-level authorization. If someone is no longer interested in participating in some application, they may leave the pool but there is no way to withdraw the authorization and someone (e.g. operator) may register in the pool again.

Here we add `deauthorizeSortitionPoolContract` to improve the situation.

An authorizer may deauthorize the individual sortition pool in case the operator should no longer be eligible for work selection and the application represented by the sortition pool should no longer be eligible to create bonds for the operator.

Keep in mind, `BondedSortitionPool` `joinPool` has no access modifier to prevent the operator from unanimously avoiding new group selection. This is not a problem if we allow the authorizer to withdraw sortition pool authorization.