### PR TITLE
keep-test: Separate ETH host

### DIFF
--- a/infrastructure/kube/keep-test/keep-ecdsa-0-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-ecdsa-0-statefulset.yaml
@@ -77,12 +77,12 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: eth-network-ropsten
-                  key: rpc-url
+                  key: keep-ecdsa-rpc-url
             - name: ETH_WS_URL
               valueFrom:
                 secretKeyRef:
                   name: eth-network-ropsten
-                  key: ws-url
+                  key: keep-ecdsa-ws-url
             - name: ETH_NETWORK_ID
               valueFrom:
                 configMapKeyRef:

--- a/infrastructure/kube/keep-test/keep-ecdsa-3-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-ecdsa-3-statefulset.yaml
@@ -78,12 +78,12 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: eth-network-ropsten
-                  key: rpc-url
+                  key: keep-ecdsa-rpc-url
             - name: ETH_WS_URL
               valueFrom:
                 secretKeyRef:
                   name: eth-network-ropsten
-                  key: ws-url
+                  key: keep-ecdsa-ws-url
             - name: ETH_NETWORK_ID
               valueFrom:
                 configMapKeyRef:

--- a/infrastructure/kube/keep-test/keep-ecdsa-4-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-ecdsa-4-statefulset.yaml
@@ -78,12 +78,12 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: eth-network-ropsten
-                  key: rpc-url
+                  key: keep-ecdsa-rpc-url
             - name: ETH_WS_URL
               valueFrom:
                 secretKeyRef:
                   name: eth-network-ropsten
-                  key: ws-url
+                  key: keep-ecdsa-ws-url
             - name: ETH_NETWORK_ID
               valueFrom:
                 configMapKeyRef:

--- a/infrastructure/kube/keep-test/keep-ecdsa-5-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-ecdsa-5-statefulset.yaml
@@ -77,12 +77,12 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: eth-network-ropsten
-                  key: rpc-url
+                  key: keep-ecdsa-rpc-url
             - name: ETH_WS_URL
               valueFrom:
                 secretKeyRef:
                   name: eth-network-ropsten
-                  key: ws-url
+                  key: keep-ecdsa-ws-url
             - name: ETH_NETWORK_ID
               valueFrom:
                 configMapKeyRef:

--- a/infrastructure/kube/keep-test/keep-ecdsa-6-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-ecdsa-6-statefulset.yaml
@@ -77,12 +77,12 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: eth-network-ropsten
-                  key: rpc-url
+                  key: keep-ecdsa-rpc-url
             - name: ETH_WS_URL
               valueFrom:
                 secretKeyRef:
                   name: eth-network-ropsten
-                  key: ws-url
+                  key: keep-ecdsa-ws-url
             - name: ETH_NETWORK_ID
               valueFrom:
                 configMapKeyRef:

--- a/infrastructure/kube/keep-test/keep-ecdsa-7-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-ecdsa-7-statefulset.yaml
@@ -77,12 +77,12 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: eth-network-ropsten
-                  key: rpc-url
+                  key: keep-ecdsa-rpc-url
             - name: ETH_WS_URL
               valueFrom:
                 secretKeyRef:
                   name: eth-network-ropsten
-                  key: ws-url
+                  key: keep-ecdsa-ws-url
             - name: ETH_NETWORK_ID
               valueFrom:
                 configMapKeyRef:

--- a/infrastructure/kube/keep-test/keep-ecdsa-8-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-ecdsa-8-statefulset.yaml
@@ -77,12 +77,12 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: eth-network-ropsten
-                  key: rpc-url
+                  key: keep-ecdsa-rpc-url
             - name: ETH_WS_URL
               valueFrom:
                 secretKeyRef:
                   name: eth-network-ropsten
-                  key: ws-url
+                  key: keep-ecdsa-ws-url
             - name: ETH_NETWORK_ID
               valueFrom:
                 configMapKeyRef:

--- a/infrastructure/kube/keep-test/keep-ecdsa-9-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-ecdsa-9-statefulset.yaml
@@ -77,12 +77,12 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: eth-network-ropsten
-                  key: rpc-url
+                  key: keep-ecdsa-rpc-url
             - name: ETH_WS_URL
               valueFrom:
                 secretKeyRef:
                   name: eth-network-ropsten
-                  key: ws-url
+                  key: keep-ecdsa-ws-url
             - name: ETH_NETWORK_ID
               valueFrom:
                 configMapKeyRef:


### PR DESCRIPTION
This is a keep-test/keep-ecdsa dedicated Alchemy app so that we can track keep-ecdsa usage in isolation on testnet.