### PR TITLE
Sortition pool registration notifications

### DIFF
--- a/pkg/client/registration.go
+++ b/pkg/client/registration.go
@@ -61,7 +61,11 @@ RegistrationLoop:
 			// once the registration is confirmed or if the client is already
 			// registered, we can start to monitor the status
 			if err := monitorSignerPoolStatus(ctx, ethereumChain, application); err != nil {
-				logger.Errorf("failed on signer pool status monitoring: [%v]", err)
+				logger.Errorf(
+					"failed on signer pool status monitoring; please inspect "+
+						"signer's unbonded value and stake: [%v]",
+					err,
+				)
 				time.Sleep(retryDelay) // TODO: #413 Replace with backoff.
 				continue RegistrationLoop
 			}

--- a/pkg/client/registration.go
+++ b/pkg/client/registration.go
@@ -10,7 +10,15 @@ import (
 )
 
 const statusCheckIntervalBlocks = 100
+
+// retryDelay defines the delay between retries related to the registration logic
+// that do not have their own specific values (like for example `eligibilityRetryDelay`
+// for sortition pool join eligibility checks).
 const retryDelay = 1 * time.Second
+
+// eligibilityRetryDelay defines the delay between checks whether the operator
+// is eligible to join the sortition pool.
+const eligibilityRetryDelay = 20 * time.Minute
 
 // checkStatusAndRegisterForApplication checks whether the operator is
 // registered as a member candidate for keep for the given application.
@@ -139,7 +147,7 @@ func registerAsMemberCandidateWhenEligible(
 					"operator is not eligible for application [%s]",
 					application.String(),
 				)
-				time.Sleep(retryDelay) // TODO: #413 Replace with backoff.
+				time.Sleep(eligibilityRetryDelay) // TODO: #413 Replace with backoff.
 				continue
 			}
 


### PR DESCRIPTION
Depends on https://github.com/keep-network/keep-ecdsa/pull/562
Closes  #555

Two improvements included here:

- Increased sortition pool join eligibility check delay to 20 minutes 

  Sortition pool join eligibility check was using the same retry delay as
every other retried operation in the registration logic - 1 sec. This is
pretty aggresive for this particular check as it may happen that the
client is no longer eligible to join the pool because its bonds have
been drained to zero. Here we increase the delay for this check to 20
minutes and in the future we should consider enhancing the logic in  way
allowing the operator to specify that it does no longer want to be in
the sortition pool but it still wants to do their signing duty.

- Refined error message for failed sortition pool status monitoring

  In 99% cases this error is logged when the sortition pool status
monitoring failed because the operator was removed from the sortition
pool because it does no longer have enough unbonded value or stake.

  We do not change the logic in any way here but just improve the error
message to at least give the operator some context on what they should
be looking at.