### PR TITLE
Add missing return to metrics initialization

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -190,6 +190,7 @@ func initializeMetrics(
 	)
 	if !isConfigured {
 		logger.Infof("metrics are not configured")
+		return
 	}
 
 	logger.Infof(


### PR DESCRIPTION
Added missing return to metrics `initializeMetrics` function in case metrics are not configured properly.