### PR TITLE
Save last seen peers and use them as bootstrap upon restart

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -125,14 +125,13 @@ func Start(c *cli.Context) error {
 		operatorPrivateKey, operatorPublicKey,
 	)
 
-	//Read last seen peers file as a slice of strings and convert it to array of strings
+	//Read last seen peers file as a bytearray and convert to a slice of strings
 	s, err := ioutil.ReadFile(c.GlobalString("peers"))
 	if err != nil {
 		logger.Debugf("Error reading last seen peers file")
 	}
 	lastSeenPeersString := string(s[:])
 	lastSeenPeers := strings.Split(lastSeenPeersString, ",")
-	logger.Infof("LOCALDEV: Last seen peers content: ", lastSeenPeers)
 
 	//If the slice of last seen peers is non empty, use it as bootstrap peers list
 	if len(lastSeenPeers) != 0 {

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ replace (
 	github.com/btcsuite/btcd => github.com/keep-network/btcd v0.0.0-20190427004231-96897255fd17
 	github.com/btcsuite/btcutil => github.com/keep-network/btcutil v0.0.0-20190425235716-9e5f4b9a998d
 	github.com/urfave/cli => github.com/keep-network/cli v1.20.0
+	github.com/keep-network/keep-core => github.com/jeremyid/keep-core v1.1.3
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ replace (
 	github.com/btcsuite/btcd => github.com/keep-network/btcd v0.0.0-20190427004231-96897255fd17
 	github.com/btcsuite/btcutil => github.com/keep-network/btcutil v0.0.0-20190425235716-9e5f4b9a998d
 	github.com/urfave/cli => github.com/keep-network/cli v1.20.0
-	github.com/keep-network/keep-core => github.com/jeremyid/keep-core v1.1.3
+	github.com/keep-network/keep-core => /home/experience/keep-core
 )
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ replace (
 	github.com/btcsuite/btcd => github.com/keep-network/btcd v0.0.0-20190427004231-96897255fd17
 	github.com/btcsuite/btcutil => github.com/keep-network/btcutil v0.0.0-20190425235716-9e5f4b9a998d
 	github.com/urfave/cli => github.com/keep-network/cli v1.20.0
-	github.com/keep-network/keep-core => /home/experience/keep-core
 )
 
 require (

--- a/main.go
+++ b/main.go
@@ -16,10 +16,14 @@ var logger = log.Logger("keep-main")
 
 const (
 	defaultConfigPath = "./configs/config.toml"
+	//Default path to last seen peers file
+	defaultPeersListPath = "./configs/peers.dat"
 )
 
 var (
 	configPath string
+	//String for last seen peers file path
+	peersListPath string
 )
 
 func main() {
@@ -44,6 +48,13 @@ func main() {
 			Value:       defaultConfigPath,
 			Destination: &configPath,
 			Usage:       "full path to the configuration file",
+		},
+		//Define new flag to specify location of file where to store last seen peers
+		cli.StringFlag{
+			Name:        "peers",
+			Value:       defaultPeersListPath,
+			Destination: &peersListPath,
+			Usage:       "full path to the last connected peers list file",
 		},
 	}
 	app.Commands = []cli.Command{


### PR DESCRIPTION
Related to [this ``keep-core`` issue](https://github.com/keep-network/keep-core/issues/1856). 

See the [corresponding PR](https://github.com/keep-network/keep-core/pull/1877) on ``keep-core`` for more explanations.

This simply extends the feature to the ECDSA client.
 