### PR TITLE
Configurable look-back period and keygen and signing timeouts

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -3,10 +3,11 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"time"
+
 	"github.com/keep-network/keep-core/pkg/chain"
 	"github.com/keep-network/keep-core/pkg/metrics"
 	"github.com/keep-network/keep-core/pkg/net"
-	"time"
 
 	"github.com/ipfs/go-log"
 
@@ -161,6 +162,7 @@ func Start(c *cli.Context) error {
 		networkProvider,
 		persistence,
 		sanctionedApplications,
+		&config.Client,
 		&config.TSS,
 	)
 	logger.Debugf("initialized operator with address: [%s]", ethereumKey.Address.String())

--- a/configs/config.toml.SAMPLE
+++ b/configs/config.toml.SAMPLE
@@ -44,7 +44,7 @@
 #   # AnnouncedAddresses = ["/dns4/example.com/tcp/3919", "/ip4/80.70.60.50/tcp/3919"]
 
 [Client]
-# Look-back period to check if existing keeps are awaiting signer generation.
+# Look-back period to check if existing keeps are awaiting signing key generation.
 # The value should be provided based on the sanctioned application requirements.
 #  AwaitingKeyGenerationLookback = "24h"	# optional
 

--- a/configs/config.toml.SAMPLE
+++ b/configs/config.toml.SAMPLE
@@ -43,6 +43,17 @@
 #   # Uncomment to override the node's default addresses announced in the network
 #   # AnnouncedAddresses = ["/dns4/example.com/tcp/3919", "/ip4/80.70.60.50/tcp/3919"]
 
+[Client]
+# Look-back period to check if existing keeps are awaiting signer generation.
+# The values should be provided based on the sanctioned application requirements.
+#  AwaitingKeyGenerationLookback = "24h"	# optional
+
+# Timeouts for processes execution. Within these timeouts the process will keep
+# retrying to generate a signer or calculate a signature. The values should be
+# provided based on the sanctioned application requirements.
+#  KeyGenerationTimeout = "3h" 				# optional
+#  SigningTimeout = "2h"					# optional
+
 [TSS]
 # Timeout for TSS protocol pre-parameters generation. The value
 # should be provided based on resources available on the machine running the client.

--- a/configs/config.toml.SAMPLE
+++ b/configs/config.toml.SAMPLE
@@ -44,8 +44,11 @@
 #   # AnnouncedAddresses = ["/dns4/example.com/tcp/3919", "/ip4/80.70.60.50/tcp/3919"]
 
 [Client]
-# Look-back period to check if existing keeps are awaiting signing key generation.
-# The value should be provided based on the sanctioned application requirements.
+# Look-back period to check if existing, active keeps are awaiting signer generation.
+# When the client starts, it goes through all keeps registered on-chain to check
+# whether it's a member of one of them and to generate the signing key if needed.
+# The client does not check keeps older than `AwaitingKeyGenerationLookback` to
+# minimize the number of calls to the chain.
 #  AwaitingKeyGenerationLookback = "24h"	# optional
 
 # Timeouts for processes execution. Within these timeouts the process will keep

--- a/configs/config.toml.SAMPLE
+++ b/configs/config.toml.SAMPLE
@@ -45,7 +45,7 @@
 
 [Client]
 # Look-back period to check if existing keeps are awaiting signer generation.
-# The values should be provided based on the sanctioned application requirements.
+# The value should be provided based on the sanctioned application requirements.
 #  AwaitingKeyGenerationLookback = "24h"	# optional
 
 # Timeouts for processes execution. Within these timeouts the process will keep

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/keep-network/keep-common/pkg/chain/ethereum"
 	"github.com/keep-network/keep-core/pkg/net/libp2p"
+	"github.com/keep-network/keep-ecdsa/pkg/client"
 	"github.com/keep-network/keep-ecdsa/pkg/ecdsa/tss"
 )
 
@@ -19,6 +20,7 @@ type Config struct {
 	SanctionedApplications SanctionedApplications
 	Storage                Storage
 	LibP2P                 libp2p.Config
+	Client                 client.Config
 	TSS                    tss.Config
 	Metrics                Metrics
 }

--- a/internal/config/time/time.go
+++ b/internal/config/time/time.go
@@ -1,0 +1,22 @@
+package time
+
+import (
+	"time"
+)
+
+// We use BurntSushi/toml package to parse configuration file. Unfortunately it
+// doesn't support time.Duration out of the box. Here we introduce a workaround
+// to be able to parse values provided in more friendly way, e.g. "4m20s".
+type Duration struct {
+	time.Duration
+}
+
+func (d *Duration) UnmarshalText(text []byte) error {
+	var err error
+	d.Duration, err = time.ParseDuration(string(text))
+	return err
+}
+
+func (d *Duration) ToDuration() time.Duration {
+	return time.Duration(d.Duration)
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -23,7 +23,7 @@ import (
 
 var logger = log.Logger("keep-ecdsa")
 
-// The default number of block confirmations the client waits until it starts the
+// The number of block confirmations the client waits until it starts the
 // requested signing process. This value prevents from reporting unauthorized
 // signings by adversaries in case of a chain fork.
 const blockConfirmations = 12

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -25,8 +25,8 @@ var logger = log.Logger("keep-ecdsa")
 
 const (
 	defaultAwaitingKeyGenerationLookback = 24 * time.Hour
-	defaultKeyGenerationTimeout          = 120 * time.Minute
-	defaultSigningTimeout                = 90 * time.Minute
+	defaultKeyGenerationTimeout          = 3 * time.Hour
+	defaultSigningTimeout                = 2 * time.Hour
 	blockConfirmations                   = 12
 )
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -23,6 +23,9 @@ import (
 
 var logger = log.Logger("keep-ecdsa")
 
+// The default number of block confirmations the client waits until it starts the
+// requested signing process. This value prevents from reporting unauthorized
+// signings by adversaries in case of a chain fork.
 const blockConfirmations = 12
 
 // Initialize initializes the ECDSA client with rules related to events handling.

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -7,9 +7,19 @@ import (
 )
 
 const (
+	// The default look-back period to check if existing, active keeps are awaiting
+	// signer generation. When the client starts, it goes through all keeps
+	// registered on-chain to check whether it's a member of one of them and to
+	// generate the signing key if needed. The client does not check keeps older
+	// than the awaiting key generation lookback value allows to minimize the
+	// number of calls to the chain calls.
 	defaultAwaitingKeyGenerationLookback = 24 * time.Hour
-	defaultKeyGenerationTimeout          = 3 * time.Hour
-	defaultSigningTimeout                = 2 * time.Hour
+
+	// The default value of a timeout for a keep key generation.
+	defaultKeyGenerationTimeout = 3 * time.Hour
+
+	// The default value of a timeout for a signature calculation.
+	defaultSigningTimeout = 2 * time.Hour
 )
 
 // Config contains configuration for tss protocol execution.
@@ -22,8 +32,9 @@ type Config struct {
 	SigningTimeout       configtime.Duration
 }
 
-// GetAwaitingKeyGenerationLookback return awaiting key generation lookback as
-// `time.Duration`.
+// GetAwaitingKeyGenerationLookback returns a look-back period to check if
+// existing, active keeps are awaiting signer generation. If a value is not set
+// it returns a default value.
 func (c *Config) GetAwaitingKeyGenerationLookback() time.Duration {
 	lookbackPeriod := c.AwaitingKeyGenerationLookback.ToDuration()
 	if lookbackPeriod == 0 {
@@ -33,7 +44,8 @@ func (c *Config) GetAwaitingKeyGenerationLookback() time.Duration {
 	return lookbackPeriod
 }
 
-// GetKeyGenerationTimeout return key generation timeout as `time.Duration`.
+// GetKeyGenerationTimeout returns key generation timeout. If a value is not set
+// it returns a default value.
 func (c *Config) GetKeyGenerationTimeout() time.Duration {
 	timeout := c.KeyGenerationTimeout.ToDuration()
 	if timeout == 0 {
@@ -43,7 +55,8 @@ func (c *Config) GetKeyGenerationTimeout() time.Duration {
 	return timeout
 }
 
-// GetSigningTimeout return key signing timeout as `time.Duration`.
+// GetSigningTimeout returns signature calculation timeout. If a value is not set
+// it returns a default value.
 func (c *Config) GetSigningTimeout() time.Duration {
 	timeout := c.SigningTimeout.ToDuration()
 	if timeout == 0 {

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -1,7 +1,15 @@
 package client
 
 import (
+	"time"
+
 	configtime "github.com/keep-network/keep-ecdsa/internal/config/time"
+)
+
+const (
+	defaultAwaitingKeyGenerationLookback = 24 * time.Hour
+	defaultKeyGenerationTimeout          = 3 * time.Hour
+	defaultSigningTimeout                = 2 * time.Hour
 )
 
 // Config contains configuration for tss protocol execution.
@@ -12,4 +20,35 @@ type Config struct {
 	// Timeout for key generation and signature calculation.
 	KeyGenerationTimeout configtime.Duration
 	SigningTimeout       configtime.Duration
+}
+
+// GetAwaitingKeyGenerationLookback return awaiting key generation lookback as
+// `time.Duration`.
+func (c *Config) GetAwaitingKeyGenerationLookback() time.Duration {
+	lookbackPeriod := c.AwaitingKeyGenerationLookback.ToDuration()
+	if lookbackPeriod == 0 {
+		lookbackPeriod = defaultAwaitingKeyGenerationLookback
+	}
+
+	return lookbackPeriod
+}
+
+// GetKeyGenerationTimeout return key generation timeout as `time.Duration`.
+func (c *Config) GetKeyGenerationTimeout() time.Duration {
+	timeout := c.KeyGenerationTimeout.ToDuration()
+	if timeout == 0 {
+		timeout = defaultKeyGenerationTimeout
+	}
+
+	return timeout
+}
+
+// GetSigningTimeout return key signing timeout as `time.Duration`.
+func (c *Config) GetSigningTimeout() time.Duration {
+	timeout := c.SigningTimeout.ToDuration()
+	if timeout == 0 {
+		timeout = defaultSigningTimeout
+	}
+
+	return timeout
 }

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -1,0 +1,15 @@
+package client
+
+import (
+	configtime "github.com/keep-network/keep-ecdsa/internal/config/time"
+)
+
+// Config contains configuration for tss protocol execution.
+type Config struct {
+	// Period to check keeps for awaiting key generation on client start.
+	AwaitingKeyGenerationLookback configtime.Duration
+
+	// Timeout for key generation and signature calculation.
+	KeyGenerationTimeout configtime.Duration
+	SigningTimeout       configtime.Duration
+}

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -24,7 +24,9 @@ const (
 
 // Config contains configuration for tss protocol execution.
 type Config struct {
-	// Period to check keeps for awaiting key generation on client start.
+	// Defines the look-back period to check if existing, active keeps are awaiting
+	// signer generation on the client start. The client does not check keeps older
+	// than the look-back value.
 	AwaitingKeyGenerationLookback configtime.Duration
 
 	// Timeout for key generation and signature calculation.

--- a/pkg/ecdsa/tss/config.go
+++ b/pkg/ecdsa/tss/config.go
@@ -1,24 +1,11 @@
 package tss
 
 import (
-	"time"
+	configtime "github.com/keep-network/keep-ecdsa/internal/config/time"
 )
 
 // Config contains configuration for tss protocol execution.
 type Config struct {
 	// Timeout for pre-parameters generation in tss-lib.
-	PreParamsGenerationTimeout duration
-}
-
-// We use BurntSushi/toml package to parse configuration file. Unfortunately it
-// doesn't support time.Duration out of the box. Here we introduce a workaround
-// to be able to parse values provided in more friendly way, e.g. "4m20s".
-type duration struct {
-	time.Duration
-}
-
-func (d *duration) UnmarshalText(text []byte) error {
-	var err error
-	d.Duration, err = time.ParseDuration(string(text))
-	return err
+	PreParamsGenerationTimeout configtime.Duration
 }

--- a/pkg/ecdsa/tss/config.go
+++ b/pkg/ecdsa/tss/config.go
@@ -16,7 +16,8 @@ type Config struct {
 	PreParamsGenerationTimeout configtime.Duration
 }
 
-// GetKeyGenerationTimeout return key generation timeout as `time.Duration`.
+// GetPreParamsGenerationTimeout returns pre-parameters generation timeout. If
+// a value is not set it returns a default value.
 func (c *Config) GetPreParamsGenerationTimeout() time.Duration {
 	timeout := c.PreParamsGenerationTimeout.ToDuration()
 	if timeout == 0 {

--- a/pkg/ecdsa/tss/config.go
+++ b/pkg/ecdsa/tss/config.go
@@ -1,11 +1,27 @@
 package tss
 
 import (
+	"time"
+
 	configtime "github.com/keep-network/keep-ecdsa/internal/config/time"
+)
+
+const (
+	defaultPreParamsGenerationTimeout = 2 * time.Minute
 )
 
 // Config contains configuration for tss protocol execution.
 type Config struct {
 	// Timeout for pre-parameters generation in tss-lib.
 	PreParamsGenerationTimeout configtime.Duration
+}
+
+// GetKeyGenerationTimeout return key generation timeout as `time.Duration`.
+func (c *Config) GetPreParamsGenerationTimeout() time.Duration {
+	timeout := c.PreParamsGenerationTimeout.ToDuration()
+	if timeout == 0 {
+		timeout = defaultPreParamsGenerationTimeout
+	}
+
+	return timeout
 }

--- a/pkg/node/params_pool.go
+++ b/pkg/node/params_pool.go
@@ -7,10 +7,6 @@ import (
 	"github.com/keep-network/keep-ecdsa/pkg/ecdsa/tss"
 )
 
-const (
-	defaultPreParamsGenerationTimeout = 2 * time.Minute
-)
-
 // tssPreParamsPool is a pool holding TSS pre parameters. It autogenerates entries
 // up to the pool size. When an entry is pulled from the pool it will generate
 // new entry.
@@ -23,15 +19,12 @@ type tssPreParamsPool struct {
 func (n *Node) InitializeTSSPreParamsPool() {
 	poolSize := 20
 
-	timeout := n.tssConfig.PreParamsGenerationTimeout.ToDuration()
-	if timeout == 0 {
-		timeout = defaultPreParamsGenerationTimeout
-	}
-
 	n.tssParamsPool = &tssPreParamsPool{
 		pool: make(chan *keygen.LocalPreParams, poolSize),
 		new: func() (*keygen.LocalPreParams, error) {
-			return tss.GenerateTSSPreParams(timeout)
+			return tss.GenerateTSSPreParams(
+				n.tssConfig.GetPreParamsGenerationTimeout(),
+			)
 		},
 	}
 

--- a/pkg/node/params_pool.go
+++ b/pkg/node/params_pool.go
@@ -23,10 +23,8 @@ type tssPreParamsPool struct {
 func (n *Node) InitializeTSSPreParamsPool() {
 	poolSize := 20
 
-	var timeout time.Duration
-	if n.tssConfig.PreParamsGenerationTimeout.Duration > 0 {
-		timeout = time.Duration(n.tssConfig.PreParamsGenerationTimeout.Duration)
-	} else {
+	timeout := n.tssConfig.PreParamsGenerationTimeout.ToDuration()
+	if timeout == 0 {
 		timeout = defaultPreParamsGenerationTimeout
 	}
 


### PR DESCRIPTION
In this PR we let operator configure values for a look-back period for awaiting key generation keeps and key generation and signing timeouts.

Values can be configured in config file as on following example:
```toml
[Client]
  AwaitingKeyGenerationLookback = "24h"
  KeyGenerationTimeout = "3h"
  SigningTimeout = "2h"
```

Providing the values is optional. If the values are not defined the default ones will be used.

Refs: https://github.com/keep-network/keep-ecdsa/issues/490