### PR TITLE
Improvements of the storage layer

### DIFF
--- a/cmd/signing.go
+++ b/cmd/signing.go
@@ -90,7 +90,7 @@ func DecryptKeyShare(c *cli.Context) error {
 
 	keepRegistry.LoadExistingKeeps()
 
-	signers, err := keepRegistry.GetSigners(keepAddress)
+	signer, err := keepRegistry.GetSigner(keepAddress)
 	if err != nil {
 		return fmt.Errorf(
 			"no signers for keep [%s]: [%v]",
@@ -98,8 +98,6 @@ func DecryptKeyShare(c *cli.Context) error {
 			err,
 		)
 	}
-
-	signer := signers[0]
 
 	signerBytes, err := signer.Marshal()
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/gogo/protobuf v1.3.1
 	github.com/google/gofuzz v1.1.0
 	github.com/ipfs/go-log v1.0.4
-	github.com/keep-network/keep-common v1.2.1-0.20200929121054-30cac806a275
+	github.com/keep-network/keep-common v1.2.1-0.20201002105641-e04cc579ff66
 	github.com/keep-network/keep-core v1.3.0
 	github.com/pkg/errors v0.9.1
 	github.com/urfave/cli v1.22.1

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/gogo/protobuf v1.3.1
 	github.com/google/gofuzz v1.1.0
 	github.com/ipfs/go-log v1.0.4
-	github.com/keep-network/keep-common v1.2.0
+	github.com/keep-network/keep-common v1.2.1-0.20200929121054-30cac806a275
 	github.com/keep-network/keep-core v1.3.0
 	github.com/pkg/errors v0.9.1
 	github.com/urfave/cli v1.22.1

--- a/go.sum
+++ b/go.sum
@@ -333,8 +333,6 @@ github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec h
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec/go.mod h1:xR8jf3/VJAjh3nWu5tFe8Yxnt2HvWsqZHfGef1P5oDk=
 github.com/keep-network/keep-common v1.2.0 h1:hVd2tTd7vL+9CQP5Ntk5kjs+GYvkgrRNBcNvTuhHhVk=
 github.com/keep-network/keep-common v1.2.0/go.mod h1:emxogTbBdey7M3jOzfxZOdfn139kN2mI2b2wA6AHKKo=
-github.com/keep-network/keep-common v1.2.1-0.20200929121054-30cac806a275 h1:UWZ4nQF20LzzLdc1tLzKBa2idd0d8+UsKZApHCEg/Ns=
-github.com/keep-network/keep-common v1.2.1-0.20200929121054-30cac806a275/go.mod h1:emxogTbBdey7M3jOzfxZOdfn139kN2mI2b2wA6AHKKo=
 github.com/keep-network/keep-common v1.2.1-0.20201002105641-e04cc579ff66 h1:x/9fra2wLrBDhS8LOQztFajoM2q13FgBN5jFiqBGBog=
 github.com/keep-network/keep-common v1.2.1-0.20201002105641-e04cc579ff66/go.mod h1:emxogTbBdey7M3jOzfxZOdfn139kN2mI2b2wA6AHKKo=
 github.com/keep-network/keep-core v1.3.0 h1:7Tb33EmO/ntHOEbOiYciRlBhqu5Ln6KemWCaYK0Z6LA=

--- a/go.sum
+++ b/go.sum
@@ -333,6 +333,8 @@ github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec h
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec/go.mod h1:xR8jf3/VJAjh3nWu5tFe8Yxnt2HvWsqZHfGef1P5oDk=
 github.com/keep-network/keep-common v1.2.0 h1:hVd2tTd7vL+9CQP5Ntk5kjs+GYvkgrRNBcNvTuhHhVk=
 github.com/keep-network/keep-common v1.2.0/go.mod h1:emxogTbBdey7M3jOzfxZOdfn139kN2mI2b2wA6AHKKo=
+github.com/keep-network/keep-common v1.2.1-0.20200929121054-30cac806a275 h1:UWZ4nQF20LzzLdc1tLzKBa2idd0d8+UsKZApHCEg/Ns=
+github.com/keep-network/keep-common v1.2.1-0.20200929121054-30cac806a275/go.mod h1:emxogTbBdey7M3jOzfxZOdfn139kN2mI2b2wA6AHKKo=
 github.com/keep-network/keep-core v1.3.0 h1:7Tb33EmO/ntHOEbOiYciRlBhqu5Ln6KemWCaYK0Z6LA=
 github.com/keep-network/keep-core v1.3.0/go.mod h1:1KsSSTQoN754TrFLW7kLy50pOG2CQ4BOfnJqdvEG7FA=
 github.com/keep-network/toml v0.3.0 h1:G+NJwWR/ZiORqeLBsDXDchYoL29PXHdxOPcCueA7ctE=

--- a/go.sum
+++ b/go.sum
@@ -335,6 +335,8 @@ github.com/keep-network/keep-common v1.2.0 h1:hVd2tTd7vL+9CQP5Ntk5kjs+GYvkgrRNBc
 github.com/keep-network/keep-common v1.2.0/go.mod h1:emxogTbBdey7M3jOzfxZOdfn139kN2mI2b2wA6AHKKo=
 github.com/keep-network/keep-common v1.2.1-0.20200929121054-30cac806a275 h1:UWZ4nQF20LzzLdc1tLzKBa2idd0d8+UsKZApHCEg/Ns=
 github.com/keep-network/keep-common v1.2.1-0.20200929121054-30cac806a275/go.mod h1:emxogTbBdey7M3jOzfxZOdfn139kN2mI2b2wA6AHKKo=
+github.com/keep-network/keep-common v1.2.1-0.20201002105641-e04cc579ff66 h1:x/9fra2wLrBDhS8LOQztFajoM2q13FgBN5jFiqBGBog=
+github.com/keep-network/keep-common v1.2.1-0.20201002105641-e04cc579ff66/go.mod h1:emxogTbBdey7M3jOzfxZOdfn139kN2mI2b2wA6AHKKo=
 github.com/keep-network/keep-core v1.3.0 h1:7Tb33EmO/ntHOEbOiYciRlBhqu5Ln6KemWCaYK0Z6LA=
 github.com/keep-network/keep-core v1.3.0/go.mod h1:1KsSSTQoN754TrFLW7kLy50pOG2CQ4BOfnJqdvEG7FA=
 github.com/keep-network/toml v0.3.0 h1:G+NJwWR/ZiORqeLBsDXDchYoL29PXHdxOPcCueA7ctE=

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -114,51 +114,50 @@ func Initialize(
 				logger.Warningf("keep [%s] is still active", keepAddress.String())
 			}
 
-			signers, err := keepsRegistry.GetSigners(keepAddress)
+			signer, err := keepsRegistry.GetSigner(keepAddress)
 			if err != nil {
-				// If there are no signers for loaded keep that something is clearly
+				// If there are no signer for loaded keep that something is clearly
 				// wrong. We don't want to continue processing for this keep.
 				logger.Errorf(
-					"no signers for keep [%s]: [%v]",
+					"no signer for keep [%s]: [%v]",
 					keepAddress.String(),
 					err,
 				)
 				return
 			}
 
-			for _, signer := range signers {
-				subscriptionOnSignatureRequested, err := monitorSigningRequests(
-					ethereumChain,
-					clientConfig,
-					tssNode,
-					keepAddress,
-					signer,
-					requestedSignatures,
+			subscriptionOnSignatureRequested, err := monitorSigningRequests(
+				ethereumChain,
+				clientConfig,
+				tssNode,
+				keepAddress,
+				signer,
+				requestedSignatures,
+			)
+			if err != nil {
+				logger.Errorf(
+					"failed registering for requested signature event for keep [%s]: [%v]",
+					keepAddress.String(),
+					err,
 				)
-				if err != nil {
-					logger.Errorf(
-						"failed registering for requested signature event for keep [%s]: [%v]",
-						keepAddress.String(),
-						err,
-					)
-					// In case of an error we want to avoid subscribing to keep
-					// closed events. Something is wrong and we should stop
-					// further processing.
-					return
-				}
-				go monitorKeepClosedEvents(
-					ethereumChain,
-					keepAddress,
-					keepsRegistry,
-					subscriptionOnSignatureRequested,
-				)
-				go monitorKeepTerminatedEvent(
-					ethereumChain,
-					keepAddress,
-					keepsRegistry,
-					subscriptionOnSignatureRequested,
-				)
+				// In case of an error we want to avoid subscribing to keep
+				// closed events. Something is wrong and we should stop
+				// further processing.
+				return
 			}
+			go monitorKeepClosedEvents(
+				ethereumChain,
+				keepAddress,
+				keepsRegistry,
+				subscriptionOnSignatureRequested,
+			)
+			go monitorKeepTerminatedEvent(
+				ethereumChain,
+				keepAddress,
+				keepsRegistry,
+				subscriptionOnSignatureRequested,
+			)
+
 		}(keepAddress)
 	}
 
@@ -433,6 +432,8 @@ func generateKeyForKeep(
 			keepAddress.String(),
 			err,
 		)
+
+		// TODO: An action should be taken here.
 	}
 
 	subscriptionOnSignatureRequested, err := monitorSigningRequests(

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -434,6 +434,9 @@ func generateKeyForKeep(
 			err,
 		)
 
+		// In case of an error during signer registration, we want to avoid
+		// subscribing to the events emitted by the keep. The signer is not
+		// operating so we should stop further processing.
 		return
 	}
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -433,7 +433,7 @@ func generateKeyForKeep(
 			err,
 		)
 
-		// TODO: An action should be taken here.
+		return
 	}
 
 	subscriptionOnSignatureRequested, err := monitorSigningRequests(

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -413,6 +413,7 @@ func generateKeyForKeep(
 		operatorPublicKey,
 		keepAddress,
 		members,
+		keepsRegistry,
 	)
 	if err != nil {
 		logger.Errorf(
@@ -479,6 +480,7 @@ func generateSignerForKeep(
 	operatorPublicKey *operator.PublicKey,
 	keepAddress common.Address,
 	members []common.Address,
+	keepsRegistry *registry.Keeps,
 ) (*tss.ThresholdSigner, error) {
 	keygenCtx, cancel := context.WithTimeout(ctx, clientConfig.GetKeyGenerationTimeout())
 	defer cancel()
@@ -488,6 +490,7 @@ func generateSignerForKeep(
 		operatorPublicKey,
 		keepAddress,
 		members,
+		keepsRegistry,
 	)
 }
 

--- a/pkg/registry/keeps.go
+++ b/pkg/registry/keeps.go
@@ -12,7 +12,7 @@ import (
 // Keeps represents a collection of keeps in which the given client is a member.
 type Keeps struct {
 	myKeepsMutex *sync.RWMutex
-	myKeeps      map[common.Address][]*tss.ThresholdSigner
+	myKeeps      map[common.Address]*tss.ThresholdSigner
 
 	storage storage
 }
@@ -21,7 +21,7 @@ type Keeps struct {
 func NewKeepsRegistry(persistence persistence.Handle) *Keeps {
 	return &Keeps{
 		myKeepsMutex: &sync.RWMutex{},
-		myKeeps:      make(map[common.Address][]*tss.ThresholdSigner),
+		myKeeps:      make(map[common.Address]*tss.ThresholdSigner),
 		storage:      newStorage(persistence),
 	}
 }
@@ -32,12 +32,26 @@ func (k *Keeps) RegisterSigner(
 	keepAddress common.Address,
 	signer *tss.ThresholdSigner,
 ) error {
-	err := k.storage.save(keepAddress, signer)
-	if err != nil {
-		return fmt.Errorf("could not persist signer to the storage: [%v]", err)
+	k.myKeepsMutex.Lock()
+	defer k.myKeepsMutex.Unlock()
+
+	if _, exists := k.myKeeps[keepAddress]; exists {
+		return fmt.Errorf(
+			"signer for keep [%s] already registered",
+			keepAddress.String(),
+		)
 	}
 
-	k.storeSigner(keepAddress, signer)
+	err := k.storage.save(keepAddress, signer)
+	if err != nil {
+		return fmt.Errorf(
+			"could not persist signer for keep [%s] in the storage: [%v]",
+			keepAddress.String(),
+			err,
+		)
+	}
+
+	k.myKeeps[keepAddress] = signer
 
 	return nil
 }
@@ -55,16 +69,20 @@ func (k *Keeps) UnregisterKeep(keepAddress common.Address) {
 	delete(k.myKeeps, keepAddress)
 }
 
-// GetSigners gets signers by a keep address.
-func (k *Keeps) GetSigners(keepAddress common.Address) ([]*tss.ThresholdSigner, error) {
+// GetSigner gets signer for a keep address.
+func (k *Keeps) GetSigner(keepAddress common.Address) (*tss.ThresholdSigner, error) {
 	k.myKeepsMutex.RLock()
 	defer k.myKeepsMutex.RUnlock()
 
-	signers, ok := k.myKeeps[keepAddress]
+	signer, ok := k.myKeeps[keepAddress]
 	if !ok {
-		return nil, fmt.Errorf("could not find signers for keep: [%s]", keepAddress.String())
+		return nil, fmt.Errorf(
+			"could not find signer for keep: [%s]",
+			keepAddress.String(),
+		)
 	}
-	return signers, nil
+
+	return signer, nil
 }
 
 // HasSigner returns true if at least one signer exists in the registry
@@ -94,6 +112,9 @@ func (k *Keeps) GetKeepsAddresses() []common.Address {
 // LoadExistingKeeps iterates over all signers stored on disk and loads them
 // into memory
 func (k *Keeps) LoadExistingKeeps() {
+	k.myKeepsMutex.Lock()
+	defer k.myKeepsMutex.Unlock()
+
 	keepSignersChannel, errorsChannel := k.storage.readAll()
 
 	// Two goroutines read from signers and errors channels and either adds
@@ -107,7 +128,16 @@ func (k *Keeps) LoadExistingKeeps() {
 
 	go func() {
 		for keepSigner := range keepSignersChannel {
-			k.storeSigner(keepSigner.keepAddress, keepSigner.signer)
+			if _, exists := k.myKeeps[keepSigner.keepAddress]; exists {
+				logger.Errorf(
+					"signer for keep [%s] already loaded; "+
+						"possible duplicate in the storage layer",
+					keepSigner.keepAddress.String(),
+				)
+				continue
+			}
+
+			k.myKeeps[keepSigner.keepAddress] = keepSigner.signer
 		}
 
 		wg.Done()
@@ -115,7 +145,7 @@ func (k *Keeps) LoadExistingKeeps() {
 
 	go func() {
 		for err := range errorsChannel {
-			logger.Errorf("could not load signer from disk: [%v]", err)
+			logger.Errorf("could not load signer from storage: [%v]", err)
 		}
 
 		wg.Done()
@@ -123,38 +153,15 @@ func (k *Keeps) LoadExistingKeeps() {
 
 	wg.Wait()
 
-	k.printSigners()
-}
-
-func (k *Keeps) printSigners() {
-	k.myKeepsMutex.RLock()
-	defer k.myKeepsMutex.RUnlock()
-
 	logger.Infof(
 		"loaded [%d] keeps from the local storage",
 		len(k.myKeeps),
 	)
 
-	for keepAddress, signers := range k.myKeeps {
+	for keepAddress := range k.myKeeps {
 		logger.Debugf(
-			"loaded [%d] signers for keep [%s]",
-			len(signers),
+			"loaded signer for keep [%s]",
 			keepAddress.String(),
 		)
-	}
-}
-
-func (k *Keeps) storeSigner(
-	keepAddress common.Address,
-	signer *tss.ThresholdSigner,
-) {
-	k.myKeepsMutex.Lock()
-	defer k.myKeepsMutex.Unlock()
-
-	signers, exists := k.myKeeps[keepAddress]
-	if exists {
-		k.myKeeps[keepAddress] = append(signers, signer)
-	} else {
-		k.myKeeps[keepAddress] = []*tss.ThresholdSigner{signer}
 	}
 }

--- a/pkg/registry/keeps.go
+++ b/pkg/registry/keeps.go
@@ -59,6 +59,13 @@ func (k *Keeps) RegisterSigner(
 	return nil
 }
 
+func (k *Keeps) SnapshotSigner(
+	keepAddress common.Address,
+	signer *tss.ThresholdSigner,
+) error {
+	return k.storage.snapshot(keepAddress, signer)
+}
+
 // UnregisterKeep archives threeshold signer info for the given keep address.
 func (k *Keeps) UnregisterKeep(keepAddress common.Address) {
 	k.myKeepsMutex.Lock()

--- a/pkg/registry/keeps.go
+++ b/pkg/registry/keeps.go
@@ -5,9 +5,12 @@ import (
 	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ipfs/go-log"
 	"github.com/keep-network/keep-common/pkg/persistence"
 	"github.com/keep-network/keep-ecdsa/pkg/ecdsa/tss"
 )
+
+var logger = log.Logger("keep-registry")
 
 // Keeps represents a collection of keeps in which the given client is a member.
 type Keeps struct {

--- a/pkg/registry/keeps_test.go
+++ b/pkg/registry/keeps_test.go
@@ -70,6 +70,18 @@ func TestRegisterSigner(t *testing.T) {
 			persistenceMock.persistedGroups[0],
 		)
 	}
+}
+
+func TestRegisterSignerDuplicate(t *testing.T) {
+	persistenceMock := &persistenceHandleMock{}
+	kr := NewKeepsRegistry(persistenceMock)
+
+	signer1, err := newTestSigner(0)
+	if err != nil {
+		t.Fatalf("failed to get signer: [%v]", err)
+	}
+
+	err = kr.RegisterSigner(keepAddress1, signer1)
 
 	signer2, err := newTestSigner(1)
 	if err != nil {
@@ -79,7 +91,7 @@ func TestRegisterSigner(t *testing.T) {
 	err = kr.RegisterSigner(keepAddress1, signer2)
 
 	expectedError := fmt.Errorf("signer for keep [%s] already registered", keepAddress1.String())
-	if err == nil || (!reflect.DeepEqual(expectedError, err)) {
+	if !reflect.DeepEqual(expectedError, err) {
 		t.Errorf(
 			"unexpected error\nexpected: [%v]\nactual:   [%v]",
 			expectedError,

--- a/pkg/registry/keeps_test.go
+++ b/pkg/registry/keeps_test.go
@@ -46,7 +46,10 @@ func TestRegisterSigner(t *testing.T) {
 		name:      fmt.Sprintf("/membership_%s", signer1.MemberID().String()),
 	}
 
-	kr.RegisterSigner(keepAddress1, signer1)
+	err = kr.RegisterSigner(keepAddress1, signer1)
+	if err != nil {
+		t.Fatalf("failed to register signer: [%v]", err)
+	}
 
 	// Verify persisted to storage.
 	if len(persistenceMock.persistedGroups) != 1 {
@@ -67,6 +70,22 @@ func TestRegisterSigner(t *testing.T) {
 			persistenceMock.persistedGroups[0],
 		)
 	}
+
+	signer2, err := newTestSigner(1)
+	if err != nil {
+		t.Fatalf("failed to get signer: [%v]", err)
+	}
+
+	err = kr.RegisterSigner(keepAddress1, signer2)
+
+	expectedError := fmt.Errorf("signer for keep [%s] already registered", keepAddress1.String())
+	if err == nil || (!reflect.DeepEqual(expectedError, err)) {
+		t.Errorf(
+			"unexpected error\nexpected: [%v]\nactual:   [%v]",
+			expectedError,
+			err,
+		)
+	}
 }
 
 func TestUnregisterSigner(t *testing.T) {
@@ -78,7 +97,10 @@ func TestUnregisterSigner(t *testing.T) {
 		t.Fatalf("failed to get signer: [%v]", err)
 	}
 
-	kr.RegisterSigner(keepAddress1, signer1)
+	err = kr.RegisterSigner(keepAddress1, signer1)
+	if err != nil {
+		t.Fatalf("failed to register signer: [%v]", err)
+	}
 
 	kr.UnregisterKeep(keepAddress1)
 
@@ -99,7 +121,7 @@ func TestUnregisterSigner(t *testing.T) {
 	}
 }
 
-func TestGetGroup(t *testing.T) {
+func TestGetSigner(t *testing.T) {
 	persistenceMock := &persistenceHandleMock{}
 	kr := NewKeepsRegistry(persistenceMock)
 
@@ -109,37 +131,35 @@ func TestGetGroup(t *testing.T) {
 	}
 
 	signer1 := signers[0]
-	signer2 := signers[1]
-	signer3 := signers[2]
 
-	kr.RegisterSigner(keepAddress1, signer1)
-	kr.RegisterSigner(keepAddress2, signer2)
-	kr.RegisterSigner(keepAddress2, signer3)
+	err = kr.RegisterSigner(keepAddress1, signer1)
+	if err != nil {
+		t.Fatalf("failed to register signer: [%v]", err)
+	}
 
 	var tests = map[string]struct {
 		keepAddress    common.Address
-		expectedSigner []*tss.ThresholdSigner
+		expectedSigner *tss.ThresholdSigner
 		expectedError  error
 	}{
 		"returns registered keep with one signer": {
 			keepAddress:    keepAddress1,
-			expectedSigner: []*tss.ThresholdSigner{signer1},
-		},
-		"returns registered keep with multiple signers": {
-			keepAddress:    keepAddress2,
-			expectedSigner: []*tss.ThresholdSigner{signer2, signer3},
+			expectedSigner: signer1,
 		},
 		"returns error for not registered keep": {
-			keepAddress:   keepAddress3,
-			expectedError: fmt.Errorf("could not find signers for keep: [%s]", keepAddress3.String()),
+			keepAddress: keepAddress3,
+			expectedError: fmt.Errorf(
+				"could not find signer for keep: [%s]",
+				keepAddress3.String(),
+			),
 		},
 	}
 
 	for testName, test := range tests {
 		t.Run(testName, func(t *testing.T) {
-			signer, err := kr.GetSigners(test.keepAddress)
+			signer, err := kr.GetSigner(test.keepAddress)
 
-			if !reflect.DeepEqual(test.expectedSigner, signer) {
+			if test.expectedSigner != signer {
 				t.Errorf(
 					"unexpected signer\nexpected: [%+v]\nactual:   [%+v]",
 					test.expectedSigner,
@@ -168,7 +188,6 @@ func TestLoadExistingGroups(t *testing.T) {
 
 	signer1 := signers[0]
 	signer2 := signers[1]
-	signer3 := signers[2]
 
 	kr := NewKeepsRegistry(persistenceMock)
 
@@ -188,22 +207,30 @@ func TestLoadExistingGroups(t *testing.T) {
 		)
 	}
 
-	expectedSigners1 := []*tss.ThresholdSigner{signer1}
-	actualSigners1, err := kr.GetSigners(keepAddress1)
+	expectedSigner1 := signer1
+	actualSigner1, err := kr.GetSigner(keepAddress1)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(expectedSigners1, actualSigners1) {
-		t.Errorf("\nexpected: [%v]\nactual:   [%v]", expectedSigners1, actualSigners1)
+	if !reflect.DeepEqual(expectedSigner1, actualSigner1) {
+		t.Errorf(
+			"\nexpected: [%v]\nactual:   [%v]",
+			expectedSigner1,
+			actualSigner1,
+		)
 	}
 
-	expectedSigners2 := []*tss.ThresholdSigner{signer2, signer3}
-	actualSigners2, err := kr.GetSigners(keepAddress2)
+	expectedSigner2 := signer2
+	actualSigner2, err := kr.GetSigner(keepAddress2)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if !reflect.DeepEqual(expectedSigners2, actualSigners2) {
-		t.Errorf("\nexpected: [%v]\nactual:   [%v]", expectedSigners2, actualSigners2)
+	if !reflect.DeepEqual(expectedSigner2, actualSigner2) {
+		t.Errorf(
+			"\nexpected: [%v]\nactual:   [%v]",
+			expectedSigner2,
+			actualSigner2,
+		)
 	}
 }
 
@@ -230,18 +257,15 @@ func (phm *persistenceHandleMock) ReadAll() (<-chan persistence.DataDescriptor, 
 	signers, _ := testSigners()
 	signer1 := signers[0]
 	signer2 := signers[1]
-	signer3 := signers[2]
 
 	signerBytes1, _ := signer1.Marshal()
 	signerBytes2, _ := signer2.Marshal()
-	signerBytes3, _ := signer3.Marshal()
 
 	outputData := make(chan persistence.DataDescriptor, 3)
 	outputErrors := make(chan error)
 
 	outputData <- &testDataDescriptor{"/membership_0", keepAddress1.String(), signerBytes1}
 	outputData <- &testDataDescriptor{"/membership_0", keepAddress2.String(), signerBytes2}
-	outputData <- &testDataDescriptor{"/membership_1", keepAddress2.String(), signerBytes3}
 
 	close(outputData)
 	close(outputErrors)

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -1,5 +1,0 @@
-package registry
-
-import "github.com/ipfs/go-log"
-
-var logger = log.Logger("keep-registry")


### PR DESCRIPTION
Depends on: https://github.com/keep-network/keep-common/pull/49

Here we introduce some improvements to the storage layer:

- Removed the many-to-one relation between signers and keeps in the keep registry. Instead of that, we introduce a one-to-one relationship. The motivation of this change is the fact that one operator can have only one signer for given keep so we can make the registry simpler
- Introduced signer snapshots just after the signer is generated but before the public key is submitted on-chain. This feature allows us to back up the generated key material on disk and recover it in case something goes wrong within a tight time window between public key submission and registration of the signer in the keep registry. 
- Added a return from `generateKeyForKeep` method execution in case the `RegisterSigner` method invocation returns an error. There is no sense to continue and subscribe to keep's events in case the signer hasn't been registered correctly.
- Made a small cleanup of unused things