### PR TITLE
Sortition pool updates for stateful sets

### DIFF
--- a/infrastructure/kube/keep-test/keep-ecdsa-2-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-ecdsa-2-statefulset.yaml
@@ -110,7 +110,7 @@ spec:
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
             - name: SANCTIONED_APPLICATIONS
-              value: '0x9F3B3bCED0AFfe862D436CB8FF462a454040Af80' # Shall we extract this property to a configmap?
+              value: '0xc3f96306eDabACEa249D2D22Ec65697f38c6Da69' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-test/keep-ecdsa-3-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-ecdsa-3-statefulset.yaml
@@ -110,7 +110,7 @@ spec:
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
             - name: SANCTIONED_APPLICATIONS
-              value: '0x9F3B3bCED0AFfe862D436CB8FF462a454040Af80' # Shall we extract this property to a configmap?
+              value: '0xc3f96306eDabACEa249D2D22Ec65697f38c6Da69' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/templates/keep-ecdsa/initcontainer/provision-keep-ecdsa/provision-keep-ecdsa.js
+++ b/infrastructure/kube/templates/keep-ecdsa/initcontainer/provision-keep-ecdsa/provision-keep-ecdsa.js
@@ -220,7 +220,11 @@ async function createSortitionPool(applicationAddress) {
     return await bondedECDSAKeepFactory.methods.getSortitionPool(applicationAddress).call()
   }
 
-  sortitionPoolContractAddress = await bondedECDSAKeepFactory.methods.getSortitionPool(applicationAddress).call()
+  try {
+    sortitionPoolContractAddress = await bondedECDSAKeepFactory.methods.getSortitionPool(applicationAddress).call()
+  } catch (err) {
+    console.error("failed to get sortition pool", err)
+  }
 
   if (!sortitionPoolContractAddress || sortitionPoolContractAddress == ADDRESS_ZERO) {
     console.log("sortition pool does not exists yet")


### PR DESCRIPTION
Two changes:
- Updated `SANCTIONED_APPLICATIONS` value to `1.1.0-rc.1` `TBTCSystem` address.
- Added `try-catch` around `getSortitionPool` in provisioning script: `getSortitionPool` reverts if pool does not exist for the given application. A similar `try-catch` solution is applied in `lcl-initialize.js`.

This state is already deployed to `keep-ecdsa-2` and `keep-ecdsa-3`.