### PR TITLE
keep-ecdsa-client:  Init with non-ancient web3 

### DIFF
--- a/infrastructure/kube/templates/keep-ecdsa/initcontainer/provision-keep-ecdsa/package.json
+++ b/infrastructure/kube/templates/keep-ecdsa/initcontainer/provision-keep-ecdsa/package.json
@@ -2,7 +2,7 @@
   "dependencies": {
     "toml": "^3.0.0",
     "tomlify-j0.4": "^3.0.0",
-    "@truffle/hdwallet-provider": "^1.0.25",
-    "web3": "1.0.0-beta.55"
+    "@truffle/hdwallet-provider": "^1.0.38",
+    "web3": "1.2.9"
   }
 }

--- a/infrastructure/kube/templates/keep-ecdsa/initcontainer/provision-keep-ecdsa/provision-keep-ecdsa.js
+++ b/infrastructure/kube/templates/keep-ecdsa/initcontainer/provision-keep-ecdsa/provision-keep-ecdsa.js
@@ -73,14 +73,14 @@ async function provisionKeepTecdsa() {
     console.log(`\n<<<<<<<<<<<< Funding Operator Account ${operatorAddress} >>>>>>>>>>>>`)
     await fundOperator(operatorAddress, purse, '10')
 
-    console.log(`\n<<<<<<<<<<<< Deposit to KeepBondingContract ${keepBondingContract.address} >>>>>>>>>>>>`)
+    console.log(`\n<<<<<<<<<<<< Deposit to KeepBondingContract ${keepBondingContract.options.address} >>>>>>>>>>>>`)
     await depositUnbondedValue(operatorAddress, purse, '10')
 
     console.log(`\n<<<<<<<<<<<< Staking Operator Account ${operatorAddress} >>>>>>>>>>>>`)
     await stakeOperator(operatorAddress, contractOwnerAddress, authorizer)
 
-    console.log(`\n<<<<<<<<<<<< Authorizing Operator Contract ${bondedECDSAKeepFactory.address} >>>>>>>>>>>>`)
-    await authorizeOperatorContract(operatorAddress, bondedECDSAKeepFactory.address, authorizer)
+    console.log(`\n<<<<<<<<<<<< Authorizing Operator Contract ${bondedECDSAKeepFactory.options.address} >>>>>>>>>>>>`)
+    await authorizeOperatorContract(operatorAddress, bondedECDSAKeepFactory.options.address, authorizer)
 
     for (let i = 0; i < sanctionedApplications.length; i++) {
       const sanctionedApplicationAddress = sanctionedApplications[i]
@@ -181,7 +181,7 @@ async function stakeOperator(operatorAddress, contractOwnerAddress, authorizer) 
   ])
 
   await keepTokenContract.methods.approveAndCall(
-    tokenStakingContract.address,
+    tokenStakingContract.options.address,
     formatAmount(2000000, 18),
     delegation).send({ from: contractOwnerAddress })
 
@@ -241,7 +241,7 @@ async function createKeepTecdsaConfig() {
 
   parsedConfigFile.ethereum.account.KeyFile = operatorKeyFile
 
-  parsedConfigFile.ethereum.ContractAddresses.BondedECDSAKeepFactory = bondedECDSAKeepFactory.address
+  parsedConfigFile.ethereum.ContractAddresses.BondedECDSAKeepFactory = bondedECDSAKeepFactory.options.address
 
   parsedConfigFile.SanctionedApplications.Addresses = [].concat(sanctionedApplications)
 


### PR DESCRIPTION
We've started running into web3 errors during InitContainer runs for both keep-client and keep-ecdsa.  Rolling the containers forward to a newer version of web3 addresses the issue.  Along with the upgrade we've had to adjust how we call a contract objects address, as the `.address` parameter has been wrapped under a new `options` object.

For posterity, here's a sample of the error we've been seeing:

```
<<<<<<<<<<<< Authorizing Operator Contract 0xe7BF8421fBE80c3Bf67082370D86C8D81D1D77F4 >>>>>>>>>>>>
Authorizing Operator Contract 0xe7BF8421fBE80c3Bf67082370D86C8D81D1D77F4 for operator account 0x3ff855895ef4ac833c32ab6a0d6c7fbfa137e26e
undefined
{ error:
   Error: Invalid method parameter(s).
       at /tmp/node_modules/web3-provider-engine/subproviders/provider.js:18:36
       at XMLHttpRequest.request.onreadystatechange (/tmp/node_modules/web3-providers-http/src/index.js:96:13)
       at XMLHttpRequestEventTarget.dispatchEvent (/tmp/node_modules/xhr2-cookies/dist/xml-http-request-event-target.js:34:22)
       at XMLHttpRequest._setReadyState (/tmp/node_modules/xhr2-cookies/dist/xml-http-request.js:208:14)
       at XMLHttpRequest._onHttpResponseEnd (/tmp/node_modules/xhr2-cookies/dist/xml-http-request.js:318:14)
       at IncomingMessage.<anonymous> (/tmp/node_modules/xhr2-cookies/dist/xml-http-request.js:289:61)
       at IncomingMessage.emit (events.js:198:15)
       at endReadableNT (_stream_readable.js:1139:12)
       at processTicksAndRejections (internal/process/task_queues.js:81:17),
  receipt: false,
  confirmations: 0,
  confirmationChecks: 16 }
```

### Testing

To prove this out I pulled down the current InitContainer from the registry and ran the provisioning script locally after updating the web3 and HDWalletProvider versions / address calls.