### PR TITLE
Ban members of FullyBackedBondedECDSAKeep in case of signature fraud

### DIFF
--- a/solidity/contracts/fully-backed/FullyBackedECDSAKeep.sol
+++ b/solidity/contracts/fully-backed/FullyBackedECDSAKeep.sol
@@ -52,9 +52,12 @@ contract FullyBackedECDSAKeep is AbstractBondedECDSAKeep {
         bonding.claimDelegatedAuthority(_keepFactory);
     }
 
+    /// @notice Punishes keep members after proving a signature fraud.
+    /// @dev Calls the keep factory to ban members of the keep. The owner of the
+    /// keep is able to seize the members bonds, so no action is necessary to be
+    /// taken from perspective of this function.
     function slashForSignatureFraud() internal {
-        // TODO: We don't need to do anything as keep owner is able to seize the bonds
-        // TODO: Ban members (remove from sortition pool and don't let to rejoin)
+        keepFactory.banKeepMembers();
     }
 
     /// @notice Gets the beneficiary for the specified member address.

--- a/solidity/contracts/fully-backed/FullyBackedECDSAKeepFactory.sol
+++ b/solidity/contracts/fully-backed/FullyBackedECDSAKeepFactory.sol
@@ -246,7 +246,7 @@ contract FullyBackedECDSAKeepFactory is
         return bonding.isAuthorizedForOperator(_operator, address(this));
     }
 
-    /// @notice Bans members of a calling keep in an sortition pools associated
+    /// @notice Bans members of a calling keep in a sortition pool associated
     /// with the application for which the keep was created.
     /// @dev The function can be called only by a keep created by this factory.
     function banKeepMembers() public onlyKeep() {

--- a/solidity/contracts/fully-backed/FullyBackedECDSAKeepFactory.sol
+++ b/solidity/contracts/fully-backed/FullyBackedECDSAKeepFactory.sol
@@ -68,7 +68,7 @@ contract FullyBackedECDSAKeepFactory is
     // in `FullyBackedBonding` contract. Minimum delegation deposit determines
     // a minimum value of ether that should be transferred to the bonding contract
     // by an owner when delegating to an operator.
-    uint256 public constant minimumBond = 20 ether;
+    uint256 public constant defaultMinimumBond = 20 ether;
 
     // Signer candidates in bonded sortition pool are weighted by their eligible
     // stake divided by a constant divisor. The divisor is set to 1 ETH so that
@@ -240,7 +240,7 @@ contract FullyBackedECDSAKeepFactory is
         return
             sortitionPoolFactory.createSortitionPool(
                 IFullyBackedBonding(address(bonding)),
-                minimumBond,
+                defaultMinimumBond,
                 bondWeightDivisor
             );
     }

--- a/solidity/contracts/test/FullyBackedECDSAKeepCloneFactoryStub.sol
+++ b/solidity/contracts/test/FullyBackedECDSAKeepCloneFactoryStub.sol
@@ -15,6 +15,8 @@ contract FullyBackedECDSAKeepCloneFactoryStub is
 {
     address public masterKeepAddress;
 
+    mapping(address => uint256) public banKeepMembersCalledCount;
+
     constructor(address _masterKeepAddress) public {
         masterKeepAddress = _masterKeepAddress;
     }
@@ -48,5 +50,9 @@ contract FullyBackedECDSAKeepCloneFactoryStub is
         returns (bool)
     {
         return true;
+    }
+
+    function banKeepMembers() public {
+        banKeepMembersCalledCount[msg.sender]++;
     }
 }

--- a/solidity/contracts/test/FullyBackedECDSAKeepStub.sol
+++ b/solidity/contracts/test/FullyBackedECDSAKeepStub.sol
@@ -13,6 +13,10 @@ contract FullyBackedECDSAKeepStub is FullyBackedECDSAKeep {
         markAsTerminated();
     }
 
+    function publicSlashForSignatureFraud() public {
+        slashForSignatureFraud();
+    }
+
     function isFradulentPreimageSet(bytes memory preimage)
         public
         view

--- a/solidity/test/BondedECDSAKeepFactoryTest.js
+++ b/solidity/test/BondedECDSAKeepFactoryTest.js
@@ -29,6 +29,8 @@ chai.use(require("bn-chai")(BN))
 const expect = chai.expect
 const assert = chai.assert
 
+// TODO: Refactor tests by pulling common parts of BondedECDSAKeepFactory and
+// FullyBackedBondedECDSAKeepFactory to one file.
 describe("BondedECDSAKeepFactory", function () {
   let registry
   let tokenStaking

--- a/solidity/test/BondedECDSAKeepTest.js
+++ b/solidity/test/BondedECDSAKeepTest.js
@@ -31,6 +31,8 @@ chai.use(require("bn-chai")(BN))
 const expect = chai.expect
 const assert = chai.assert
 
+// TODO: Refactor tests by pulling common parts of BondedECDSAKeep and
+// FullyBackedBondedECDSAKeep to one file.
 describe("BondedECDSAKeep", function () {
   const bondCreator = accounts[0]
   const owner = accounts[1]

--- a/solidity/test/FullyBackedECDSAKeepFactoryTest.js
+++ b/solidity/test/FullyBackedECDSAKeepFactoryTest.js
@@ -824,7 +824,7 @@ describe("FullyBackedECDSAKeepFactory", function () {
     })
 
     it("reverts if one member has insufficient unbonded value", async () => {
-      const minimumBond = await keepFactory.minimumBond.call()
+      const minimumBond = await keepFactory.defaultMinimumBond.call()
       const availableUnbonded = await bonding.availableUnbondedValue(
         members[2],
         keepFactory.address,
@@ -1451,7 +1451,7 @@ describe("FullyBackedECDSAKeepFactory", function () {
   describe("getKeepAtIndex", async () => {
     before(async () => {
       await initializeNewFactory()
-      const minimumBond = await keepFactory.minimumBond.call()
+      const minimumBond = await keepFactory.defaultMinimumBond.call()
       const memberBond = minimumBond.muln(2) // want to be able to open 2 keeps
       await initializeMemberCandidates(memberBond)
       await registerMemberCandidates()


### PR DESCRIPTION
In this PR we added functionality of banning keep members in case of a signature fraud for FullyBackedECDSAKeeps.

Once a signature fraud is discovered a keep will call the associated factory to ban its' members. The factory will traverse over all already created sortition pools and ban the keep members.

Refs: https://github.com/keep-network/keep-ecdsa/issues/271
Depends on: https://github.com/keep-network/keep-ecdsa/pull/483