### PR TITLE
DefaultMaxGasPrice used by client set to 500 Gwei

### DIFF
--- a/configs/config.toml.SAMPLE
+++ b/configs/config.toml.SAMPLE
@@ -18,7 +18,7 @@
 	# allowed gas price is reached, no further resubmission attempts are
 	# performed.
 	#
-	# MaxGasPrice = 70000000000 # 70 gwei (default value)
+	# MaxGasPrice = 500000000000 # 500 Gwei (default value)
 	#
   # Uncomment to enable Ethereum node rate limiting. Both properties can be
   # used together or separately.

--- a/pkg/chain/ethereum/connect.go
+++ b/pkg/chain/ethereum/connect.go
@@ -2,10 +2,11 @@ package ethereum
 
 import (
 	"fmt"
-	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"math/big"
 	"sync"
 	"time"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/ethereum/go-ethereum/ethclient"
@@ -29,7 +30,7 @@ var (
 	// gas price can not be higher than the max gas price value. If the maximum
 	// allowed gas price is reached, no further resubmission attempts are
 	// performed. This value can be overwritten in the configuration file.
-	DefaultMaxGasPrice = big.NewInt(70000000000) // 70 Gwei
+	DefaultMaxGasPrice = big.NewInt(500000000000) // 500 Gwei
 )
 
 // EthereumChain is an implementation of ethereum blockchain interface.


### PR DESCRIPTION

<img width="1300" alt="image" src="https://user-images.githubusercontent.com/4712360/92464147-0accb900-f1cd-11ea-9ed7-b395f2634cdb.png">


Source: https://etherscan.io/chart/gasprice

The last weeks brought an extreme gas price increase on mainnet, even to 500 Gwei average price. The default value of 70 Gwei could not be enough.

The `MaxGasPrice` can be still configured in the config file, here we just update the default value to keep it aligned with the reality.