### PR TITLE
Include distributed rewards amount in events

### DIFF
--- a/solidity/contracts/BondedECDSAKeep.sol
+++ b/solidity/contracts/BondedECDSAKeep.sol
@@ -106,7 +106,7 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
     event ETHRewardDistributed(uint256 amount);
 
     // Notification that ERC20 reward has been distributed to keep members.
-    event ERC20RewardDistributed(uint256 amount);
+    event ERC20RewardDistributed(address indexed token, uint256 amount);
 
     // Notification that the keep was closed by the owner.
     // Members no longer need to support this keep.
@@ -447,7 +447,7 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
             dividend.add(remainder)
         );
 
-        emit ERC20RewardDistributed(_value);
+        emit ERC20RewardDistributed(_tokenAddress, _value);
     }
 
     /// @notice Gets current amount of ETH hold in the keep for the member.

--- a/solidity/contracts/BondedECDSAKeep.sol
+++ b/solidity/contracts/BondedECDSAKeep.sol
@@ -103,10 +103,10 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
     event PublicKeyPublished(bytes publicKey);
 
     // Notification that ETH reward has been distributed to keep members.
-    event ETHRewardDistributed();
+    event ETHRewardDistributed(uint256 amount);
 
     // Notification that ERC20 reward has been distributed to keep members.
-    event ERC20RewardDistributed();
+    event ERC20RewardDistributed(uint256 amount);
 
     // Notification that the keep was closed by the owner.
     // Members no longer need to support this keep.
@@ -407,7 +407,7 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
         uint256 remainder = msg.value.mod(memberCount);
         memberETHBalances[members[memberCount - 1]] += dividend.add(remainder);
 
-        emit ETHRewardDistributed();
+        emit ETHRewardDistributed(msg.value);
     }
 
     /// @notice Distributes ERC20 reward evenly across all keep signer beneficiaries.
@@ -447,7 +447,7 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
             dividend.add(remainder)
         );
 
-        emit ERC20RewardDistributed();
+        emit ERC20RewardDistributed(_value);
     }
 
     /// @notice Gets current amount of ETH hold in the keep for the member.

--- a/solidity/test/BondedECDSAKeepTest.js
+++ b/solidity/test/BondedECDSAKeepTest.js
@@ -1423,7 +1423,9 @@ contract("BondedECDSAKeep", (accounts) => {
       const startBlock = await web3.eth.getBlockNumber()
 
       const res = await keep.distributeETHReward({value: ethValue})
-      truffleAssert.eventEmitted(res, "ETHRewardDistributed")
+      truffleAssert.eventEmitted(res, "ETHRewardDistributed", (event) => {
+        return web3.utils.toBN(event.amount).eq(ethValue)
+      })
 
       assert.lengthOf(
         await keep.getPastEvents("ETHRewardDistributed", {
@@ -1667,7 +1669,9 @@ contract("BondedECDSAKeep", (accounts) => {
       const startBlock = await web3.eth.getBlockNumber()
 
       const res = await keep.distributeERC20Reward(token.address, erc20Value)
-      truffleAssert.eventEmitted(res, "ERC20RewardDistributed")
+      truffleAssert.eventEmitted(res, "ERC20RewardDistributed", (event) => {
+        return web3.utils.toBN(event.amount).eq(erc20Value)
+      })
 
       assert.lengthOf(
         await keep.getPastEvents("ERC20RewardDistributed", {

--- a/solidity/test/BondedECDSAKeepTest.js
+++ b/solidity/test/BondedECDSAKeepTest.js
@@ -1670,7 +1670,10 @@ contract("BondedECDSAKeep", (accounts) => {
 
       const res = await keep.distributeERC20Reward(token.address, erc20Value)
       truffleAssert.eventEmitted(res, "ERC20RewardDistributed", (event) => {
-        return web3.utils.toBN(event.amount).eq(erc20Value)
+        return (
+          token.address == event.token &&
+          web3.utils.toBN(event.amount).eq(erc20Value)
+        )
       })
 
       assert.lengthOf(


### PR DESCRIPTION
It is gas-cheap but should help with splitting rewards in case someone uses third party staking provider for running nodes.