### PR TITLE
Firewall caching improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/gofuzz v1.1.0
 	github.com/ipfs/go-log v0.0.1
 	github.com/keep-network/keep-common v1.1.1-0.20200703125023-d9872a19ebd1
-	github.com/keep-network/keep-core v1.2.4-rc.0.20200703125443-6c5dd769bc46
+	github.com/keep-network/keep-core v1.2.4-rc.0.20200730171509-23390fca2250
 	github.com/pkg/errors v0.9.1
 	github.com/urfave/cli v1.22.1
 )

--- a/go.sum
+++ b/go.sum
@@ -158,6 +158,7 @@ github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoA
 github.com/gorilla/websocket v1.4.1-0.20190629185528-ae1634f6a989/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=
 github.com/gorilla/websocket v1.4.1 h1:q7AeDBpnBk8AogcD4DSag/Ukw/KV+YhzLj2bP5HvKCM=
 github.com/gorilla/websocket v1.4.1/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+github.com/graph-gophers/graphql-go v0.0.0-20191115155744-f33e81362277 h1:E0whKxgp2ojts0FDgUA8dl62bmH0LxKanMoBr6MDTDM=
 github.com/graph-gophers/graphql-go v0.0.0-20191115155744-f33e81362277/go.mod h1:9CQHMSxwO4MprSdzoIEobiHpoLtHm77vfxsvsIN5Vuc=
 github.com/gxed/hashland/keccakpg v0.0.1/go.mod h1:kRzw3HkwxFU1mpmPP8v1WyQzwdGfmKFJ6tItnhQ67kU=
 github.com/gxed/hashland/murmur3 v0.0.1/go.mod h1:KjXop02n4/ckmZSnY2+HKcLud/tcmvhST0bie/0lS48=
@@ -179,6 +180,7 @@ github.com/huin/goupnp v1.0.0 h1:wg75sLpL6DZqwHQN6E1Cfk6mtfzS45z8OV+ic+DtHRo=
 github.com/huin/goupnp v1.0.0/go.mod h1:n9v9KO1tAxYH82qOn+UTIFQDmx5n1Zxd/ClZDMX7Bnc=
 github.com/huin/goutil v0.0.0-20170803182201-1ca381bf3150/go.mod h1:PpLOETDnJ0o3iZrZfqZzyLl6l7F3c6L1oWn7OICBi6o=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
+github.com/influxdata/influxdb v1.2.3-0.20180221223340-01288bdb0883 h1:FSeK4fZCo8u40n2JMnyAsd6x7+SbvoOMHvQOU/n10P4=
 github.com/influxdata/influxdb v1.2.3-0.20180221223340-01288bdb0883/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOprn86kgg4+IzY=
 github.com/influxdata/influxdb1-client v0.0.0-20190809212627-fc22c7df067e/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/ipfs/go-cid v0.0.1/go.mod h1:GHWU/WuQdMPmIosc4Yn1bcCT7dSeX4lBafM7iqUPQvM=
@@ -259,6 +261,8 @@ github.com/keep-network/keep-core v1.2.2-0.20200612133212-1e0d6439ee2a h1:kYnqEP
 github.com/keep-network/keep-core v1.2.2-0.20200612133212-1e0d6439ee2a/go.mod h1:+SCVJxA1UBcd3RPEgUq4YnEIoCjbt+pj+Axj3tc4Yn8=
 github.com/keep-network/keep-core v1.2.4-rc.0.20200703125443-6c5dd769bc46 h1:dKrNquMLVUPf2hPyGBk4O1K5SFp1Wneh2B9TrTSQvCk=
 github.com/keep-network/keep-core v1.2.4-rc.0.20200703125443-6c5dd769bc46/go.mod h1:o7hHfkAoMgCKrtWZJ+CeukeQOGy88I2JqXFGvARpu0Y=
+github.com/keep-network/keep-core v1.2.4-rc.0.20200730171509-23390fca2250 h1:NhmQqKlq1Oi2Id0fMQNwcsWQdO7f4tqDikjimHMmg+M=
+github.com/keep-network/keep-core v1.2.4-rc.0.20200730171509-23390fca2250/go.mod h1:o7hHfkAoMgCKrtWZJ+CeukeQOGy88I2JqXFGvARpu0Y=
 github.com/keep-network/toml v0.3.0 h1:G+NJwWR/ZiORqeLBsDXDchYoL29PXHdxOPcCueA7ctE=
 github.com/keep-network/toml v0.3.0/go.mod h1:Zeyd3lxbIlMYLREho3UK1dMP2xjqt2gLkQ5E5vM6K38=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=


### PR DESCRIPTION
Closes: #505 

Three improvements allowing to reduce the number of calls to ETH client:

1. `keep-core` Go dependency updated to the most recent version caching negative `HasMinimumCheck` results (see https://github.com/keep-network/keep-core/pull/1904)
2. Introduced caches for `IsOperatorAuthorized` check results. (`IsOperatorAuthorized` is checked after `HasMinimumCheck` and before active keep lookup).
3. Cached two pieces of information that never change in the active keep lookup: is keep inactive? and the list of keep members. 

This set of caches should give us pretty neat reduction of calls to ETH client in the firewall.