### PR TITLE
Event already registered log levels changed from ERROR to WARNING

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -183,7 +183,7 @@ func Initialize(
 		if event.IsMember(ethereumChain.Address()) {
 			go func(event *eth.BondedECDSAKeepCreatedEvent) {
 				if ok := requestedSigners.add(event.KeepAddress); !ok {
-					logger.Errorf(
+					logger.Warningf(
 						"keep creation event for keep [%s] already registered",
 						event.KeepAddress.String(),
 					)
@@ -521,7 +521,7 @@ func monitorSigningRequests(
 
 			go func(event *eth.SignatureRequestedEvent) {
 				if ok := requestedSignatures.add(keepAddress, event.Digest); !ok {
-					logger.Errorf(
+					logger.Warningf(
 						"signature requested event for keep [%s] and digest [%x] already registered",
 						keepAddress.String(),
 						event.Digest,
@@ -597,7 +597,7 @@ func checkAwaitingSignature(
 		)
 
 		if ok := requestedSignatures.add(keepAddress, latestDigest); !ok {
-			logger.Errorf(
+			logger.Warningf(
 				"signature requested event for keep [%s] and digest [%x] already registered",
 				keepAddress.String(),
 				latestDigest,


### PR DESCRIPTION
Closes #560 
Closes #552

Event duplicates are happening quite often on mainnet given minor chain
reorgs. Logging event duplicates on ERROR level is too noisy for
operators monitoring their nodes. We are changing event duplicate log
levels for keep creation and signature request from ERROR to WARNING.