### PR TITLE
Changing websockets flag to false

### DIFF
--- a/solidity/truffle.js
+++ b/solidity/truffle.js
@@ -30,7 +30,7 @@ module.exports = {
       host: "127.0.0.1",     // Localhost (default: none)
       port: 8545,            // Standard Ethereum port (default: none)
       network_id: "*",       // Any network (default: none)
-      websockets: true,      // Enable EventEmitter interface for web3 (default: false)
+      websockets: false,     // To enable EventEmitter interface for web3 change it to 'true'
     },
     keep_dev: {
       provider: function () {


### PR DESCRIPTION
Set websockets flag to false because of the failing solidity tests "Error: connection not open"