### PR TITLE
Check signer existence before key generation

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -191,6 +191,14 @@ func Initialize(
 				}
 				defer requestedSigners.remove(event.KeepAddress)
 
+				if keepsRegistry.HasSigner(event.KeepAddress) {
+					logger.Warning(
+						"signer for keep [%s] already registered;",
+						event.KeepAddress.String(),
+					)
+					return
+				}
+
 				generateKeyForKeep(
 					ctx,
 					ethereumChain,


### PR DESCRIPTION
Closes: #554 

Added a condition which checks signer existence before triggering a key generation process in response to `BondedECDSAKeepCreatedEvent`.

The problem addressed here concerns duplicated events emerging just after the end of the first key generation process. In that case, the `requestedSigners` cache does no longer contain the original event reference and allows triggering a new key generation in response to the duplicated event. Checking signer existence at this stage will protect against redundant key generation processes which may lead to an unpredictable behavior of the clients.