### PR TITLE
Require beneficiary to be set for withdraw

### DIFF
--- a/solidity/contracts/BondedECDSAKeep.sol
+++ b/solidity/contracts/BondedECDSAKeep.sol
@@ -485,14 +485,10 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
 
         memberETHBalances[_member] = 0;
 
-        address beneficiary = tokenStaking.beneficiaryOf(_member);
-        require(
-            beneficiary != address(0),
-            "Beneficiary not defined for the operator"
-        );
-
         /* solium-disable-next-line security/no-call-value */
-        (bool success, ) = beneficiary.call.value(value)("");
+        (bool success, ) = tokenStaking.beneficiaryOf(_member).call.value(
+            value
+        )("");
 
         require(success, "Transfer failed");
     }

--- a/solidity/contracts/BondedECDSAKeep.sol
+++ b/solidity/contracts/BondedECDSAKeep.sol
@@ -485,10 +485,14 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
 
         memberETHBalances[_member] = 0;
 
+        address beneficiary = tokenStaking.beneficiaryOf(_member);
+        require(
+            beneficiary != address(0),
+            "Beneficiary not defined for the operator"
+        );
+
         /* solium-disable-next-line security/no-call-value */
-        (bool success, ) = tokenStaking.beneficiaryOf(_member).call.value(
-            value
-        )("");
+        (bool success, ) = beneficiary.call.value(value)("");
 
         require(success, "Transfer failed");
     }

--- a/solidity/contracts/KeepBonding.sol
+++ b/solidity/contracts/KeepBonding.sol
@@ -43,7 +43,11 @@ contract KeepBonding {
     mapping(address => mapping(address => bool)) internal authorizedPools;
 
     event UnbondedValueDeposited(address indexed operator, uint256 amount);
-    event UnbondedValueWithdrawn(address indexed operator, uint256 amount);
+    event UnbondedValueWithdrawn(
+        address indexed operator,
+        address indexed beneficiary,
+        uint256 amount
+    );
     event BondCreated(
         address indexed operator,
         address indexed holder,
@@ -136,7 +140,7 @@ contract KeepBonding {
         (bool success, ) = beneficiary.call.value(amount)("");
         require(success, "Transfer failed");
 
-        emit UnbondedValueWithdrawn(operator, amount);
+        emit UnbondedValueWithdrawn(operator, beneficiary, amount);
     }
 
     /// @notice Create bond for the given operator, holder, reference and amount.

--- a/solidity/contracts/KeepBonding.sol
+++ b/solidity/contracts/KeepBonding.sol
@@ -109,7 +109,8 @@ contract KeepBonding {
     }
 
     /// @notice Withdraws amount from operator's value available for bonding.
-    /// Can be called only by the operator or by the stake owner.
+    /// Can be called only by the operator or by the stake owner. The value is
+    /// transferred to the beneficiary associated with the operator.
     /// @param amount Value to withdraw in wei.
     /// @param operator Address of the operator.
     function withdraw(uint256 amount, address operator) public {
@@ -126,9 +127,13 @@ contract KeepBonding {
 
         unbondedValue[operator] = unbondedValue[operator].sub(amount);
 
-        (bool success, ) = tokenStaking.beneficiaryOf(operator).call.value(
-            amount
-        )("");
+        address beneficiary = tokenStaking.beneficiaryOf(operator);
+        require(
+            beneficiary != address(0),
+            "Beneficiary not defined for the operator"
+        );
+
+        (bool success, ) = beneficiary.call.value(amount)("");
         require(success, "Transfer failed");
 
         emit UnbondedValueWithdrawn(operator, amount);

--- a/solidity/contracts/KeepBonding.sol
+++ b/solidity/contracts/KeepBonding.sol
@@ -376,6 +376,9 @@ contract KeepBonding {
         unbondedValue[operator] = unbondedValue[operator].sub(amount);
 
         address beneficiary = tokenStaking.beneficiaryOf(operator);
+        // Following check protects from a situation when a bonding value has
+        // been deposited before defining a beneficiary for the operator in the
+        // TokenStaking contract.
         require(
             beneficiary != address(0),
             "Beneficiary not defined for the operator"

--- a/solidity/test/BondedECDSAKeepFactoryTest.js
+++ b/solidity/test/BondedECDSAKeepFactoryTest.js
@@ -1514,6 +1514,7 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
       await keepBonding.authorizeSortitionPoolContract(members[i], signerPool, {
         from: authorizers[i],
       })
+      await tokenStaking.setBeneficiary(members[i], members[i])
     }
 
     const unbondedAmount = unbondedValue || minimumBond

--- a/solidity/test/BondedECDSAKeepTest.js
+++ b/solidity/test/BondedECDSAKeepTest.js
@@ -973,9 +973,9 @@ contract("BondedECDSAKeep", (accounts) => {
       const memberStake = web3.utils.toBN("100000000000000000000000")
       // setting a value other then the min stake for testing purposes
       await keep.setMemberStake(memberStake)
-      
+
       assert.isFalse(
-        await keep.isFradulentPreimageSet(preimage1), 
+        await keep.isFradulentPreimageSet(preimage1),
         "fradulent preimage should not have been set"
       )
 
@@ -988,10 +988,10 @@ contract("BondedECDSAKeep", (accounts) => {
       )
 
       assert.isTrue(
-        await keep.isFradulentPreimageSet(preimage1), 
+        await keep.isFradulentPreimageSet(preimage1),
         "fradulent preimage should have been set"
       )
-      
+
       await keep.submitSignatureFraud(
         signature1.V,
         signature1.R,
@@ -1005,7 +1005,10 @@ contract("BondedECDSAKeep", (accounts) => {
           members[i],
           constants.ZERO_ADDRESS
         )
-        expect(actualStake).to.eq.BN(minimumStake.sub(memberStake), `incorrect stake for member ${i}`)
+        expect(actualStake).to.eq.BN(
+          minimumStake.sub(memberStake),
+          `incorrect stake for member ${i}`
+        )
       }
     })
 
@@ -1657,17 +1660,6 @@ contract("BondedECDSAKeep", (accounts) => {
       )
 
       await expectRevert(keep.withdraw(member), "No funds to withdraw")
-    })
-
-    it("reverts in case of not defined beneficiary", async () => {
-      const member = members[0]
-
-      await tokenStaking.setBeneficiary(member, constants.ZERO_ADDRESS)
-
-      await expectRevert(
-        keep.withdraw(member),
-        "Beneficiary not defined for the operator"
-      )
     })
 
     it("reverts in case of transfer failure", async () => {

--- a/solidity/test/KeepBondingTest.js
+++ b/solidity/test/KeepBondingTest.js
@@ -204,6 +204,7 @@ contract("KeepBonding", (accounts) => {
 
     beforeEach(async () => {
       await keepBonding.deposit(operator, {value: value})
+      await tokenStaking.setBeneficiary(operator, beneficiary)
 
       managedGrant = await ManagedGrant.new(managedGrantee)
       await tokenGrant.setGranteeOperator(managedGrant.address, operator)

--- a/solidity/test/contracts/TokenStakingStub.sol
+++ b/solidity/test/contracts/TokenStakingStub.sol
@@ -45,16 +45,18 @@ contract TokenStakingStub is IStaking {
         return stakes[_operator];
     }
 
-    function setBeneficiary(address _operator, address payable _beneficiary) public {
+    function setBeneficiary(address _operator, address payable _beneficiary)
+        public
+    {
         operatorToBeneficiary[_operator] = _beneficiary;
     }
 
-    function beneficiaryOf(address _operator) public view returns (address payable) {
-        address payable beneficiary = operatorToBeneficiary[_operator];
-        if (beneficiary == address(0)) {
-            return address(uint160(_operator));
-        }
-        return beneficiary;
+    function beneficiaryOf(address _operator)
+        public
+        view
+        returns (address payable)
+    {
+        return operatorToBeneficiary[_operator];
     }
 
     function slash(uint256 _amount, address[] memory _misbehavedOperators)


### PR DESCRIPTION
In this PR we update ETH withdraws with checks that a beneficiary is set for the operator. 

Previously it was possible that bonding value was deposited for the operator before stake delegation happened, so the beneficiary was not set yet. In such a case, the operator was able to withdraw the unbonded value, but the `tokenStaking.beneficiaryOf` returned zero address, to which funds could be transferred. 

Here we added verification if the beneficiary is defined. If not the transaction will revert.