### PR TITLE
keep-core Go dependency bumped up to v1.3.0-rc.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/google/gofuzz v1.1.0
 	github.com/ipfs/go-log v1.0.4
 	github.com/keep-network/keep-common v1.2.0
-	github.com/keep-network/keep-core v1.3.0-rc.3
+	github.com/keep-network/keep-core v1.3.0-rc.4
 	github.com/pkg/errors v0.9.1
 	github.com/urfave/cli v1.22.1
 )

--- a/go.sum
+++ b/go.sum
@@ -333,8 +333,8 @@ github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec h
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec/go.mod h1:xR8jf3/VJAjh3nWu5tFe8Yxnt2HvWsqZHfGef1P5oDk=
 github.com/keep-network/keep-common v1.2.0 h1:hVd2tTd7vL+9CQP5Ntk5kjs+GYvkgrRNBcNvTuhHhVk=
 github.com/keep-network/keep-common v1.2.0/go.mod h1:emxogTbBdey7M3jOzfxZOdfn139kN2mI2b2wA6AHKKo=
-github.com/keep-network/keep-core v1.3.0-rc.3 h1:N0B9EEJBnznGIY3a1zvLMNo5JEjUfunQkSi/6ZYQKfM=
-github.com/keep-network/keep-core v1.3.0-rc.3/go.mod h1:1KsSSTQoN754TrFLW7kLy50pOG2CQ4BOfnJqdvEG7FA=
+github.com/keep-network/keep-core v1.3.0-rc.4 h1:24sYPSb+UE0kpTx3e0vcd0uDwy9nj7O1wxV55PARIQU=
+github.com/keep-network/keep-core v1.3.0-rc.4/go.mod h1:1KsSSTQoN754TrFLW7kLy50pOG2CQ4BOfnJqdvEG7FA=
 github.com/keep-network/toml v0.3.0 h1:G+NJwWR/ZiORqeLBsDXDchYoL29PXHdxOPcCueA7ctE=
 github.com/keep-network/toml v0.3.0/go.mod h1:Zeyd3lxbIlMYLREho3UK1dMP2xjqt2gLkQ5E5vM6K38=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=


### PR DESCRIPTION
keep-core dependency updated to the most recent version `v1.3.0-rc.4`.