### PR TITLE
Metrics module

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -188,10 +188,10 @@ func initializeMetrics(
 	netProvider net.Provider,
 	stakeMonitor chain.StakeMonitor,
 ) error {
-	registry, err := metrics.Initialize(
+	registry, isConfigured := metrics.Initialize(
 		config.Metrics.Port,
 	)
-	if err != nil {
+	if !isConfigured {
 		logger.Infof("metrics are not configured")
 		return nil
 	}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -189,8 +189,6 @@ func initializeMetrics(
 	stakeMonitor chain.StakeMonitor,
 ) error {
 	registry, err := metrics.Initialize(
-		"keep-ecdsa",
-		config.Metrics.Identifier,
 		config.Metrics.Port,
 	)
 	if err != nil {
@@ -199,8 +197,7 @@ func initializeMetrics(
 	}
 
 	logger.Infof(
-		"enabled metrics with identifier [%v] on port [%v]",
-		config.Metrics.Identifier,
+		"enabled metrics on port [%v]",
 		config.Metrics.Port,
 	)
 
@@ -232,6 +229,11 @@ func initializeMetrics(
 		stakeMonitor,
 		config.Ethereum.Account.Address,
 		observationTick,
+	)
+
+	metrics.ExposeLibP2PInfo(
+		registry,
+		netProvider,
 	)
 
 	return nil

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -165,10 +165,7 @@ func Start(c *cli.Context) error {
 	)
 	logger.Debugf("initialized operator with address: [%s]", ethereumKey.Address.String())
 
-	err = initializeMetrics(ctx, config, networkProvider, stakeMonitor)
-	if err != nil {
-		return fmt.Errorf("error initializing metrics: [%v]", err)
-	}
+	initializeMetrics(ctx, config, networkProvider, stakeMonitor)
 
 	logger.Info("client started")
 
@@ -187,13 +184,12 @@ func initializeMetrics(
 	config *config.Config,
 	netProvider net.Provider,
 	stakeMonitor chain.StakeMonitor,
-) error {
+) {
 	registry, isConfigured := metrics.Initialize(
 		config.Metrics.Port,
 	)
 	if !isConfigured {
 		logger.Infof("metrics are not configured")
-		return nil
 	}
 
 	logger.Infof(
@@ -228,6 +224,4 @@ func initializeMetrics(
 		registry,
 		netProvider,
 	)
-
-	return nil
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -201,26 +201,19 @@ func initializeMetrics(
 		config.Metrics.Port,
 	)
 
-	var observationTick time.Duration
-	if tick := config.Metrics.Tick; tick != 0 {
-		observationTick = time.Duration(tick) * time.Second
-	} else {
-		observationTick = 60 * time.Second
-	}
-
 	metrics.ObserveConnectedPeersCount(
 		ctx,
 		registry,
 		netProvider,
-		observationTick,
+		time.Duration(config.Metrics.NetworkMetricsTick)*time.Second,
 	)
 
-	metrics.ObserveConnectedBootstrapPercentage(
+	metrics.ObserveConnectedBootstrapCount(
 		ctx,
 		registry,
 		netProvider,
 		config.LibP2P.Peers,
-		observationTick,
+		time.Duration(config.Metrics.NetworkMetricsTick)*time.Second,
 	)
 
 	metrics.ObserveEthConnectivity(
@@ -228,7 +221,7 @@ func initializeMetrics(
 		registry,
 		stakeMonitor,
 		config.Ethereum.Account.Address,
-		observationTick,
+		time.Duration(config.Metrics.EthereumMetricsTick)*time.Second,
 	)
 
 	metrics.ExposeLibP2PInfo(

--- a/configs/config.toml.SAMPLE
+++ b/configs/config.toml.SAMPLE
@@ -49,3 +49,8 @@
 # This is an optional parameter, if not provided timeout for TSS protocol
 # pre-parameters generation will be set to `2 minutes`.
 #  PreParamsGenerationTimeout = "2m30s"
+
+# [Metrics]
+    # Identifier = "example-id"
+    # Port = 8080
+    # Tick = 60

--- a/configs/config.toml.SAMPLE
+++ b/configs/config.toml.SAMPLE
@@ -51,6 +51,5 @@
 #  PreParamsGenerationTimeout = "2m30s"
 
 # [Metrics]
-    # Identifier = "example-id"
     # Port = 8080
     # Tick = 60

--- a/configs/config.toml.SAMPLE
+++ b/configs/config.toml.SAMPLE
@@ -52,4 +52,5 @@
 
 # [Metrics]
     # Port = 8080
-    # Tick = 60
+    # NetworkMetricsTick = 60
+    # EthereumMetricsTick = 600

--- a/go.mod
+++ b/go.mod
@@ -18,8 +18,8 @@ require (
 	github.com/gogo/protobuf v1.3.1
 	github.com/google/gofuzz v1.1.0
 	github.com/ipfs/go-log v0.0.1
-	github.com/keep-network/keep-common v1.1.0
-	github.com/keep-network/keep-core v1.2.0
+	github.com/keep-network/keep-common v1.1.1-0.20200610130035-55afd4237caf
+	github.com/keep-network/keep-core v1.2.2-0.20200610141441-f0f42b38cee5
 	github.com/pkg/errors v0.9.1
 	github.com/urfave/cli v1.22.1
 )

--- a/go.mod
+++ b/go.mod
@@ -18,8 +18,8 @@ require (
 	github.com/gogo/protobuf v1.3.1
 	github.com/google/gofuzz v1.1.0
 	github.com/ipfs/go-log v0.0.1
-	github.com/keep-network/keep-common v1.1.1-0.20200610130035-55afd4237caf
-	github.com/keep-network/keep-core v1.2.2-0.20200610141441-f0f42b38cee5
+	github.com/keep-network/keep-common v1.1.1-0.20200612121439-e1944b162625
+	github.com/keep-network/keep-core v1.2.2-0.20200612133212-1e0d6439ee2a
 	github.com/pkg/errors v0.9.1
 	github.com/urfave/cli v1.22.1
 )

--- a/go.mod
+++ b/go.mod
@@ -18,8 +18,8 @@ require (
 	github.com/gogo/protobuf v1.3.1
 	github.com/google/gofuzz v1.1.0
 	github.com/ipfs/go-log v0.0.1
-	github.com/keep-network/keep-common v1.1.1-0.20200612121439-e1944b162625
-	github.com/keep-network/keep-core v1.2.2-0.20200612133212-1e0d6439ee2a
+	github.com/keep-network/keep-common v1.1.1-0.20200703125023-d9872a19ebd1
+	github.com/keep-network/keep-core v1.2.4-rc.0.20200703125443-6c5dd769bc46
 	github.com/pkg/errors v0.9.1
 	github.com/urfave/cli v1.22.1
 )

--- a/go.sum
+++ b/go.sum
@@ -245,8 +245,12 @@ github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec h
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec/go.mod h1:xR8jf3/VJAjh3nWu5tFe8Yxnt2HvWsqZHfGef1P5oDk=
 github.com/keep-network/keep-common v1.1.0 h1:m5ZDfUpH+DVqQz3qIi+E53utWHv7kVSooPD01kVG3n8=
 github.com/keep-network/keep-common v1.1.0/go.mod h1:0uY+hufkP66nFnL+3GXMwWXRiKKsFyXFQTby1xR7AwY=
+github.com/keep-network/keep-common v1.1.1-0.20200610130035-55afd4237caf h1:bNOzvCwlxnWANqoUzN+FWVKfzToA86EZrfLquERwcUY=
+github.com/keep-network/keep-common v1.1.1-0.20200610130035-55afd4237caf/go.mod h1:0uY+hufkP66nFnL+3GXMwWXRiKKsFyXFQTby1xR7AwY=
 github.com/keep-network/keep-core v1.2.0 h1:SYUlMqcZ2cqfJGSWQKdsf+MYNrl5MAUz+ahP5EGZw9E=
 github.com/keep-network/keep-core v1.2.0/go.mod h1:+8wx+DsRXczgc0By80PecvDTVu9HRh2Ti671/uFdGsQ=
+github.com/keep-network/keep-core v1.2.2-0.20200610141441-f0f42b38cee5 h1:EFuFrEIDwn683td2TYg/tnZIvWq2dy2xSFcBlDWDYfk=
+github.com/keep-network/keep-core v1.2.2-0.20200610141441-f0f42b38cee5/go.mod h1:wIMKFESKwioAdQSo+j+Ppf48A5dGH9JZX2vTUAtKzYM=
 github.com/keep-network/toml v0.3.0 h1:G+NJwWR/ZiORqeLBsDXDchYoL29PXHdxOPcCueA7ctE=
 github.com/keep-network/toml v0.3.0/go.mod h1:Zeyd3lxbIlMYLREho3UK1dMP2xjqt2gLkQ5E5vM6K38=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=

--- a/go.sum
+++ b/go.sum
@@ -247,10 +247,14 @@ github.com/keep-network/keep-common v1.1.0 h1:m5ZDfUpH+DVqQz3qIi+E53utWHv7kVSooP
 github.com/keep-network/keep-common v1.1.0/go.mod h1:0uY+hufkP66nFnL+3GXMwWXRiKKsFyXFQTby1xR7AwY=
 github.com/keep-network/keep-common v1.1.1-0.20200610130035-55afd4237caf h1:bNOzvCwlxnWANqoUzN+FWVKfzToA86EZrfLquERwcUY=
 github.com/keep-network/keep-common v1.1.1-0.20200610130035-55afd4237caf/go.mod h1:0uY+hufkP66nFnL+3GXMwWXRiKKsFyXFQTby1xR7AwY=
+github.com/keep-network/keep-common v1.1.1-0.20200612121439-e1944b162625 h1:ZDb+ewPufSqbbO49hTPotyO8RMzVODcOPxGWm8xzHeg=
+github.com/keep-network/keep-common v1.1.1-0.20200612121439-e1944b162625/go.mod h1:0uY+hufkP66nFnL+3GXMwWXRiKKsFyXFQTby1xR7AwY=
 github.com/keep-network/keep-core v1.2.0 h1:SYUlMqcZ2cqfJGSWQKdsf+MYNrl5MAUz+ahP5EGZw9E=
 github.com/keep-network/keep-core v1.2.0/go.mod h1:+8wx+DsRXczgc0By80PecvDTVu9HRh2Ti671/uFdGsQ=
 github.com/keep-network/keep-core v1.2.2-0.20200610141441-f0f42b38cee5 h1:EFuFrEIDwn683td2TYg/tnZIvWq2dy2xSFcBlDWDYfk=
 github.com/keep-network/keep-core v1.2.2-0.20200610141441-f0f42b38cee5/go.mod h1:wIMKFESKwioAdQSo+j+Ppf48A5dGH9JZX2vTUAtKzYM=
+github.com/keep-network/keep-core v1.2.2-0.20200612133212-1e0d6439ee2a h1:kYnqEPxYkavipvXm2rZQwT5+dSGTf7glHdokI1m8nHw=
+github.com/keep-network/keep-core v1.2.2-0.20200612133212-1e0d6439ee2a/go.mod h1:+SCVJxA1UBcd3RPEgUq4YnEIoCjbt+pj+Axj3tc4Yn8=
 github.com/keep-network/toml v0.3.0 h1:G+NJwWR/ZiORqeLBsDXDchYoL29PXHdxOPcCueA7ctE=
 github.com/keep-network/toml v0.3.0/go.mod h1:Zeyd3lxbIlMYLREho3UK1dMP2xjqt2gLkQ5E5vM6K38=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=

--- a/go.sum
+++ b/go.sum
@@ -249,12 +249,16 @@ github.com/keep-network/keep-common v1.1.1-0.20200610130035-55afd4237caf h1:bNOz
 github.com/keep-network/keep-common v1.1.1-0.20200610130035-55afd4237caf/go.mod h1:0uY+hufkP66nFnL+3GXMwWXRiKKsFyXFQTby1xR7AwY=
 github.com/keep-network/keep-common v1.1.1-0.20200612121439-e1944b162625 h1:ZDb+ewPufSqbbO49hTPotyO8RMzVODcOPxGWm8xzHeg=
 github.com/keep-network/keep-common v1.1.1-0.20200612121439-e1944b162625/go.mod h1:0uY+hufkP66nFnL+3GXMwWXRiKKsFyXFQTby1xR7AwY=
+github.com/keep-network/keep-common v1.1.1-0.20200703125023-d9872a19ebd1 h1:SCjStilprtxkLaY6+pw/xqvCJFPEm71n3GJyC+cbLU0=
+github.com/keep-network/keep-common v1.1.1-0.20200703125023-d9872a19ebd1/go.mod h1:0uY+hufkP66nFnL+3GXMwWXRiKKsFyXFQTby1xR7AwY=
 github.com/keep-network/keep-core v1.2.0 h1:SYUlMqcZ2cqfJGSWQKdsf+MYNrl5MAUz+ahP5EGZw9E=
 github.com/keep-network/keep-core v1.2.0/go.mod h1:+8wx+DsRXczgc0By80PecvDTVu9HRh2Ti671/uFdGsQ=
 github.com/keep-network/keep-core v1.2.2-0.20200610141441-f0f42b38cee5 h1:EFuFrEIDwn683td2TYg/tnZIvWq2dy2xSFcBlDWDYfk=
 github.com/keep-network/keep-core v1.2.2-0.20200610141441-f0f42b38cee5/go.mod h1:wIMKFESKwioAdQSo+j+Ppf48A5dGH9JZX2vTUAtKzYM=
 github.com/keep-network/keep-core v1.2.2-0.20200612133212-1e0d6439ee2a h1:kYnqEPxYkavipvXm2rZQwT5+dSGTf7glHdokI1m8nHw=
 github.com/keep-network/keep-core v1.2.2-0.20200612133212-1e0d6439ee2a/go.mod h1:+SCVJxA1UBcd3RPEgUq4YnEIoCjbt+pj+Axj3tc4Yn8=
+github.com/keep-network/keep-core v1.2.4-rc.0.20200703125443-6c5dd769bc46 h1:dKrNquMLVUPf2hPyGBk4O1K5SFp1Wneh2B9TrTSQvCk=
+github.com/keep-network/keep-core v1.2.4-rc.0.20200703125443-6c5dd769bc46/go.mod h1:o7hHfkAoMgCKrtWZJ+CeukeQOGy88I2JqXFGvARpu0Y=
 github.com/keep-network/toml v0.3.0 h1:G+NJwWR/ZiORqeLBsDXDchYoL29PXHdxOPcCueA7ctE=
 github.com/keep-network/toml v0.3.0/go.mod h1:Zeyd3lxbIlMYLREho3UK1dMP2xjqt2gLkQ5E5vM6K38=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,9 +54,8 @@ type Storage struct {
 
 // Metrics stores meta-info about metrics.
 type Metrics struct {
-	Identifier string
-	Port       int
-	Tick       int
+	Port int
+	Tick int
 }
 
 // ReadConfig reads in the configuration file in .toml format. Ethereum key file

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -54,8 +54,9 @@ type Storage struct {
 
 // Metrics stores meta-info about metrics.
 type Metrics struct {
-	Port int
-	Tick int
+	Port                int
+	NetworkMetricsTick  int
+	EthereumMetricsTick int
 }
 
 // ReadConfig reads in the configuration file in .toml format. Ethereum key file

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	Storage                Storage
 	LibP2P                 libp2p.Config
 	TSS                    tss.Config
+	Metrics                Metrics
 }
 
 // SanctionedApplications contains addresses of applications approved by the
@@ -49,6 +50,13 @@ func (sa *SanctionedApplications) Addresses() ([]common.Address, error) {
 // Storage stores meta-info about keeping data on disk
 type Storage struct {
 	DataDir string
+}
+
+// Metrics stores meta-info about metrics.
+type Metrics struct {
+	Identifier string
+	Port       int
+	Tick       int
 }
 
 // ReadConfig reads in the configuration file in .toml format. Ethereum key file


### PR DESCRIPTION
<s>Depends on keep-network/keep-common#40</s>
<s>Depends on https://github.com/keep-network/keep-core/pull/1850</s>

Here we introduce some basic metrics gathering and exposing them through an HTTP endpoint.

**Metrics table**
| Metric | Description |
| ------ | ------------ |
| connected_peers_count | Presents the count of all connected peers |
| connected_bootstrap_count | Presents the count of connected bootstraps from the list of bootstraps defined in the configuration |
| eth_connectivity | Presents whether the connection with ETH node is up (1 - yes, 0 - no) |
| libp2p_info | Presents some libp2p specific data |

**Example response from the `/metrics` endpoint**

Presented output follows the [Prometheus text-based exposition format](https://prometheus.io/docs/instrumenting/exposition_formats/)

```
# TYPE connected_peers_count gauge
connected_peers_count 62 1592993341396

# TYPE connected_bootstrap_count gauge
connected_bootstrap_count 10 1592993341396

# TYPE eth_connectivity gauge
eth_connectivity 1 1592993341421

libp2p_info{id="16Uiu2HAkuTUKNh6HkfvWBEkftZbqZHPHi3Kak5ZUygAxvsdQ2UgG"} 1
```