### PR TITLE
Repair lcl-initialize script

### DIFF
--- a/solidity/scripts/lcl-initialize.js
+++ b/solidity/scripts/lcl-initialize.js
@@ -82,9 +82,18 @@ module.exports = async function () {
         application
       )
     } catch (err) {
-      console.error("failed to get sortition pool", err, "; creating a new one")
+      console.error("failed to get sortition pool", err)
+    }
 
+    if (
+      !sortitionPoolAddress ||
+      sortitionPoolAddress === "0x0000000000000000000000000000000000000000"
+    ) {
       try {
+        console.error(
+          `no sortition pool for application: [${application}]; creating a new one`
+        )
+
         await bondedECDSAKeepFactory.createSortitionPool(application)
 
         console.log(`created sortition pool for application: [${application}]`)

--- a/solidity/scripts/lcl-initialize.js
+++ b/solidity/scripts/lcl-initialize.js
@@ -86,8 +86,8 @@ module.exports = async function () {
     }
 
     // FIXME: Workaround for https://github.com/ethereum/go-ethereum/pull/21083 - instead of failing,
-    // contract call returns address 0x0. Once we are able to update to the most recent abigen 
-    // (see https://github.com/keep-network/keep-common/issues/45), the additional case for 0x0 address 
+    // contract call returns address 0x0. Once we are able to update to the most recent abigen
+    // (see https://github.com/keep-network/keep-common/issues/45), the additional case for 0x0 address
     // should be removed.
     if (
       !sortitionPoolAddress ||

--- a/solidity/scripts/lcl-initialize.js
+++ b/solidity/scripts/lcl-initialize.js
@@ -85,6 +85,10 @@ module.exports = async function () {
       console.error("failed to get sortition pool", err)
     }
 
+    // FIXME: Workaround for https://github.com/ethereum/go-ethereum/pull/21083 - instead of failing,
+    // contract call returns address 0x0. Once we are able to update to the most recent abigen 
+    // (see https://github.com/keep-network/keep-common/issues/45), the additional case for 0x0 address 
+    // should be removed.
     if (
       !sortitionPoolAddress ||
       sortitionPoolAddress === "0x0000000000000000000000000000000000000000"


### PR DESCRIPTION
The sortition pool creation logic in `lcl-initialize.js` script, didn't consider a case when the `getSortitionPool` method returned a zero address. This PR adds some improvements to that logic.