### PR TITLE
Allow the application to set pool's minimum bondable value

### DIFF
--- a/solidity/contracts/BondedECDSAKeepFactory.sol
+++ b/solidity/contracts/BondedECDSAKeepFactory.sol
@@ -170,21 +170,17 @@ contract BondedECDSAKeepFactory is
         return candidatesPools[_application];
     }
 
-    /// @notice Gets the sortition pool address for the given application.
-    /// @dev Reverts if sortition does not exits for the application.
-    /// @param _application Address of the application.
-    /// @return Address of the sortition pool contract.
-    function getSortitionPool(address _application)
-        external
-        view
-        returns (address)
-    {
-        require(
-            candidatesPools[_application] != address(0),
-            "No pool found for the application"
+    /// @notice Sets the minimum bondable value required from the operator to
+    /// join the sortition pool of the given application. It is up to the
+    /// application to specify a reasonable minimum bond for operators trying to
+    /// join the pool to prevent griefing by operators joining without enough
+    /// bondable value.
+    /// @param _minimumBondableValue The minimum unbonded value allowing
+    /// an operator to join and stay in the sortition pool for the application.
+    function setMinimumBondableValue(uint256 _minimumBondableValue) external {
+        BondedSortitionPool(getSortitionPool(msg.sender)).setMinimumBondableValue(
+            _minimumBondableValue
         );
-
-        return candidatesPools[_application];
     }
 
     /// @notice Register caller as a candidate to be selected as keep member
@@ -192,13 +188,8 @@ contract BondedECDSAKeepFactory is
     /// @dev If caller is already registered it returns without any changes.
     /// @param _application Address of the application.
     function registerMemberCandidate(address _application) external {
-        require(
-            candidatesPools[_application] != address(0),
-            "No pool found for the application"
-        );
-
         BondedSortitionPool candidatesPool = BondedSortitionPool(
-            candidatesPools[_application]
+            getSortitionPool(_application)
         );
 
         address operator = msg.sender;
@@ -384,6 +375,23 @@ contract BondedECDSAKeepFactory is
         groupSelectionSeed = _relayEntry;
     }
 
+    /// @notice Gets the sortition pool address for the given application.
+    /// @dev Reverts if sortition does not exits for the application.
+    /// @param _application Address of the application.
+    /// @return Address of the sortition pool contract.
+    function getSortitionPool(address _application)
+        public
+        view
+        returns (address)
+    {
+        require(
+            candidatesPools[_application] != address(0),
+            "No pool found for the application"
+        );
+
+        return candidatesPools[_application];
+    }
+
     /// @notice Checks if operator is registered as a candidate for the given
     /// customer application.
     /// @param _operator Operator's address.
@@ -505,11 +513,7 @@ contract BondedECDSAKeepFactory is
         view
         returns (uint256)
     {
-        address poolAddress = candidatesPools[_application];
-
-        require(poolAddress != address(0), "No pool found for the application");
-
-        return BondedSortitionPool(poolAddress).totalWeight();
+        return BondedSortitionPool(getSortitionPool(_application)).totalWeight();
     }
 
     /// @notice Gets bonded sortition pool of specific application for the

--- a/solidity/contracts/BondedECDSAKeepFactory.sol
+++ b/solidity/contracts/BondedECDSAKeepFactory.sol
@@ -174,9 +174,8 @@ contract BondedECDSAKeepFactory is
     /// @param _minimumBondableValue The minimum unbonded value allowing
     /// an operator to join and stay in the sortition pool for the application.
     function setMinimumBondableValue(uint256 _minimumBondableValue) external {
-        BondedSortitionPool(getSortitionPool(msg.sender)).setMinimumBondableValue(
-            _minimumBondableValue
-        );
+        BondedSortitionPool(getSortitionPool(msg.sender))
+            .setMinimumBondableValue(_minimumBondableValue);
     }
 
     /// @notice Register caller as a candidate to be selected as keep member
@@ -509,7 +508,8 @@ contract BondedECDSAKeepFactory is
         view
         returns (uint256)
     {
-        return BondedSortitionPool(getSortitionPool(_application)).totalWeight();
+        return
+            BondedSortitionPool(getSortitionPool(_application)).totalWeight();
     }
 
     /// @notice Gets bonded sortition pool of specific application for the

--- a/solidity/contracts/BondedECDSAKeepFactory.sol
+++ b/solidity/contracts/BondedECDSAKeepFactory.sol
@@ -371,7 +371,7 @@ contract BondedECDSAKeepFactory is
     }
 
     /// @notice Gets the sortition pool address for the given application.
-    /// @dev Reverts if sortition does not exits for the application.
+    /// @dev Reverts if sortition does not exist for the application.
     /// @param _application Address of the application.
     /// @return Address of the sortition pool contract.
     function getSortitionPool(address _application)

--- a/solidity/contracts/BondedECDSAKeepFactory.sol
+++ b/solidity/contracts/BondedECDSAKeepFactory.sol
@@ -84,18 +84,14 @@ contract BondedECDSAKeepFactory is
     KeepBonding keepBonding;
     IRandomBeacon randomBeacon;
 
-    // Sortition pool is created with a minimum bond of 1 to avoid
-    // griefing.
+    // Sortition pool is created with a minimum bond of 20 ETH to avoid
+    // small operators joining and griefing future selections before the
+    // minimum bond is set to the right value by the application.
     //
-    // Anyone can create a sortition pool for an application. If a pool is
-    // created with a ridiculously high bond, nobody can join it and
-    // updating bond is not possible because trying to select a group
-    // with an empty pool reverts.
-    //
-    // We set the minimum bond value to 1 to prevent from this situation and
-    // to allow the pool adjust the minimum bond during the first signer
-    // selection.
-    uint256 public constant minimumBond = 1;
+    // Anyone can create a sortition pool for an application with the default
+    // minimum bond value but the application can change this value later, at
+    // any point.
+    uint256 public constant minimumBond = 20e18; // 20 ETH
 
     // Signer candidates in bonded sortition pool are weighted by their eligible
     // stake divided by a constant divisor. The divisor is set to 1 KEEP so that

--- a/solidity/contracts/api/IBondedECDSAKeepFactory.sol
+++ b/solidity/contracts/api/IBondedECDSAKeepFactory.sol
@@ -44,4 +44,15 @@ interface IBondedECDSAKeepFactory {
     function getSortitionPoolWeight(
         address _application
     ) external view returns (uint256);
+
+    /// @notice Sets the minimum bondable value required from the operator to
+    /// join the sortition pool of the given application. It is up to the
+    /// application to specify a reasonable minimum bond for operators trying to
+    /// join the pool to prevent griefing by operators joining without enough
+    /// bondable value.
+    /// @dev The default minimum bond value for each sortition pool created
+    /// is 20 ETH.
+    /// @param _minimumBondableValue The minimum unbonded value allowing
+    /// an operator to join and stay in the sortition pool for the application.
+    function setMinimumBondableValue(uint256 _minimumBondableValue) external;
 }

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -959,8 +959,9 @@
       }
     },
     "@keep-network/sortition-pools": {
-      "version": "git://github.com/keep-network/sortition-pools.git#46d187a8d5a02ae19bf0e4d4813b68d5959a032c",
-      "from": "git://github.com/keep-network/sortition-pools.git#46d187a8d5a02ae19bf0e4d4813b68d5959a032c",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-1.1.0.tgz",
+      "integrity": "sha512-4mPp6f6HpfEdjfFM/PHwqabfnWc91gldbcIQEoS6bSfrqfrgFgmmOT6r9WO+Sqw9bR6Ve1tPWp3jpu6ufkPDww==",
       "requires": {
         "@openzeppelin/contracts": "^2.4.0"
       }

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -959,9 +959,8 @@
       }
     },
     "@keep-network/sortition-pools": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-1.0.0.tgz",
-      "integrity": "sha512-wPOjqQphGtIBTGpGmw8gwBDbvMeq/9wf+HCsD6Vhvd7bcY5lPT/oWFFqhiExhuaLyISwr1fl6Jgm4RkN6Cispg==",
+      "version": "git://github.com/keep-network/sortition-pools.git#46d187a8d5a02ae19bf0e4d4813b68d5959a032c",
+      "from": "git://github.com/keep-network/sortition-pools.git#46d187a8d5a02ae19bf0e4d4813b68d5959a032c",
       "requires": {
         "@openzeppelin/contracts": "^2.4.0"
       }
@@ -26882,7 +26881,7 @@
       }
     },
     "websocket": {
-      "version": "github:web3-js/WebSocket-Node#ef5ea2f41daf4a2113b80c9223df884b4d56c400",
+      "version": "github:web3-js/WebSocket-Node#905deb4812572b344f5801f8c9ce8bb02799d82e",
       "from": "github:web3-js/WebSocket-Node#polyfill/globalThis",
       "requires": {
         "debug": "^2.2.0",

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -35,7 +35,7 @@
   "homepage": "https://github.com/keep-network/keep-ecdsa",
   "dependencies": {
     "@keep-network/keep-core": ">1.3.0-pre <1.3.0-rc",
-    "@keep-network/sortition-pools": "git://github.com/keep-network/sortition-pools.git#46d187a8d5a02ae19bf0e4d4813b68d5959a032c",
+    "@keep-network/sortition-pools": "1.1.0",
     "@openzeppelin/upgrades": "^2.7.2",
     "openzeppelin-solidity": "2.3.0",
     "solidity-bytes-utils": "0.0.7"

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -35,7 +35,7 @@
   "homepage": "https://github.com/keep-network/keep-ecdsa",
   "dependencies": {
     "@keep-network/keep-core": ">1.3.0-pre <1.3.0-rc",
-    "@keep-network/sortition-pools": "1.0.0",
+    "@keep-network/sortition-pools": "git://github.com/keep-network/sortition-pools.git#46d187a8d5a02ae19bf0e4d4813b68d5959a032c",
     "@openzeppelin/upgrades": "^2.7.2",
     "openzeppelin-solidity": "2.3.0",
     "solidity-bytes-utils": "0.0.7"

--- a/solidity/test-environment.config.js
+++ b/solidity/test-environment.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  accounts: {
+    amount: 50, // Number of unlocked accounts
+    ether: 1e6, // Initial balance of unlocked accounts (in ether)
+  }
+};

--- a/solidity/test/BondedECDSAKeepFactoryTest.js
+++ b/solidity/test/BondedECDSAKeepFactoryTest.js
@@ -78,6 +78,16 @@ describe("BondedECDSAKeepFactory", function () {
       await initializeMemberCandidates()
     })
 
+    it("reverts for unknown application", async () => {
+      const unknownApplication = "0xCfd27747D1583feb1eCbD7c4e66C848Db0aA82FB"
+      await expectRevert(
+        keepFactory.registerMemberCandidate(unknownApplication, {
+          from: members[0],
+        }),
+        "No pool found for the application"
+      )
+    })
+
     it("inserts operator with the correct staking weight in the pool", async () => {
       const minimumStakeMultiplier = new BN("10")
       await stakeOperators(members, minimumStake.mul(minimumStakeMultiplier))
@@ -1497,7 +1507,7 @@ describe("BondedECDSAKeepFactory", function () {
       await initializeMemberCandidates()
     })
 
-    it("fails for unknown application", async () => {
+    it("reverts for unknown application", async () => {
       await expectRevert(
         keepFactory.setMinimumBondableValue(10),
         "No pool found for the application"

--- a/solidity/test/BondedECDSAKeepFactoryTest.js
+++ b/solidity/test/BondedECDSAKeepFactoryTest.js
@@ -51,7 +51,7 @@ describe("BondedECDSAKeepFactory", function () {
   const groupSize = new BN(members.length)
   const threshold = new BN(groupSize - 1)
 
-  const singleBond = new BN(1)
+  const singleBond = web3.utils.toWei(new BN("20"), "ether")
   const bond = singleBond.mul(groupSize)
 
   const stakeLockDuration = time.duration.days(180)
@@ -1168,7 +1168,7 @@ describe("BondedECDSAKeepFactory", function () {
         web3.eth.sendTransaction({
           from: accounts[0],
           to: operator,
-          value: web3.utils.toWei("1", "ether"),
+          value: web3.utils.toWei("21", "ether"),
         })
 
         await tokenStaking.setBalance(operator, stakeBalance)

--- a/solidity/test/BondedECDSAKeepFactoryTest.js
+++ b/solidity/test/BondedECDSAKeepFactoryTest.js
@@ -1491,6 +1491,27 @@ describe("BondedECDSAKeepFactory", function () {
     })
   })
 
+  describe("setMinimumBondableValue", async () => {
+    before(async () => {
+      await initializeNewFactory()
+      await initializeMemberCandidates()
+    })
+
+    it("fails for unknown application", async () => {
+      await expectRevert(
+        keepFactory.setMinimumBondableValue(10),
+        "No pool found for the application"
+      )
+    })
+
+    it("sets the minimum bond value for the application", async () => {
+      await keepFactory.setMinimumBondableValue(13, {from: application})
+      const poolAddress = await keepFactory.getSortitionPool(application)
+      const pool = await BondedSortitionPool.at(poolAddress)
+      expect(await pool.getMinimumBondableValue()).to.eq.BN(13)
+    })
+  })
+
   async function initializeNewFactory() {
     registry = await KeepRegistry.new()
     bondedSortitionPoolFactory = await BondedSortitionPoolFactory.new()


### PR DESCRIPTION
Refs: keep-network/keep-ecdsa#506
Depends on https://github.com/keep-network/sortition-pools/pull/84

`BondedSortitionPool` allows specifying a global minimum bondable value the operator needs to have so that it can join and stay in the pool. The responsibility for setting it to some reasonable value goes to the application.

We now have two minimum bond values in the sortition pool (see https://github.com/keep-network/sortition-pools/pull/84): one defining the minimum unbonded value the operator needs to have so that it can join and stay in the pool, and another defining the required bond value for the current selection. If the given operator has enough unbonded value to stay in the pool but it does not have enough unbonded value for the current group selection, it is
skipped.

Sortition pool is created with a minimum bond of 20 ETH to avoid small operators joining and griefing future selections before the minimum bond is set to the right value by the application. Anyone can create a sortition pool for an application with the default minimum bond value but the application can change this value later, at any point. 20 ETH per operator should be more than enough to cover 1 BTC deposit in 3-operators group.

The next step is going to be: modify tBTC to set the minimum bondable value for itself on initialization and for each lot size update. 