### PR TITLE
Remove BondedECDSAKeep signing timeout

### DIFF
--- a/pkg/chain/chain.go
+++ b/pkg/chain/chain.go
@@ -118,11 +118,6 @@ type BondedECDSAKeep interface {
 	// calculated for the given digest.
 	IsAwaitingSignature(keepAddress common.Address, digest [32]byte) (bool, error)
 
-	// HasSigningTimedOut checks if the ongoing signing process timed out for
-	// the keep. If there is no ongoing signing for the keep or if the ongoing
-	// signing process has not timed out yet, this function returns false.
-	HasSigningTimedOut(keepAddress common.Address) (bool, error)
-
 	// IsActive checks if the keep with the given address is active and responds
 	// to signing request. This function returns false only for closed keeps.
 	IsActive(keepAddress common.Address) (bool, error)

--- a/pkg/chain/ethereum/ethereum.go
+++ b/pkg/chain/ethereum/ethereum.go
@@ -310,16 +310,6 @@ func (ec *EthereumChain) IsAwaitingSignature(keepAddress common.Address, digest 
 	return keepContract.IsAwaitingSignature(digest)
 }
 
-// HasSigningTimedOut checks if signing has timed out for keep.
-func (ec *EthereumChain) HasSigningTimedOut(keepAddress common.Address) (bool, error) {
-	keepContract, err := ec.getKeepContract(keepAddress)
-	if err != nil {
-		return false, err
-	}
-
-	return keepContract.HasSigningTimedOut()
-}
-
 // IsActive checks for current state of a keep on-chain.
 func (ec *EthereumChain) IsActive(keepAddress common.Address) (bool, error) {
 	keepContract, err := ec.getKeepContract(keepAddress)

--- a/pkg/chain/local/local.go
+++ b/pkg/chain/local/local.go
@@ -188,11 +188,6 @@ func (lc *localChain) IsAwaitingSignature(
 	panic("implement")
 }
 
-// HasSigningTimedOut checks if signing has timed out for keep.
-func (lc *localChain) HasSigningTimedOut(keepAddress common.Address) (bool, error) {
-	panic("implement")
-}
-
 // IsActive checks for current state of a keep on-chain.
 func (lc *localChain) IsActive(keepAddress common.Address) (bool, error) {
 	lc.handlerMutex.Lock()

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -598,12 +598,12 @@ func checkAwaitingSignature(
 					return false, err
 				}
 
-				hasSigningTimedOut, err := ethereumChain.HasSigningTimedOut(keepAddress)
+				isActive, err := ethereumChain.IsActive(keepAddress)
 				if err != nil {
 					return false, err
 				}
 
-				return (isAwaitingSignature && !hasSigningTimedOut), nil
+				return (isAwaitingSignature && isActive), nil
 			},
 		)
 		if err != nil {

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -303,8 +303,8 @@ func (n *Node) publishSignature(
 		}
 
 		// Check if keep is still active. There is no point in submitting the
-		// request as keep is no longer active, which means that it was either
-		// closed or terminated and signers' bonds may have been seized already.
+		// request when keep is no longer active, which means that it was either
+		// closed or terminated and signers' bonds might have been seized already.
 		// We are giving up and leaving this function.
 		isActive, err := n.ethereumChain.IsActive(keepAddress)
 		if err != nil {

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -302,21 +302,22 @@ func (n *Node) publishSignature(
 			return fmt.Errorf("context timeout exceeded")
 		}
 
-		// Timeout for generating a signature defined in the contract exceeded.
-		// There is no point in submitting the request as it will be rejected
-		// by the chain. We are giving up and leaving this function.
-		hasSigningTimedOut, err := n.ethereumChain.HasSigningTimedOut(keepAddress)
+		// Check if keep is still active. There is no point in submitting the
+		// request as keep is no longer active, which means that it was either
+		// closed or terminated and signers' bonds may have been seized already.
+		// We are giving up and leaving this function.
+		isActive, err := n.ethereumChain.IsActive(keepAddress)
 		if err != nil {
 			logger.Errorf(
-				"failed to verify if signing has timed out for keep [%s]: [%v]",
+				"failed to verify if keep [%s] is still active: [%v]",
 				keepAddress.String(),
 				err,
 			)
 			time.Sleep(retryDelay) // TODO: #413 Replace with backoff.
 			continue
 		}
-		if hasSigningTimedOut {
-			return fmt.Errorf("on-chain timeout exceeded")
+		if !isActive {
+			return fmt.Errorf("keep is no longer active")
 		}
 
 		// Check if keep still awaits a signature for this digest.

--- a/solidity/test/BondedECDSAKeepTest.js
+++ b/solidity/test/BondedECDSAKeepTest.js
@@ -650,14 +650,6 @@ contract("BondedECDSAKeep", (accounts) => {
       )
     })
 
-    it("reverts when signing is in progress", async () => {
-      keep.sign(digest, {from: owner})
-      await expectRevert(
-        keep.seizeSignerBonds({from: owner}),
-        "Requested signing has not timed out yet"
-      )
-    })
-
     it("succeeds when signing is in progress", async () => {
       keep.sign(digest, {from: owner})
 

--- a/solidity/test/BondedECDSAKeepTest.js
+++ b/solidity/test/BondedECDSAKeepTest.js
@@ -138,7 +138,6 @@ contract("BondedECDSAKeep", (accounts) => {
   describe("initialize", async () => {
     it("succeeds", async () => {
       const expectedKeyGenerationTimeout = new BN(9000) // 9000 = 150*60 = 2.5h in seconds
-      const expectedSigningTimeout = new BN(5400) // 5400 = 90 * 60 = 1.5h in seconds
 
       keep = await BondedECDSAKeepStub.new()
       await keep.initialize(
@@ -156,9 +155,6 @@ contract("BondedECDSAKeep", (accounts) => {
         await keep.keyGenerationTimeout(),
         "incorrect key generation timeout"
       ).to.eq.BN(expectedKeyGenerationTimeout)
-      expect(await keep.signingTimeout(), "incorrect signing timeout").to.eq.BN(
-        expectedSigningTimeout
-      )
     })
 
     it("claims token staking delegated authority", async () => {
@@ -335,61 +331,6 @@ contract("BondedECDSAKeep", (accounts) => {
       )
 
       assert.isTrue(await keep.isAwaitingSignature(digest1))
-    })
-  })
-
-  describe("hasSigningTimedOut", async () => {
-    const digest1 =
-      "0x54a6483b8aca55c9df2a35baf71d9965ddfd623468d81d51229bd5eb7d1e1c1b"
-    const publicKey =
-      "0x657282135ed640b0f5a280874c7e7ade110b5c3db362e0552e6b7fff2cc8459328850039b734db7629c31567d7fc5677536b7fc504e967dc11f3f2289d3d4051"
-    const signatureR =
-      "0x9b32c3623b6a16e87b4d3a56cd67c666c9897751e24a51518136185403b1cba2"
-    const signatureS =
-      "0x6f7c776efde1e382f2ecc99ec0db13534a70ee86bd91d7b3a4059bccbed5d70c"
-    const signatureRecoveryID = 1
-
-    const digest2 =
-      "0xca071ca92644f1f2c4ae1bf71b6032e5eff4f78f3aa632b27cbc5f84104a32da"
-
-    let signingTimeout
-
-    beforeEach(async () => {
-      signingTimeout = await keep.signingTimeout.call()
-
-      await submitMembersPublicKeys(publicKey)
-    })
-
-    it("returns false if signing was not requested", async () => {
-      assert.isFalse(await keep.hasSigningTimedOut())
-    })
-
-    it("returns false if signing was requested and have not timed out yet", async () => {
-      await keep.sign(digest1, {from: owner})
-
-      await increaseTime(duration.seconds(signingTimeout - 1))
-
-      assert.isFalse(await keep.hasSigningTimedOut())
-    })
-
-    it("returns true if signing was requested and have timed out", async () => {
-      await keep.sign(digest2, {from: owner})
-
-      await increaseTime(duration.seconds(signingTimeout))
-
-      assert.isTrue(await keep.hasSigningTimedOut())
-    })
-
-    it("returns false if signing was requested and signature have been submitted", async () => {
-      await keep.sign(digest1, {from: owner})
-
-      await keep.submitSignature(signatureR, signatureS, signatureRecoveryID, {
-        from: members[0],
-      })
-
-      await increaseTime(duration.seconds(signingTimeout))
-
-      assert.isFalse(await keep.hasSigningTimedOut())
     })
   })
 
@@ -717,27 +658,11 @@ contract("BondedECDSAKeep", (accounts) => {
       )
     })
 
-    it("reverts when signing was requested but has not timed out yet", async () => {
+    it("succeeds when signing is in progress", async () => {
       keep.sign(digest, {from: owner})
-
-      const signingTimeout = await keep.signingTimeout.call()
-      await increaseTime(duration.seconds(signingTimeout - 1))
-
-      await expectRevert(
-        keep.seizeSignerBonds({from: owner}),
-        "Requested signing has not timed out yet"
-      )
-    })
-
-    it("succeeds when signing was requested but timed out", async () => {
-      keep.sign(digest, {from: owner})
-
-      const signingTimeout = await keep.signingTimeout.call()
-      await increaseTime(duration.seconds(signingTimeout))
 
       await keep.seizeSignerBonds({from: owner})
     })
-
     it("reverts when already seized", async () => {
       await keep.seizeSignerBonds({from: owner})
 
@@ -1150,33 +1075,6 @@ contract("BondedECDSAKeep", (accounts) => {
       await keep.sign(digest, {from: owner})
     })
 
-    it("can be called just before the timeout", async () => {
-      await keep.sign(digest, {from: owner})
-
-      const signingTimeout = await keep.signingTimeout.call()
-
-      await increaseTime(duration.seconds(signingTimeout - 1))
-
-      await keep.submitSignature(signatureR, signatureS, signatureRecoveryID, {
-        from: members[0],
-      })
-    })
-
-    it("cannot be called after the timeout passed", async () => {
-      await keep.sign(digest, {from: owner})
-
-      const signingTimeout = await keep.signingTimeout.call()
-
-      await increaseTime(duration.seconds(signingTimeout))
-
-      await expectRevert(
-        keep.submitSignature(signatureR, signatureS, signatureRecoveryID, {
-          from: members[0],
-        }),
-        "Signing timeout elapsed"
-      )
-    })
-
     it("cannot be submitted if signing was not requested", async () => {
       await expectRevert(
         keep.submitSignature(signatureR, signatureS, signatureRecoveryID, {
@@ -1317,32 +1215,8 @@ contract("BondedECDSAKeep", (accounts) => {
       }
     })
 
-    it("reverts when signing is in progress", async () => {
+    it("succeeds when signing is in progress", async () => {
       keep.sign(digest, {from: owner})
-
-      await expectRevert(
-        keep.closeKeep({from: owner}),
-        "Requested signing has not timed out yet"
-      )
-    })
-
-    it("reverts when signing was requested but has not timed out yet", async () => {
-      keep.sign(digest, {from: owner})
-
-      const signingTimeout = await keep.signingTimeout.call()
-      await increaseTime(duration.seconds(signingTimeout - 1))
-
-      await expectRevert(
-        keep.closeKeep({from: owner}),
-        "Requested signing has not timed out yet"
-      )
-    })
-
-    it("succeeds when signing was requested but timed out", async () => {
-      keep.sign(digest, {from: owner})
-
-      const signingTimeout = await keep.signingTimeout.call()
-      await increaseTime(duration.seconds(signingTimeout))
 
       await keep.closeKeep({from: owner})
     })


### PR DESCRIPTION
This PR removes signing timeouts handling for BondedECDSAKeep. We expect the application to track the timeout and close the keep when it's exceeded. Until then the keep should expect the signature to be delivered by a client.

Please expect two more PRs:
1. We will introduce a similar change for key generation timeout (https://github.com/keep-network/keep-ecdsa/pull/496).
2. We will make client timeouts configurable in a config file.

Closes: https://github.com/keep-network/keep-ecdsa/issues/490