### PR TITLE
Try to get sortition pool before creating a new one

### DIFF
--- a/solidity/scripts/lcl-initialize.js
+++ b/solidity/scripts/lcl-initialize.js
@@ -76,16 +76,31 @@ module.exports = async function () {
     }
 
     try {
-      await bondedECDSAKeepFactory.createSortitionPool(application)
-      console.log(`created sortition pool for application: [${application}]`)
+      console.log(`getting sortition pool for application [${application}]`)
 
       sortitionPoolAddress = await bondedECDSAKeepFactory.getSortitionPool(
-        application
+          application
       )
     } catch (err) {
-      console.error("failed to create sortition pool", err)
-      process.exit(1)
+      console.error("failed to get sortition pool", err, "; creating a new one")
+
+      try {
+        await bondedECDSAKeepFactory.createSortitionPool(application)
+
+        console.log(`created sortition pool for application: [${application}]`)
+
+        sortitionPoolAddress = await bondedECDSAKeepFactory.getSortitionPool(
+            application
+        )
+      } catch (err) {
+        console.error("failed to create sortition pool", err)
+        process.exit(1)
+      }
     }
+
+    console.log(
+        `sortition pool for application [${application}] is [${sortitionPoolAddress}]`
+    )
 
     try {
       for (let i = 0; i < operators.length; i++) {

--- a/solidity/scripts/lcl-initialize.js
+++ b/solidity/scripts/lcl-initialize.js
@@ -79,7 +79,7 @@ module.exports = async function () {
       console.log(`getting sortition pool for application [${application}]`)
 
       sortitionPoolAddress = await bondedECDSAKeepFactory.getSortitionPool(
-          application
+        application
       )
     } catch (err) {
       console.error("failed to get sortition pool", err, "; creating a new one")
@@ -90,7 +90,7 @@ module.exports = async function () {
         console.log(`created sortition pool for application: [${application}]`)
 
         sortitionPoolAddress = await bondedECDSAKeepFactory.getSortitionPool(
-            application
+          application
         )
       } catch (err) {
         console.error("failed to create sortition pool", err)
@@ -99,7 +99,7 @@ module.exports = async function () {
     }
 
     console.log(
-        `sortition pool for application [${application}] is [${sortitionPoolAddress}]`
+      `sortition pool for application [${application}] is [${sortitionPoolAddress}]`
     )
 
     try {


### PR DESCRIPTION
Sortition pool existence should be checked before trying to create a new one during `lcl-initialize.js` script execution. This is a must when executing `local-setup` scripts because keep-network/tbtc#715 introduced sortition pool creation during `tbtc` contract migration. If we always create a sortition pool in that case, we can expect the `lcl-initialize.js` to fail.