### PR TITLE
submitPublicKey TX gas limit set to 350k

### DIFF
--- a/pkg/chain/ethereum/ethereum.go
+++ b/pkg/chain/ethereum/ethereum.go
@@ -227,7 +227,7 @@ func (ec *EthereumChain) SubmitKeepPublicKey(
 		transaction, err := keepContract.SubmitPublicKey(
 			publicKey[:],
 			ethutil.TransactionOptions{
-				GasLimit: 3000000, // enough for a group size of 16
+				GasLimit: 350000, // enough for a group size of 16
 			},
 		)
 		if err != nil {
@@ -242,7 +242,7 @@ func (ec *EthereumChain) SubmitKeepPublicKey(
 	// a new cloned contract has not been registered by the ethereum node. Common
 	// case is when Ethereum nodes are behind a load balancer and not fully synced
 	// with each other. To mitigate this issue, a client will retry submitting
-	// a public key up to 4 times with a 250ms interval.
+	// a public key up to 10 times with a 250ms interval.
 	if err := ec.withRetry(submitPubKey); err != nil {
 		return err
 	}

--- a/solidity/test/BondedECDSAKeepTest.js
+++ b/solidity/test/BondedECDSAKeepTest.js
@@ -11,6 +11,7 @@ const {createSnapshot, restoreSnapshot} = require("./helpers/snapshot")
 const {expectRevert, constants, time} = require("@openzeppelin/test-helpers")
 
 const KeepRegistry = contract.fromArtifact("KeepRegistry")
+const BondedECDSAKeep = contract.fromArtifact("BondedECDSAKeep")
 const BondedECDSAKeepStub = contract.fromArtifact("BondedECDSAKeepStub")
 const TestToken = contract.fromArtifact("TestToken")
 const KeepBonding = contract.fromArtifact("KeepBonding")
@@ -330,6 +331,71 @@ describe("BondedECDSAKeep", function () {
       )
 
       assert.isTrue(await keep.isAwaitingSignature(digest1))
+    })
+  })
+
+  describe("public key submission gas cost", async () => {
+    const publicKey =
+      "0x657282135ed640b0f5a280874c7e7ade110b5c3db362e0552e6b7fff2cc8459328850039b734db7629c31567d7fc5677536b7fc504e967dc11f3f2289d3d4051"
+    const anotherPublicKey =
+      "0x699282135ed640b0f5a280874c7e7ade110b5c3db362e0552e6b7fff2cc8459328850039b734db7629c31567d7fc5677536b7fc504e967dc11f3f2289d3d4052"
+
+    const sixteenSigners = [...Array(16).keys()].map((i) => accounts[i])
+
+    let keepWith16Signers
+
+    beforeEach(async () => {
+      const keepAddress = await factoryStub.newKeep.call(
+        owner,
+        sixteenSigners,
+        sixteenSigners.length,
+        memberStake,
+        stakeLockDuration,
+        tokenStaking.address,
+        keepBonding.address,
+        factoryStub.address
+      )
+
+      await factoryStub.newKeep(
+        owner,
+        sixteenSigners,
+        sixteenSigners.length,
+        memberStake,
+        stakeLockDuration,
+        tokenStaking.address,
+        keepBonding.address,
+        factoryStub.address
+      )
+
+      keepWith16Signers = await BondedECDSAKeep.at(keepAddress)
+    })
+
+    it("should be less than 350k if all submitted keys match", async () => {
+      const maxExpectedCost = web3.utils.toBN(350000)
+      for (let i = 0; i < sixteenSigners.length; i++) {
+        const tx = await keepWith16Signers.submitPublicKey(publicKey, {
+          from: sixteenSigners[i],
+        })
+
+        const gasUsed = web3.utils.toBN(tx.receipt.gasUsed)
+        expect(gasUsed).to.be.lte.BN(maxExpectedCost)
+      }
+    })
+
+    it("should be less than 350k if the last submitted key does not match", async () => {
+      const maxExpectedCost = web3.utils.toBN(350000)
+      for (let i = 0; i < sixteenSigners.length - 1; i++) {
+        await keepWith16Signers.submitPublicKey(publicKey, {
+          from: sixteenSigners[i],
+        })
+      }
+
+      const tx = await keepWith16Signers.submitPublicKey(anotherPublicKey, {
+        from: sixteenSigners[15],
+      })
+
+      const gasUsed = web3.utils.toBN(tx.receipt.gasUsed)
+      expect(gasUsed).to.be.lte.BN(maxExpectedCost)
     })
   })
 


### PR DESCRIPTION
# The problem

Yesterday, Ropsten block gas limit went down to ~1.6M and after 12 hours is now at ~1.7M. We discovered that no keep public key has been submitted since the gas limit reduction. Looking at the logs provided by community members (thanks _whataday2day_ and _Danil Ushakov_ 🙌 ) we found:

> 2020-09-07T20:16:00.765Z ERROR keep-chain-eth-ethereum Error occurred [response [[]] was not long enough to interpret while resolving original error [exceeds block gas limit]]; on [1] retry

# The solution

The gas limit for `submitPublicKey` TX is hardcoded to the most pessimistic case. When estimating transaction costs, most clients see and use an empty state of the keep, with no public keys submitted. As a result, transactions land in the mempool with gas limit calculated based on the contract state that could be different from the one when the transactions are mined and some keys have been already submitted by other members.

Although using the hardcoded limit seems to be the best option now, the hardcoded 3M gas limit was quite suspicious. All estimations [we have made so far](https://github.com/keep-network/keep-ecdsa/pull/228) were about 300k and 3M gas limit looks like a typo. I implemented two unit tests making sure the gas cost is never higher than 350k and updated the hardcoded limit in `ethereum.go`. The most pessimistic case is around ~350k and it's when we have 16 members in a keep and the last member submitted incorrect public key.

Gas used for 3 keep members and success scenario: `110984, 110211, 172693`.
Gas used for 3 keep members and the "last key does not match" scenario: `110984, 110211, 130022`.
Gas used for 16 keep members and success scenario: `206951, 206178, 205405, 204632, 203859, 203086, 202313, 201540, 200767, 199994, 199221, 198448, 197675, 196902, 196129`.
Gas used for 16 keep members and the "last key does not match" scenario: `206951, 206178, 205405, 204632, 203859, 203086, 202313, 201540, 200767, 199994, 199221, 198448, 197675, 196902, 349697`.