### PR TITLE
Remove BondedECDSAKeep key generation timeout

### DIFF
--- a/pkg/chain/chain.go
+++ b/pkg/chain/chain.go
@@ -4,6 +4,7 @@ package eth
 
 import (
 	"math/big"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/keep-network/keep-common/pkg/subscription"
@@ -145,7 +146,6 @@ type BondedECDSAKeep interface {
 	// GetHonestThreshold returns keep's honest threshold.
 	GetHonestThreshold(keepAddress common.Address) (uint64, error)
 
-	// HasKeyGenerationTimedOut returns whether key generation
-	// has timed out for the given keep.
-	HasKeyGenerationTimedOut(keepAddress common.Address) (bool, error)
+	// GetOpenedTimestamp returns timestamp when the keep was created.
+	GetOpenedTimestamp(keepAddress common.Address) (time.Time, error)
 }

--- a/pkg/chain/ethereum/ethereum.go
+++ b/pkg/chain/ethereum/ethereum.go
@@ -479,15 +479,19 @@ func (ec *EthereumChain) GetHonestThreshold(
 	return threshold.Uint64(), nil
 }
 
-// HasKeyGenerationTimedOut returns whether key generation
-// has timed out for the given keep.
-func (ec *EthereumChain) HasKeyGenerationTimedOut(
-	keepAddress common.Address,
-) (bool, error) {
+// GetOpenedTimestamp returns timestamp when the keep was created.
+func (ec *EthereumChain) GetOpenedTimestamp(keepAddress common.Address) (time.Time, error) {
 	keepContract, err := ec.getKeepContract(keepAddress)
 	if err != nil {
-		return false, err
+		return time.Unix(0, 0), err
 	}
 
-	return keepContract.HasKeyGenerationTimedOut()
+	timestamp, err := keepContract.GetOpenedTimestamp()
+	if err != nil {
+		return time.Unix(0, 0), err
+	}
+
+	keepOpenTime := time.Unix(timestamp.Int64(), 0)
+
+	return keepOpenTime, nil
 }

--- a/pkg/chain/local/local.go
+++ b/pkg/chain/local/local.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"math/rand"
 	"sync"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/keep-network/keep-common/pkg/subscription"
@@ -317,8 +318,6 @@ func (lc *localChain) GetHonestThreshold(
 	panic("implement")
 }
 
-func (lc *localChain) HasKeyGenerationTimedOut(
-	keepAddress common.Address,
-) (bool, error) {
+func (lc *localChain) GetOpenedTimestamp(keepAddress common.Address) (time.Time, error) {
 	panic("implement")
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -24,9 +24,10 @@ import (
 var logger = log.Logger("keep-ecdsa")
 
 const (
-	keyGenerationTimeout = 150 * time.Minute
-	signingTimeout       = 90 * time.Minute
-	blockConfirmations   = 12
+	awaitingKeyGenerationLookback = 24 * time.Hour
+	keyGenerationTimeout          = 120 * time.Minute
+	signingTimeout                = 90 * time.Minute
+	blockConfirmations            = 12
 )
 
 // Initialize initializes the ECDSA client with rules related to events handling.
@@ -245,20 +246,24 @@ func checkAwaitingKeyGeneration(
 			continue
 		}
 
-		keygenTimeout, err := ethereumChain.HasKeyGenerationTimedOut(keep)
+		keepOpenedTimestamp, err := ethereumChain.GetOpenedTimestamp(keep)
 		if err != nil {
 			logger.Warningf(
-				"could not check key generation timeout for keep [%s]: [%v]",
+				"could not check opening timestamp for keep [%s]: [%v]",
 				keep.String(),
 				err,
 			)
 			continue
 		}
 
-		// If key generation timeout of current keep has been exceeded,
-		// there is no sense to continue because the next keep (created earlier)
-		// will have this timeout exceeded as well.
-		if keygenTimeout {
+		// If a keep was opened before the defined lookback duration there is no
+		// sense to continue because the next keep was created earlier.
+		if keepOpenedTimestamp.Before(time.Now().Add(-awaitingKeyGenerationLookback)) {
+			logger.Debugf(
+				"stopping awaiting key generation check with keep at index [%s] opened at [%s]",
+				keepIndex,
+				keepOpenedTimestamp,
+			)
 			break
 		}
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -258,7 +258,7 @@ func checkAwaitingKeyGeneration(
 
 		// If a keep was opened before the defined lookback duration there is no
 		// sense to continue because the next keep was created earlier.
-		if keepOpenedTimestamp.Before(time.Now().Add(-awaitingKeyGenerationLookback)) {
+		if keepOpenedTimestamp.Add(awaitingKeyGenerationLookback).Before(time.Now()) {
 			logger.Debugf(
 				"stopping awaiting key generation check with keep at index [%s] opened at [%s]",
 				keepIndex,

--- a/solidity/contracts/BondedECDSAKeep.sol
+++ b/solidity/contracts/BondedECDSAKeep.sol
@@ -70,10 +70,6 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
     // digest was requested
     mapping(bytes32 => uint256) public digests;
 
-    // Timeout for the keep public key to appear on the chain. Time is counted
-    // from the moment keep has been created.
-    uint256 public constant keyGenerationTimeout = 150 * 60; // 2.5h in seconds
-
     // The timestamp at which keep has been created and key generation process
     // started.
     uint256 internal keyGenerationStartTimestamp;
@@ -188,8 +184,6 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
     /// event.
     /// @param _publicKey Signer's public key.
     function submitPublicKey(bytes calldata _publicKey) external onlyMember {
-        require(!hasKeyGenerationTimedOut(), "Key generation timeout elapsed");
-
         require(
             !hasMemberSubmittedPublicKey(msg.sender),
             "Member already submitted a public key"
@@ -623,16 +617,6 @@ contract BondedECDSAKeep is IBondedECDSAKeep {
 
         // Check if the signature is valid but was not requested.
         return isSignatureValid && digests[_signedDigest] == 0;
-    }
-
-    /// @notice Returns true if the ongoing key generation process timed out.
-    /// @dev There is a certain timeout for keep public key to be produced and
-    /// appear on the chain, see `keyGenerationTimeout`.
-    function hasKeyGenerationTimedOut() public view returns (bool) {
-        /* solium-disable-next-line */
-        return
-            block.timestamp >
-            keyGenerationStartTimestamp + keyGenerationTimeout;
     }
 
     /// @notice Returns true if the ongoing signing process timed out.

--- a/solidity/test/BondedECDSAKeepTest.js
+++ b/solidity/test/BondedECDSAKeepTest.js
@@ -137,7 +137,6 @@ contract("BondedECDSAKeep", (accounts) => {
 
   describe("initialize", async () => {
     it("succeeds", async () => {
-      const expectedKeyGenerationTimeout = new BN(9000) // 9000 = 150*60 = 2.5h in seconds
       const expectedSigningTimeout = new BN(5400) // 5400 = 90 * 60 = 1.5h in seconds
 
       keep = await BondedECDSAKeepStub.new()
@@ -152,10 +151,6 @@ contract("BondedECDSAKeep", (accounts) => {
         factoryStub.address
       )
 
-      expect(
-        await keep.keyGenerationTimeout(),
-        "incorrect key generation timeout"
-      ).to.eq.BN(expectedKeyGenerationTimeout)
       expect(await keep.signingTimeout(), "incorrect signing timeout").to.eq.BN(
         expectedSigningTimeout
       )
@@ -587,38 +582,6 @@ contract("BondedECDSAKeep", (accounts) => {
         await expectRevert(
           keep.submitPublicKey(badPublicKey, {from: members[2]}),
           "Public key must be 64 bytes long"
-        )
-      })
-
-      it("can be called just before the timeout", async () => {
-        const keyGenerationTimeout = await keep.keyGenerationTimeout.call()
-
-        await keep.submitPublicKey(publicKey1, {from: members[0]})
-        await keep.submitPublicKey(publicKey1, {from: members[1]})
-
-        // 5 seconds before the timeout
-        await increaseTime(duration.seconds(keyGenerationTimeout - 5))
-
-        await keep.submitPublicKey(publicKey1, {from: members[2]})
-
-        assert.equal(
-          await keep.getPublicKey(),
-          publicKey1,
-          "incorrect public key"
-        )
-      })
-
-      it("cannot be called after timeout", async () => {
-        const keyGenerationTimeout = await keep.keyGenerationTimeout.call()
-
-        await keep.submitPublicKey(publicKey1, {from: members[0]})
-        await keep.submitPublicKey(publicKey1, {from: members[1]})
-
-        await increaseTime(duration.seconds(keyGenerationTimeout))
-
-        await expectRevert(
-          keep.submitPublicKey(publicKey1, {from: members[2]}),
-          "Key generation timeout elapsed"
         )
       })
     })


### PR DESCRIPTION
This PR removes key generation timeouts handling for BondedECDSAKeep. We expect the application to track the timeout and close the keep when it's exceeded. Until then signers will be trying to generate a key for the keep.

Removing the timeout from contract complicated check for old keeps in the client. When the client starts we want to see if there are any keeps awaiting key generation. Previously we were walking through the list of all created keeps and checking them one by one starting from the bottom. We used the timeout to determine at which point there is no sense in looking any further as all following keeps will be timed out for sure.
Now we defined a time period to check keeps for awaiting key generation. We compare the period with a timestamp of the keep creation.

The lookback period is currently fixed, but in an upcoming PR, we want to let an operator configure the value in a client's config file.

Refs: #490