### PR TITLE
Calculate the required unbonded value per keep member

### DIFF
--- a/solidity/contracts/BondedECDSAKeepFactory.sol
+++ b/solidity/contracts/BondedECDSAKeepFactory.sol
@@ -173,7 +173,7 @@ contract BondedECDSAKeepFactory is
     /// bondable value.
     /// @param _minimumBondableValue The minimum bond value the application
     /// requires from a single keep.
-    /// @param _groupSize Number of singers in the keep.
+    /// @param _groupSize Number of signers in the keep.
     /// @param _honestThreshold Minimum number of honest keep signers.
     function setMinimumBondableValue(
         uint256 _minimumBondableValue,

--- a/solidity/contracts/BondedECDSAKeepFactory.sol
+++ b/solidity/contracts/BondedECDSAKeepFactory.sol
@@ -171,11 +171,16 @@ contract BondedECDSAKeepFactory is
     /// application to specify a reasonable minimum bond for operators trying to
     /// join the pool to prevent griefing by operators joining without enough
     /// bondable value.
-    /// @param _minimumBondableValue The minimum unbonded value allowing
-    /// an operator to join and stay in the sortition pool for the application.
-    function setMinimumBondableValue(uint256 _minimumBondableValue) external {
+    /// @param _minimumBondableValue The minimum bond value the application
+    /// requires from a single keep.
+    /// @param _groupSize Number of singers in the keep.
+    function setMinimumBondableValue(
+        uint256 _minimumBondableValue,
+        uint256 _groupSize
+    ) external {
+        uint256 memberBond = bondPerMember(_minimumBondableValue, _groupSize);
         BondedSortitionPool(getSortitionPool(msg.sender))
-            .setMinimumBondableValue(_minimumBondableValue);
+            .setMinimumBondableValue(memberBond);
     }
 
     /// @notice Register caller as a candidate to be selected as keep member
@@ -258,12 +263,7 @@ contract BondedECDSAKeepFactory is
         address pool = candidatesPools[application];
         require(pool != address(0), "No signer pool for this application");
 
-        // In Solidity, division rounds towards zero (down) and dividing
-        // '_bond' by '_groupSize' can leave a remainder. Even though, a remainder
-        // is very small, we want to avoid this from happening and memberBond is
-        // rounded up by: `(bond + groupSize - 1 ) / groupSize`
-        // Ex. (100 + 3 - 1) / 3 = 34
-        uint256 memberBond = (_bond.add(_groupSize).sub(1)).div(_groupSize);
+        uint256 memberBond = bondPerMember(_bond, _groupSize);
         require(memberBond > 0, "Bond per member must be greater than zero");
 
         require(
@@ -510,6 +510,23 @@ contract BondedECDSAKeepFactory is
     {
         return
             BondedSortitionPool(getSortitionPool(_application)).totalWeight();
+    }
+
+    /// @notice Calculates bond requirement per member performing the necessary
+    /// rounding.
+    /// @param _keepBond The bond required from a keep.
+    /// @param _groupSize Number of signers in the keep.
+    /// @return Bond value required from each keep member.
+    function bondPerMember(
+        uint256 _keepBond,
+        uint256 _groupSize
+    ) internal pure returns (uint256) {
+        // In Solidity, division rounds towards zero (down) and dividing
+        // '_bond' by '_groupSize' can leave a remainder. Even though, a remainder
+        // is very small, we want to avoid this from happening and memberBond is
+        // rounded up by: `(bond + groupSize - 1 ) / groupSize`
+        // Ex. (100 + 3 - 1) / 3 = 34
+        return (_keepBond.add(_groupSize).sub(1)).div(_groupSize);
     }
 
     /// @notice Gets bonded sortition pool of specific application for the

--- a/solidity/contracts/BondedECDSAKeepFactory.sol
+++ b/solidity/contracts/BondedECDSAKeepFactory.sol
@@ -174,9 +174,11 @@ contract BondedECDSAKeepFactory is
     /// @param _minimumBondableValue The minimum bond value the application
     /// requires from a single keep.
     /// @param _groupSize Number of singers in the keep.
+    /// @param _honestThreshold Minimum number of honest keep signers.
     function setMinimumBondableValue(
         uint256 _minimumBondableValue,
-        uint256 _groupSize
+        uint256 _groupSize,
+        uint256 _honestThreshold
     ) external {
         uint256 memberBond = bondPerMember(_minimumBondableValue, _groupSize);
         BondedSortitionPool(getSortitionPool(msg.sender))
@@ -517,10 +519,11 @@ contract BondedECDSAKeepFactory is
     /// @param _keepBond The bond required from a keep.
     /// @param _groupSize Number of signers in the keep.
     /// @return Bond value required from each keep member.
-    function bondPerMember(
-        uint256 _keepBond,
-        uint256 _groupSize
-    ) internal pure returns (uint256) {
+    function bondPerMember(uint256 _keepBond, uint256 _groupSize)
+        internal
+        pure
+        returns (uint256)
+    {
         // In Solidity, division rounds towards zero (down) and dividing
         // '_bond' by '_groupSize' can leave a remainder. Even though, a remainder
         // is very small, we want to avoid this from happening and memberBond is

--- a/solidity/contracts/api/IBondedECDSAKeepFactory.sol
+++ b/solidity/contracts/api/IBondedECDSAKeepFactory.sol
@@ -55,8 +55,10 @@ interface IBondedECDSAKeepFactory {
     /// @param _minimumBondableValue The minimum unbonded value the application
     /// requires from a single keep.
     /// @param _groupSize Number of singers in the keep.
+    /// @param _honestThreshold Minimum number of honest keep signers.
     function setMinimumBondableValue(
         uint256 _minimumBondableValue,
-        uint256 _groupSize
+        uint256 _groupSize,
+        uint256 _honestThreshold
     ) external;
 }

--- a/solidity/contracts/api/IBondedECDSAKeepFactory.sol
+++ b/solidity/contracts/api/IBondedECDSAKeepFactory.sol
@@ -54,7 +54,7 @@ interface IBondedECDSAKeepFactory {
     /// is 20 ETH.
     /// @param _minimumBondableValue The minimum unbonded value the application
     /// requires from a single keep.
-    /// @param _groupSize Number of singers in the keep.
+    /// @param _groupSize Number of signers in the keep.
     /// @param _honestThreshold Minimum number of honest keep signers.
     function setMinimumBondableValue(
         uint256 _minimumBondableValue,

--- a/solidity/contracts/api/IBondedECDSAKeepFactory.sol
+++ b/solidity/contracts/api/IBondedECDSAKeepFactory.sol
@@ -52,7 +52,11 @@ interface IBondedECDSAKeepFactory {
     /// bondable value.
     /// @dev The default minimum bond value for each sortition pool created
     /// is 20 ETH.
-    /// @param _minimumBondableValue The minimum unbonded value allowing
-    /// an operator to join and stay in the sortition pool for the application.
-    function setMinimumBondableValue(uint256 _minimumBondableValue) external;
+    /// @param _minimumBondableValue The minimum unbonded value the application
+    /// requires from a single keep.
+    /// @param _groupSize Number of singers in the keep.
+    function setMinimumBondableValue(
+        uint256 _minimumBondableValue,
+        uint256 _groupSize
+    ) external;
 }

--- a/solidity/test/BondedECDSAKeepFactoryTest.js
+++ b/solidity/test/BondedECDSAKeepFactoryTest.js
@@ -1509,27 +1509,27 @@ describe("BondedECDSAKeepFactory", function () {
 
     it("reverts for unknown application", async () => {
       await expectRevert(
-        keepFactory.setMinimumBondableValue(10, 3),
+        keepFactory.setMinimumBondableValue(10, 3, 3),
         "No pool found for the application"
       )
     })
 
     it("sets the minimum bond value for the application", async () => {
-      await keepFactory.setMinimumBondableValue(12, 3, {from: application})
+      await keepFactory.setMinimumBondableValue(12, 3, 3, {from: application})
       const poolAddress = await keepFactory.getSortitionPool(application)
       const pool = await BondedSortitionPool.at(poolAddress)
       expect(await pool.getMinimumBondableValue()).to.eq.BN(4)
     })
 
     it("rounds up member bonds", async () => {
-      await keepFactory.setMinimumBondableValue(10, 3, {from: application})
+      await keepFactory.setMinimumBondableValue(10, 3, 3, {from: application})
       const poolAddress = await keepFactory.getSortitionPool(application)
       const pool = await BondedSortitionPool.at(poolAddress)
       expect(await pool.getMinimumBondableValue()).to.eq.BN(4)
     })
 
     it("rounds up members bonds when calculated bond per member equals zero", async () => {
-      await keepFactory.setMinimumBondableValue(2, 3, {from: application})
+      await keepFactory.setMinimumBondableValue(2, 3, 3, {from: application})
       const poolAddress = await keepFactory.getSortitionPool(application)
       const pool = await BondedSortitionPool.at(poolAddress)
       expect(await pool.getMinimumBondableValue()).to.eq.BN(1)

--- a/solidity/test/BondedECDSAKeepFactoryTest.js
+++ b/solidity/test/BondedECDSAKeepFactoryTest.js
@@ -1509,16 +1509,30 @@ describe("BondedECDSAKeepFactory", function () {
 
     it("reverts for unknown application", async () => {
       await expectRevert(
-        keepFactory.setMinimumBondableValue(10),
+        keepFactory.setMinimumBondableValue(10, 3),
         "No pool found for the application"
       )
     })
 
     it("sets the minimum bond value for the application", async () => {
-      await keepFactory.setMinimumBondableValue(13, {from: application})
+      await keepFactory.setMinimumBondableValue(12, 3, {from: application})
       const poolAddress = await keepFactory.getSortitionPool(application)
       const pool = await BondedSortitionPool.at(poolAddress)
-      expect(await pool.getMinimumBondableValue()).to.eq.BN(13)
+      expect(await pool.getMinimumBondableValue()).to.eq.BN(4)
+    })
+
+    it("rounds up member bonds", async () => {
+      await keepFactory.setMinimumBondableValue(10, 3, {from: application})
+      const poolAddress = await keepFactory.getSortitionPool(application)
+      const pool = await BondedSortitionPool.at(poolAddress)
+      expect(await pool.getMinimumBondableValue()).to.eq.BN(4)
+    })
+
+    it("rounds up members bonds when calculated bond per member equals zero", async () => {
+      await keepFactory.setMinimumBondableValue(2, 3, {from: application})
+      const poolAddress = await keepFactory.getSortitionPool(application)
+      const pool = await BondedSortitionPool.at(poolAddress)
+      expect(await pool.getMinimumBondableValue()).to.eq.BN(1)
     })
   })
 


### PR DESCRIPTION
Refs keep-network/keep-ecdsa#506

Instead of expecting the application (sortition pool owner) to calculate
the minimum unbonded value and perform all the necessary rounding, we
now calculate everything in BondedECDSAKeepFactory based on the provided
bond required from a keep and the number of signers in that keep.

Although we currently do not use threshold when calculating the required bond,
we want the applications to pass this parameter so that we can later add
proper support for n>t keeps without changing the public API.