### PR TITLE
Release: v1.1.2-rc (Ropsten)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -298,14 +298,14 @@ workflows:
             tags:
               only: /^v.*/
             branches:
-              ignore: /.*/
+              only: /releases\/.*/
       - build_client_and_test_go:
           context: github-package-registry
           filters:
             tags:
               only: /^v.*/
             branches:
-              ignore: /.*/
+              only: /releases\/.*/
           requires:
             - keep_test_approval
       - migrate_contracts:
@@ -314,7 +314,7 @@ workflows:
             tags:
               only: /^v.*/
             branches:
-              ignore: /.*/
+              only: /releases\/.*/
           requires:
             - build_client_and_test_go
       - build_initcontainer:
@@ -323,7 +323,7 @@ workflows:
             tags:
               only: /^v.*/
             branches:
-              ignore: /.*/
+              only: /releases\/.*/
           requires:
             - migrate_contracts
       - publish_client:
@@ -332,7 +332,7 @@ workflows:
             tags:
               only: /^v.*/
             branches:
-              ignore: /.*/
+              only: /releases\/.*/
           requires:
             - build_client_and_test_go
             - build_initcontainer
@@ -343,7 +343,7 @@ workflows:
             tags:
               only: /^v.*/
             branches:
-              ignore: /.*/
+              only: /releases\/.*/
           requires:
             - build_client_and_test_go
             - build_initcontainer
@@ -354,7 +354,7 @@ workflows:
             tags:
               only: /^v.*/
             branches:
-              ignore: /.*/
+              only: /releases\/.*/
           requires:
             - migrate_contracts
       - publish_contract_data:
@@ -363,6 +363,6 @@ workflows:
             tags:
               only: /^v.*/
             branches:
-              ignore: /.*/
+              only: /releases\/.*/
           requires:
             - migrate_contracts

--- a/docs/run-keep-ecdsa.adoc
+++ b/docs/run-keep-ecdsa.adoc
@@ -391,9 +391,14 @@ Once you've got your KEEP token grant you can manage it with our https://dashboa
 
 ==== Bootstrap Peers
 
+Bootstrap peers will come and go on testnet.  As long as at least one of your configured peers is
+up, there is no need to worry.
+
 [.small]
 ```
 "/dns4/bootstrap-1.ecdsa.keep.test.boar.network/tcp/4001/ipfs/16Uiu2HAmPFXDaeGWtnzd8s39NsaQguoWtKi77834A6xwYqeicq6N",
+"/dns4/ecdsa-2.test.keep.network/tcp/3919/ipfs/16Uiu2HAmNNuCp45z5bgB8KiTHv1vHTNAVbBgxxtTFGAndageo9Dp",	
+"/dns4/ecdsa-3.test.keep.network/tcp/3919/ipfs/16Uiu2HAm8KJX32kr3eYUhDuzwTucSfAfspnjnXNf9veVhB12t6Vf",
 ```
 
 ==== Contracts
@@ -406,13 +411,13 @@ Contract addresses needed to boot a Keep ECDSA client:
 |
 
 |BondedECDSAKeepFactory
-|`0x17caddf97a1d1123efb7b233cb16c76c31a96e02`
+|`0xe7BF8421fBE80c3Bf67082370D86C8D81D1D77F4`
 
 |Sanctioned Applications
-|`0x2b70907b5c44897030ea1369591ddcd23c5d85d6` (tBTC's system contract)
+|`0x25B60668E7a0967a86223828D20f93714D91Ee4B` (tBTC's system contract)
 
 |tBTC Sortition pool (for <<Authorizations,authorization>>)
-|`0xf5bc2812344ecacdd45c0b53824168f522533fc5`
+|`0x787fE59d9EefAf4c1214D6d6F547318Fcad54EE9`
 |===
 
 

--- a/infrastructure/kube/keep-test/keep-ecdsa-2-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-ecdsa-2-statefulset.yaml
@@ -102,7 +102,7 @@ spec:
             - name: KEEP_TECDSA_ETH_KEYFILE_PATH
               value: /mnt/keep-ecdsa/keyfile/account-2-keyfile
             - name: KEEP_TECDSA_PEERS
-              value: /dns4/ecdsa-1.test.keep.network/tcp/3919/ipfs/16Uiu2HAm3eJtyFKAttzJ85NLMromHuRg4yyum3CREMf6CHBBV6KY
+              value: /dns4/ecdsa-3.test.keep.network/tcp/3919/ipfs/16Uiu2HAm8KJX32kr3eYUhDuzwTucSfAfspnjnXNf9veVhB12t6Vf
             - name: KEEP_TECDSA_ANNOUNCED_ADDRESSES
               value: /dns4/ecdsa-2.test.keep.network/tcp/3919
             - name: KEEP_TECDSA_PORT
@@ -110,7 +110,7 @@ spec:
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
             - name: SANCTIONED_APPLICATIONS
-              value: '0x576ad5Ced9D0030D2F26E2F08BD2E92de9fcD858' # Shall we extract this property to a configmap?
+              value: '0x25B60668E7a0967a86223828D20f93714D91Ee4B' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-test/keep-ecdsa-3-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-ecdsa-3-statefulset.yaml
@@ -110,7 +110,7 @@ spec:
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
             - name: SANCTIONED_APPLICATIONS
-              value: '0x576ad5Ced9D0030D2F26E2F08BD2E92de9fcD858' # Shall we extract this property to a configmap?
+              value: '0x25B60668E7a0967a86223828D20f93714D91Ee4B' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "1.0.0",
+  "version": "1.1.2-rc",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -879,9 +879,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "1.2.3-pre.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.2.3-pre.0.tgz",
-      "integrity": "sha512-acnELPecyPbk4pkcsPHqCnXyMntG0qS2e1I1gTeqWLE/VOkcgvgv2QnCCQY31lwP9Ne0J7Vmq0upqmJtrH9/Gg==",
+      "version": "1.2.4-rc.1",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.2.4-rc.1.tgz",
+      "integrity": "sha512-Pda3oitEIcNC9diiNfFOi5SPiK8TNtl/JW8ucOwYMSCHbQJmrxITeJ6PGS5hwMdhf81lToBMYvhwpf3Slv+D7w==",
       "requires": {
         "@openzeppelin/contracts-ethereum-package": "^2.4.0",
         "@openzeppelin/upgrades": "^2.7.2",

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "1.0.0",
+  "version": "1.1.2-rc",
   "description": "Smart contracts for ECDSA Keep",
   "repository": {
     "type": "git",
@@ -32,7 +32,7 @@
   },
   "homepage": "https://github.com/keep-network/keep-ecdsa",
   "dependencies": {
-    "@keep-network/keep-core": "1.2.3-pre.0",
+    "@keep-network/keep-core": ">1.2.4-rc <1.2.4",
     "@keep-network/sortition-pools": "1.0.0",
     "@openzeppelin/upgrades": "^2.7.2",
     "openzeppelin-solidity": "2.3.0",


### PR DESCRIPTION
### Intro 

Here's a collection of changes to facilitate migration and deploying the keep-test environment against keep-ecdsa v1.1.2-rc. We did this one slightly different in that we've left keep-ecdsa-0 and keep-ecda-1 running against the previous deployment, to not disturb operation while we roll the new release out.

Please do not merge this PR until all checkboxes in Tasks are checked.

### Migration Job

https://app.circleci.com/pipelines/github/keep-network/keep-ecdsa/2059/workflows/f22593b8-db0d-41be-8b8d-fe87dbb6fef2

### Tasks

- [X] Bump keep-ecdsa to v1.1.2-rc
- [X] Bump keep-core dependency to v1.2.4-rc
- [X] Create sortition pool for application TBTCSystem (`0x25B60668E7a0967a86223828D20f93714D91Ee4B`)
  - Side not here: This is typically handled via the keep-ecdsa InitContainer but had to be executed manually due to a contract tx revert in the InitContainer code.  Will have to investigate.
- [X] (After tbtc migration) update TBTCSystem contract for keep-ecdsa clients 2 and 3, then deploy
-  [X] Ensure keep-ecdsa client 2 and 3 registered with the new TBTCSystem and finished generating TSS pre-params
- [X] Update docu to reflect new contract addresses and updated peers list
~~- [ ]  Observe keep-ecdsa clients participating in a tbtc deposit/redemption~~  keep-ecdsa clients are creating keeps for tbtc deposits. I can't fully exercise the flow due to issues with proof submission from the tbtc-dapp on deposit.  Current working theory is that the 6 confirmation wait is biting us on testnet due to erratic difficulty.