### PR TITLE
Repair eth_connectivity metric

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -167,7 +167,7 @@ func Start(c *cli.Context) error {
 	)
 	logger.Debugf("initialized operator with address: [%s]", ethereumKey.Address.String())
 
-	initializeMetrics(ctx, config, networkProvider, stakeMonitor)
+	initializeMetrics(ctx, config, networkProvider, stakeMonitor, ethereumKey.Address.Hex())
 
 	logger.Info("client started")
 
@@ -186,6 +186,7 @@ func initializeMetrics(
 	config *config.Config,
 	netProvider net.Provider,
 	stakeMonitor chain.StakeMonitor,
+	ethereumAddres string,
 ) {
 	registry, isConfigured := metrics.Initialize(
 		config.Metrics.Port,
@@ -219,7 +220,7 @@ func initializeMetrics(
 		ctx,
 		registry,
 		stakeMonitor,
-		config.Ethereum.Account.Address,
+		ethereumAddres,
 		time.Duration(config.Metrics.EthereumMetricsTick)*time.Second,
 	)
 


### PR DESCRIPTION
`eth_connectivity` metric didn't work properly for `keep-ecdsa` because it invoked the `hasMinimumStake` method using a non-existing address taken from a non-existing config property. This PR fixes the problem by taking the address directly from the parsed key.