### PR TITLE
Disable assembly, timestamp, and solc-version detectors 

### DIFF
--- a/solidity/slither.config.json
+++ b/solidity/slither.config.json
@@ -1,3 +1,4 @@
 {
-    "filter_paths": "contracts/test|node_modules/@keep-network/keep-core"
+    "filter_paths": "contracts/test|node_modules/@keep-network/keep-core",
+    "detectors_to_exclude": "assembly,timestamp,solc-version"
 }


### PR DESCRIPTION
`assembly` and `timestamp` are checked via Solium in our case, so no reason to have Slither pile on.

`solc-version` warning has some outdated version information in the mix, so it's mostly extremely noisy.