### PR TITLE
Check operator balance before status update

### DIFF
--- a/configs/config.toml.SAMPLE
+++ b/configs/config.toml.SAMPLE
@@ -74,11 +74,11 @@
 #  KeyGenerationTimeout = "3h" 				# optional
 #  SigningTimeout = "2h"					# optional
 #
-# Specifies the minimum operator ETH balance to participate in new keeps.
+# Specifies the minimum operator WEI balance to participate in new keeps.
 # When the operator balance is below the minimum, the operator will unregister
 # from the sortition pool and focus on supporting existing keeps by providing
 # the requested signatures instead of candidating to new keeps.
-#  MinimumKeyGenerationBalance = 0.5 # 0.5 ETH (default value)
+#  MinimumKeyGenerationBalance = 500000000000000000 # 0.5 ETH (default value)
 
 [TSS]
 # Timeout for TSS protocol pre-parameters generation. The value

--- a/configs/config.toml.SAMPLE
+++ b/configs/config.toml.SAMPLE
@@ -67,12 +67,18 @@
 # The client does not check keeps older than `AwaitingKeyGenerationLookback` to
 # minimize the number of calls to the chain.
 #  AwaitingKeyGenerationLookback = "24h"	# optional
-
+#
 # Timeouts for processes execution. Within these timeouts the process will keep
 # retrying to generate a signer or calculate a signature. The values should be
 # provided based on the sanctioned application requirements.
 #  KeyGenerationTimeout = "3h" 				# optional
 #  SigningTimeout = "2h"					# optional
+#
+# Specifies the minimum operator ETH balance to participate in new keeps.
+# When the operator balance is below the minimum, the operator will unregister
+# from the sortition pool and focus on supporting existing keeps by providing
+# the requested signatures instead of candidating to new keeps.
+#  MinimumKeyGenerationBalance = 0.5 # 0.5 ETH (default value)
 
 [TSS]
 # Timeout for TSS protocol pre-parameters generation. The value

--- a/pkg/chain/chain.go
+++ b/pkg/chain/chain.go
@@ -16,6 +16,8 @@ import (
 type Handle interface {
 	// Address returns client's ethereum address.
 	Address() common.Address
+	// BalanceOf returns the balance of the given address.
+	BalanceOf(address common.Address) (*big.Int, error)
 	// StakeMonitor returns a stake monitor.
 	StakeMonitor() (chain.StakeMonitor, error)
 	// BlockCounter returns a block counter.

--- a/pkg/chain/local/local.go
+++ b/pkg/chain/local/local.go
@@ -86,6 +86,10 @@ func (lc *localChain) Address() common.Address {
 	return lc.clientAddress
 }
 
+func (lc *localChain) BalanceOf(address common.Address) (*big.Int, error) {
+	return nil, nil // not implemented.
+}
+
 func (lc *localChain) StakeMonitor() (chain.StakeMonitor, error) {
 	return nil, nil // not implemented.
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -216,7 +216,12 @@ func Initialize(
 	})
 
 	for _, application := range sanctionedApplications {
-		go checkStatusAndRegisterForApplication(ctx, ethereumChain, application)
+		go checkStatusAndRegisterForApplication(
+			ctx,
+			ethereumChain,
+			application,
+			clientConfig,
+		)
 	}
 }
 

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -20,6 +20,9 @@ const (
 
 	// The default value of a timeout for a signature calculation.
 	defaultSigningTimeout = 2 * time.Hour
+
+	// The default value of the minimum key generation balance.
+	defaultMinimumKeyGenerationBalance = 0.5 // ETH
 )
 
 // Config contains configuration for tss protocol execution.
@@ -32,6 +35,9 @@ type Config struct {
 	// Timeout for key generation and signature calculation.
 	KeyGenerationTimeout configtime.Duration
 	SigningTimeout       configtime.Duration
+
+	// Specifies the minimum operator balance to participate in new keeps.
+	MinimumKeyGenerationBalance float64
 }
 
 // GetAwaitingKeyGenerationLookback returns a look-back period to check if
@@ -66,4 +72,15 @@ func (c *Config) GetSigningTimeout() time.Duration {
 	}
 
 	return timeout
+}
+
+// GetMinimumKeyGenerationBalance returns the minimum key generation balance.
+// If a value is not set it returns a default value.
+func (c *Config) GetMinimumKeyGenerationBalance() float64 {
+	minimumBalance := c.MinimumKeyGenerationBalance
+	if minimumBalance == 0 {
+		minimumBalance = defaultMinimumKeyGenerationBalance
+	}
+
+	return minimumBalance
 }

--- a/pkg/client/config.go
+++ b/pkg/client/config.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"math/big"
 	"time"
 
 	configtime "github.com/keep-network/keep-ecdsa/internal/config/time"
@@ -22,7 +23,7 @@ const (
 	defaultSigningTimeout = 2 * time.Hour
 
 	// The default value of the minimum key generation balance.
-	defaultMinimumKeyGenerationBalance = 0.5 // ETH
+	defaultMinimumKeyGenerationBalance = 500000000000000000 // 0.5 ETH
 )
 
 // Config contains configuration for tss protocol execution.
@@ -37,7 +38,7 @@ type Config struct {
 	SigningTimeout       configtime.Duration
 
 	// Specifies the minimum operator balance to participate in new keeps.
-	MinimumKeyGenerationBalance float64
+	MinimumKeyGenerationBalance uint64
 }
 
 // GetAwaitingKeyGenerationLookback returns a look-back period to check if
@@ -76,11 +77,11 @@ func (c *Config) GetSigningTimeout() time.Duration {
 
 // GetMinimumKeyGenerationBalance returns the minimum key generation balance.
 // If a value is not set it returns a default value.
-func (c *Config) GetMinimumKeyGenerationBalance() float64 {
+func (c *Config) GetMinimumKeyGenerationBalance() *big.Int {
 	minimumBalance := c.MinimumKeyGenerationBalance
 	if minimumBalance == 0 {
 		minimumBalance = defaultMinimumKeyGenerationBalance
 	}
 
-	return minimumBalance
+	return new(big.Int).SetUint64(minimumBalance)
 }


### PR DESCRIPTION
Closes: #551

This pull request introduces a new `MinimumKeyGenerationBalance` config property which defines a minimum WEI balance below which the operator should not participate in new keeps. The main motivation is to avoid spending funds during the key generation protocol and hold them for signatures requests to mitigate the risk of bonds seizing by not having enough ETH to submit requested signatures to the chain.

Technically, the aforementioned behavior is achieved by checking the current operator's balance against the `MinimumKeyGenerationBalance` value and aborting the operator status update in the sortition pool in case the current balance is below the minimum. Not updating the operator status will force the sortition pool to omit the operator during group selection.