### PR TITLE
Signing CLI 

### DIFF
--- a/cmd/signing.go
+++ b/cmd/signing.go
@@ -1,0 +1,125 @@
+package cmd
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/keep-network/keep-common/pkg/chain/ethereum/ethutil"
+	"github.com/keep-network/keep-common/pkg/persistence"
+	"github.com/keep-network/keep-ecdsa/internal/config"
+	"github.com/keep-network/keep-ecdsa/pkg/registry"
+	"github.com/urfave/cli"
+)
+
+var SigningCommand cli.Command
+
+func init() {
+	SigningCommand = cli.Command{
+		Name:  "signing",
+		Usage: "Provides several tools useful for out-of-band signing",
+		Subcommands: []cli.Command{
+			{
+				Name: "decrypt-key-share",
+				Usage: "Decrypts the key share of the operator for the given " +
+					"keep and stores it in a file",
+				Action: DecryptKeyShare,
+				Flags: []cli.Flag{
+					cli.StringFlag{
+						Name:  "keep-address,k",
+						Usage: "address of the keep",
+					},
+				},
+			},
+		},
+	}
+}
+
+func DecryptKeyShare(c *cli.Context) error {
+	config, err := config.ReadConfig(c.GlobalString("config"))
+	if err != nil {
+		return fmt.Errorf("failed while reading config file: [%v]", err)
+	}
+
+	keyFile, err := ethutil.DecryptKeyFile(
+		config.Ethereum.Account.KeyFile,
+		config.Ethereum.Account.KeyFilePassword,
+	)
+	if err != nil {
+		return fmt.Errorf("failed to decrypt key file: [%v]", err)
+	}
+
+	keepAddressHex := c.String("keep-address")
+	if !common.IsHexAddress(keepAddressHex) {
+		return fmt.Errorf("invalid keep address")
+	}
+
+	keepAddress := common.HexToAddress(keepAddressHex)
+
+	handle, err := persistence.NewDiskHandle(config.Storage.DataDir)
+	if err != nil {
+		return fmt.Errorf(
+			"failed while creating a storage disk handler: [%v]",
+			err,
+		)
+	}
+
+	persistence := persistence.NewEncryptedPersistence(
+		handle,
+		config.Ethereum.Account.KeyFilePassword,
+	)
+
+	keepRegistry := registry.NewKeepsRegistry(persistence)
+
+	keepRegistry.LoadExistingKeeps()
+
+	signers, err := keepRegistry.GetSigners(keepAddress)
+	if err != nil {
+		return fmt.Errorf(
+			"no signers for keep [%s]: [%v]",
+			keepAddress.String(),
+			err,
+		)
+	}
+
+	signer := signers[0]
+
+	signerBytes, err := signer.Marshal()
+	if err != nil {
+		return fmt.Errorf(
+			"failed to marshall signer for keep [%s]: [%v]",
+			keepAddress.String(),
+			err,
+		)
+	}
+
+	targetFilePath := fmt.Sprintf(
+		"key_share_%.10s_%.10s",
+		keepAddress.String(),
+		keyFile.Address.String(),
+	)
+
+	if _, err := os.Stat(targetFilePath); !os.IsNotExist(err) {
+		return fmt.Errorf(
+			"could not write shares to file; file [%s] already exists",
+			targetFilePath,
+		)
+	}
+
+	err = ioutil.WriteFile(targetFilePath, signerBytes, 0444) // read-only
+	if err != nil {
+		return fmt.Errorf(
+			"failed to write to file [%s]: [%v]",
+			targetFilePath,
+			err,
+		)
+	}
+
+	logger.Infof(
+		"key share has been decrypted successfully and written to file [%s]",
+		targetFilePath,
+	)
+
+	return nil
+}

--- a/cmd/signing.go
+++ b/cmd/signing.go
@@ -110,7 +110,13 @@ func DecryptKeyShare(c *cli.Context) error {
 		)
 	}
 
-	fmt.Printf("%x", signerBytes)
+	_, err = os.Stdout.Write(signerBytes)
+	if err != nil {
+		return fmt.Errorf(
+			"could not write signer bytes to stdout: [%v]",
+			err,
+		)
+	}
 
 	outputFilePath := c.String("output-file")
 

--- a/cmd/signing.go
+++ b/cmd/signing.go
@@ -40,21 +40,10 @@ func init() {
 				Action:    DecryptKeyShare,
 			},
 			{
-				Name:   "sign-digest",
-				Usage:  "Sign a given digest using provided key shares",
-				Action: SignDigest,
-				Flags: []cli.Flag{
-					cli.StringFlag{
-						Name: "digest,d",
-						Usage: "digest to sign in hex format without " +
-							"the `0x` prefix",
-					},
-					cli.StringFlag{
-						Name: "key-shares-dir,k",
-						Usage: "directory containing the key shares which " +
-							"should be used for signing",
-					},
-				},
+				Name:      "sign-digest",
+				Usage:     "Sign a given digest using provided key shares",
+				Action:    SignDigest,
+				ArgsUsage: "[unprefixed-hex-digest] [key-shares-dir]",
 			},
 		},
 	}
@@ -151,12 +140,12 @@ func DecryptKeyShare(c *cli.Context) error {
 
 // SignDigest signs a given digest using key shares from the provided directory.
 func SignDigest(c *cli.Context) error {
-	digest := c.String("digest")
+	digest := c.Args().First()
 	if len(digest) == 0 {
 		return fmt.Errorf("invalid digest")
 	}
 
-	keySharesDir := c.String("key-shares-dir")
+	keySharesDir := c.Args().Get(1)
 	if len(keySharesDir) == 0 {
 		return fmt.Errorf("invalid key shares directory name")
 	}

--- a/cmd/signing.go
+++ b/cmd/signing.go
@@ -36,13 +36,8 @@ func init() {
 				Name: "decrypt-key-share",
 				Usage: "Decrypts the key share of the operator for the given " +
 					"keep and stores it in a file",
-				Action: DecryptKeyShare,
-				Flags: []cli.Flag{
-					cli.StringFlag{
-						Name:  "keep-address,k",
-						Usage: "address of the keep",
-					},
-				},
+				ArgsUsage: "[keep-address]",
+				Action:    DecryptKeyShare,
 			},
 			{
 				Name:   "sign-digest",
@@ -80,7 +75,7 @@ func DecryptKeyShare(c *cli.Context) error {
 		return fmt.Errorf("failed to decrypt key file: [%v]", err)
 	}
 
-	keepAddressHex := c.String("keep-address")
+	keepAddressHex := c.Args().First()
 	if !common.IsHexAddress(keepAddressHex) {
 		return fmt.Errorf("invalid keep address")
 	}

--- a/main.go
+++ b/main.go
@@ -60,6 +60,7 @@ func main() {
 	app.Commands = []cli.Command{
 		cmd.StartCommand,
 		cmd.EthereumCommand,
+		cmd.SigningCommand,
 	}
 
 	err = app.Run(os.Args)


### PR DESCRIPTION
This pull request introduces an out-of-band signing CLI.

That signing CLI contains the following commands:
- `decrypt-key-share`: allows to decrypt a key share for given keep and store it in a file using the client config toml
- `sign-digest`: allows signing a given digest using provided key shares 