### PR TITLE
Checking beneficiary address before depositing funds

### DIFF
--- a/solidity/contracts/KeepBonding.sol
+++ b/solidity/contracts/KeepBonding.sol
@@ -21,7 +21,6 @@ import "@keep-network/keep-core/contracts/libraries/RolesLookup.sol";
 
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 
-
 /// @title Keep Bonding
 /// @notice Contract holding deposits from keeps' operators.
 contract KeepBonding {
@@ -231,11 +230,11 @@ contract KeepBonding {
     /// @param holder Address of the holder of the bond.
     /// @param referenceID Reference ID of the bond.
     /// @return Amount of wei in the selected bond.
-    function bondAmount(address operator, address holder, uint256 referenceID)
-        public
-        view
-        returns (uint256)
-    {
+    function bondAmount(
+        address operator,
+        address holder,
+        uint256 referenceID
+    ) public view returns (uint256) {
         bytes32 bondID = keccak256(
             abi.encodePacked(operator, holder, referenceID)
         );

--- a/solidity/contracts/KeepBonding.sol
+++ b/solidity/contracts/KeepBonding.sol
@@ -48,7 +48,11 @@ contract KeepBonding {
     // operator -> pool -> boolean
     mapping(address => mapping(address => bool)) internal authorizedPools;
 
-    event UnbondedValueDeposited(address indexed operator, uint256 amount);
+    event UnbondedValueDeposited(
+        address indexed operator,
+        address indexed beneficiary,
+        uint256 amount
+    );
     event UnbondedValueWithdrawn(
         address indexed operator,
         address indexed beneficiary,
@@ -92,8 +96,17 @@ contract KeepBonding {
     /// @notice Add the provided value to operator's pool available for bonding.
     /// @param operator Address of the operator.
     function deposit(address operator) external payable {
+        address beneficiary = tokenStaking.beneficiaryOf(operator);
+        // Beneficiary has to be set (delegation exist) before an operator can
+        // deposit wei. It protects from a situation when an operator wants
+        // to withdraw funds which are transfered to beneficiary with zero
+        // address.
+        require(
+            beneficiary != address(0),
+            "Beneficiary not defined for the operator"
+        );
         unbondedValue[operator] = unbondedValue[operator].add(msg.value);
-        emit UnbondedValueDeposited(operator, msg.value);
+        emit UnbondedValueDeposited(operator, beneficiary, msg.value);
     }
 
     /// @notice Returns the amount of wei the operator has made available for

--- a/solidity/contracts/KeepBonding.sol
+++ b/solidity/contracts/KeepBonding.sol
@@ -21,6 +21,7 @@ import "@keep-network/keep-core/contracts/libraries/RolesLookup.sol";
 
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 
+
 /// @title Keep Bonding
 /// @notice Contract holding deposits from keeps' operators.
 contract KeepBonding {
@@ -230,11 +231,11 @@ contract KeepBonding {
     /// @param holder Address of the holder of the bond.
     /// @param referenceID Reference ID of the bond.
     /// @return Amount of wei in the selected bond.
-    function bondAmount(
-        address operator,
-        address holder,
-        uint256 referenceID
-    ) public view returns (uint256) {
+    function bondAmount(address operator, address holder, uint256 referenceID)
+        public
+        view
+        returns (uint256)
+    {
         bytes32 bondID = keccak256(
             abi.encodePacked(operator, holder, referenceID)
         );
@@ -326,6 +327,7 @@ contract KeepBonding {
 
         lockedBonds[bondID] = lockedBonds[bondID].sub(amount);
 
+        /* solium-disable-next-line */
         (bool success, ) = destination.call.value(amount)("");
         require(success, "Transfer failed");
 
@@ -389,6 +391,7 @@ contract KeepBonding {
 
         address beneficiary = tokenStaking.beneficiaryOf(operator);
 
+        /* solium-disable-next-line */
         (bool success, ) = beneficiary.call.value(amount)("");
         require(success, "Transfer failed");
 

--- a/solidity/contracts/KeepBonding.sol
+++ b/solidity/contracts/KeepBonding.sol
@@ -389,13 +389,6 @@ contract KeepBonding {
         unbondedValue[operator] = unbondedValue[operator].sub(amount);
 
         address beneficiary = tokenStaking.beneficiaryOf(operator);
-        // Following check protects from a situation when a bonding value has
-        // been deposited before defining a beneficiary for the operator in the
-        // TokenStaking contract.
-        require(
-            beneficiary != address(0),
-            "Beneficiary not defined for the operator"
-        );
 
         (bool success, ) = beneficiary.call.value(amount)("");
         require(success, "Transfer failed");

--- a/solidity/contracts/KeepBonding.sol
+++ b/solidity/contracts/KeepBonding.sol
@@ -327,7 +327,6 @@ contract KeepBonding {
 
         lockedBonds[bondID] = lockedBonds[bondID].sub(amount);
 
-        /* solium-disable-next-line */
         (bool success, ) = destination.call.value(amount)("");
         require(success, "Transfer failed");
 
@@ -391,7 +390,6 @@ contract KeepBonding {
 
         address beneficiary = tokenStaking.beneficiaryOf(operator);
 
-        /* solium-disable-next-line */
         (bool success, ) = beneficiary.call.value(amount)("");
         require(success, "Transfer failed");
 

--- a/solidity/test/BondedECDSAKeepFactoryTest.js
+++ b/solidity/test/BondedECDSAKeepFactoryTest.js
@@ -43,7 +43,7 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
   const notMember = accounts[5]
 
   const keepOwner = accounts[6]
-  const beneficiary = notMember
+  const beneficiary = accounts[7]
 
   const groupSize = new BN(members.length)
   const threshold = new BN(groupSize - 1)

--- a/solidity/test/BondedECDSAKeepFactoryTest.js
+++ b/solidity/test/BondedECDSAKeepFactoryTest.js
@@ -43,6 +43,7 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
   const notMember = accounts[5]
 
   const keepOwner = accounts[6]
+  const beneficiary = notMember
 
   const groupSize = new BN(members.length)
   const threshold = new BN(groupSize - 1)
@@ -1150,6 +1151,8 @@ contract("BondedECDSAKeepFactory", async (accounts) => {
       for (let i = 0; i < memberCount; i++) {
         const operator = await web3.eth.personal.newAccount("pass")
         await web3.eth.personal.unlockAccount(operator, "pass", 5000) // 5 sec unlock
+
+        await tokenStaking.setBeneficiary(operator, beneficiary)
 
         web3.eth.sendTransaction({
           from: accounts[0],

--- a/solidity/test/BondedECDSAKeepTest.js
+++ b/solidity/test/BondedECDSAKeepTest.js
@@ -36,6 +36,7 @@ contract("BondedECDSAKeep", (accounts) => {
   const members = [accounts[2], accounts[3], accounts[4]]
   const authorizers = [accounts[2], accounts[3], accounts[4]]
   const signingPool = accounts[5]
+  const beneficiary = accounts[6]
   const honestThreshold = 1
 
   const stakeLockDuration = time.duration.days(180)
@@ -1566,7 +1567,6 @@ contract("BondedECDSAKeep", (accounts) => {
   describe("withdraw", async () => {
     const singleValue = new BN(1000)
     const ethValue = singleValue.mul(new BN(members.length))
-    const beneficiary = accounts[4]
 
     beforeEach(async () => {
       await keep.distributeETHReward({value: ethValue})
@@ -1806,7 +1806,6 @@ contract("BondedECDSAKeep", (accounts) => {
 
       const member1 = accounts[2]
       const member2 = accounts[3]
-      const beneficiary = accounts[4]
 
       const testMembers = [member1, member2]
 
@@ -1865,7 +1864,6 @@ contract("BondedECDSAKeep", (accounts) => {
   }
 
   async function depositForBonding(member1Value, member2Value, member3Value) {
-    const beneficiary = accounts[4]
     await tokenStaking.setBeneficiary(members[0], beneficiary)
     await tokenStaking.setBeneficiary(members[1], beneficiary)
     await tokenStaking.setBeneficiary(members[2], beneficiary)

--- a/solidity/test/BondedECDSAKeepTest.js
+++ b/solidity/test/BondedECDSAKeepTest.js
@@ -1865,6 +1865,11 @@ contract("BondedECDSAKeep", (accounts) => {
   }
 
   async function depositForBonding(member1Value, member2Value, member3Value) {
+    const beneficiary = accounts[4]
+    await tokenStaking.setBeneficiary(members[0], beneficiary)
+    await tokenStaking.setBeneficiary(members[1], beneficiary)
+    await tokenStaking.setBeneficiary(members[2], beneficiary)
+
     await keepBonding.deposit(members[0], {value: member1Value})
     await keepBonding.deposit(members[1], {value: member2Value})
     await keepBonding.deposit(members[2], {value: member3Value})

--- a/solidity/test/KeepBondingTest.js
+++ b/solidity/test/KeepBondingTest.js
@@ -68,14 +68,10 @@ contract("KeepBonding", (accounts) => {
   describe("deposit", async () => {
     const value = new BN(100)
     const expectedUnbonded = value
-    let receipt;
-
-    beforeEach(async () => {
-      await tokenStaking.setBeneficiary(operator, beneficiary)
-      receipt = await keepBonding.deposit(operator, {value: value})
-    })
 
     it("registers unbonded value", async () => {
+      await tokenStaking.setBeneficiary(operator, beneficiary)
+      await keepBonding.deposit(operator, {value: value})
       const unbonded = await keepBonding.availableUnbondedValue(
         operator,
         bondCreator,
@@ -86,10 +82,22 @@ contract("KeepBonding", (accounts) => {
     })
 
     it("emits event", async () => {
+      await tokenStaking.setBeneficiary(operator, beneficiary)
+      const receipt = await keepBonding.deposit(operator, {value: value})
       expectEvent(receipt, "UnbondedValueDeposited", {
         operator: operator,
+        beneficiary: beneficiary,
         amount: value,
       })
+    })
+
+    it("reverts if beneficiary is not defined", async () => {
+      await tokenStaking.setBeneficiary(operator, constants.ZERO_ADDRESS)
+
+      await expectRevert(	
+        keepBonding.deposit(operator, {value: value}),	
+        "Beneficiary not defined for the operator"	
+      )	
     })
   })
 
@@ -98,7 +106,6 @@ contract("KeepBonding", (accounts) => {
 
     beforeEach(async () => {
       await tokenStaking.setBeneficiary(operator, beneficiary)
-
       await keepBonding.deposit(operator, {value: value})
     })
 

--- a/solidity/test/KeepBondingTest.js
+++ b/solidity/test/KeepBondingTest.js
@@ -94,10 +94,10 @@ contract("KeepBonding", (accounts) => {
     it("reverts if beneficiary is not defined", async () => {
       await tokenStaking.setBeneficiary(operator, constants.ZERO_ADDRESS)
 
-      await expectRevert(	
-        keepBonding.deposit(operator, {value: value}),	
-        "Beneficiary not defined for the operator"	
-      )	
+      await expectRevert(
+        keepBonding.deposit(operator, {value: value}),
+        "Beneficiary not defined for the operator"
+      )
     })
   })
 

--- a/solidity/test/KeepBondingTest.js
+++ b/solidity/test/KeepBondingTest.js
@@ -68,10 +68,14 @@ contract("KeepBonding", (accounts) => {
   describe("deposit", async () => {
     const value = new BN(100)
     const expectedUnbonded = value
+    let receipt;
+
+    beforeEach(async () => {
+      await tokenStaking.setBeneficiary(operator, beneficiary)
+      receipt = await keepBonding.deposit(operator, {value: value})
+    })
 
     it("registers unbonded value", async () => {
-      await keepBonding.deposit(operator, {value: value})
-
       const unbonded = await keepBonding.availableUnbondedValue(
         operator,
         bondCreator,
@@ -82,7 +86,6 @@ contract("KeepBonding", (accounts) => {
     })
 
     it("emits event", async () => {
-      const receipt = await keepBonding.deposit(operator, {value: value})
       expectEvent(receipt, "UnbondedValueDeposited", {
         operator: operator,
         amount: value,
@@ -168,15 +171,6 @@ contract("KeepBonding", (accounts) => {
       })
     })
 
-    it("reverts if beneficiary is not defined", async () => {
-      await tokenStaking.setBeneficiary(operator, constants.ZERO_ADDRESS)
-
-      await expectRevert(
-        keepBonding.withdraw(value, operator, {from: operator}),
-        "Beneficiary not defined for the operator"
-      )
-    })
-
     it("reverts if insufficient unbonded value", async () => {
       const invalidValue = value.add(new BN(1))
 
@@ -203,8 +197,8 @@ contract("KeepBonding", (accounts) => {
     let managedGrant
 
     beforeEach(async () => {
-      await keepBonding.deposit(operator, {value: value})
       await tokenStaking.setBeneficiary(operator, beneficiary)
+      await keepBonding.deposit(operator, {value: value})
 
       managedGrant = await ManagedGrant.new(managedGrantee)
       await tokenGrant.setGranteeOperator(managedGrant.address, operator)
@@ -353,6 +347,7 @@ contract("KeepBonding", (accounts) => {
     const value = new BN(100)
 
     beforeEach(async () => {
+      await tokenStaking.setBeneficiary(operator, beneficiary)
       await keepBonding.deposit(operator, {value: value})
     })
 
@@ -412,6 +407,7 @@ contract("KeepBonding", (accounts) => {
     const value = new BN(100)
 
     beforeEach(async () => {
+      await tokenStaking.setBeneficiary(operator, beneficiary)
       await keepBonding.deposit(operator, {value: value})
     })
 
@@ -473,6 +469,7 @@ contract("KeepBonding", (accounts) => {
 
       const expectedUnbonded = value.sub(bondValue)
 
+      await tokenStaking.setBeneficiary(operator2, etherReceiver.address)
       await keepBonding.deposit(operator2, {value: value})
 
       await tokenStaking.authorizeOperatorContract(operator2, bondCreator)
@@ -573,6 +570,7 @@ contract("KeepBonding", (accounts) => {
     const newReference = new BN(888)
 
     beforeEach(async () => {
+      await tokenStaking.setBeneficiary(operator, beneficiary)
       await keepBonding.deposit(operator, {value: bondValue})
       await keepBonding.createBond(
         operator,
@@ -707,6 +705,7 @@ contract("KeepBonding", (accounts) => {
     const reference = new BN(777)
 
     beforeEach(async () => {
+      await tokenStaking.setBeneficiary(operator, beneficiary)
       await keepBonding.deposit(operator, {value: initialUnboundedValue})
       await keepBonding.createBond(
         operator,
@@ -765,6 +764,7 @@ contract("KeepBonding", (accounts) => {
     const reference = new BN(777)
 
     beforeEach(async () => {
+      await tokenStaking.setBeneficiary(operator, beneficiary)
       await keepBonding.deposit(operator, {value: bondValue})
       await keepBonding.createBond(
         operator,


### PR DESCRIPTION
Closes https://github.com/keep-network/keep-ecdsa/issues/491

Blocking unbonded value deposits when the beneficiary is not yet defined (delegation does not exist).
Removing check from `withdraw` function that previously blocked withdrawal if the beneficiary was not defined. 