### PR TITLE
ECDSA staker rewards

### DIFF
--- a/solidity/contracts/ECDSABackportRewards.sol
+++ b/solidity/contracts/ECDSABackportRewards.sol
@@ -66,11 +66,16 @@ contract ECDSABackportRewards is Rewards {
         return fromAddress(factory.getKeepAtIndex(index));
     }
 
-    function _getCreationTime(bytes32 _keep) internal isAddress(_keep) view returns (uint256) {
+    function _getCreationTime(bytes32 _keep)
+        internal
+        view
+        isAddress(_keep)
+        returns (uint256)
+    {
         return factory.getKeepOpenedTimestamp(toAddress(_keep));
     }
 
-    function _isClosed(bytes32) internal isAddress(_keep)  view returns (bool) {
+    function _isClosed(bytes32) internal view isAddress(_keep) returns (bool) {
         // Even though we still have some of the keeps opened, all the keeps
         // created between May 13 2020 - Sep 14 2020 are considered closed.
         // Because of the deposits pause
@@ -83,19 +88,27 @@ contract ECDSABackportRewards is Rewards {
 
     function _isTerminated(bytes32 groupIndexBytes)
         internal
-        isAddress(_keep) 
         view
+        isAddress(_keep)
         returns (bool)
     {
         return false;
     }
 
     // A keep is recognized if it was created by this factory.
-    function _recognizedByFactory(bytes32 _keep) internal view isAddress(_keep) returns (bool) {
+    function _recognizedByFactory(bytes32 _keep)
+        internal
+        view
+        isAddress(_keep)
+        returns (bool)
+    {
         return factory.getKeepOpenedTimestamp(toAddress(_keep)) != 0;
     }
 
-    function _distributeReward(bytes32 _keep, uint256 amount) internal isAddress(_keep) {
+    function _distributeReward(bytes32 _keep, uint256 amount)
+        internal
+        isAddress(_keep)
+    {
         token.approve(toAddress(_keep), amount);
 
         IBondedECDSAKeep(toAddress(_keep)).distributeERC20Reward(
@@ -104,7 +117,7 @@ contract ECDSABackportRewards is Rewards {
         );
     }
 
-   function toAddress(bytes32 keepBytes) internal pure returns (address) {
+    function toAddress(bytes32 keepBytes) internal pure returns (address) {
         return address(bytes20(keepBytes));
     }
 

--- a/solidity/contracts/ECDSABackportRewards.sol
+++ b/solidity/contracts/ECDSABackportRewards.sol
@@ -66,11 +66,11 @@ contract ECDSABackportRewards is Rewards {
         return fromAddress(factory.getKeepAtIndex(index));
     }
 
-    function _getCreationTime(bytes32 _keep) internal view returns (uint256) {
+    function _getCreationTime(bytes32 _keep) internal isAddress(_keep) view returns (uint256) {
         return factory.getKeepOpenedTimestamp(toAddress(_keep));
     }
 
-    function _isClosed(bytes32) internal view returns (bool) {
+    function _isClosed(bytes32) internal isAddress(_keep)  view returns (bool) {
         // Even though we still have some of the keeps opened, all the keeps
         // created between May 13 2020 - Sep 14 2020 are considered closed.
         // Because of the deposits pause
@@ -83,6 +83,7 @@ contract ECDSABackportRewards is Rewards {
 
     function _isTerminated(bytes32 groupIndexBytes)
         internal
+        isAddress(_keep) 
         view
         returns (bool)
     {
@@ -90,11 +91,11 @@ contract ECDSABackportRewards is Rewards {
     }
 
     // A keep is recognized if it was created by this factory.
-    function _recognizedByFactory(bytes32 _keep) internal view returns (bool) {
+    function _recognizedByFactory(bytes32 _keep) internal view isAddress(_keep) returns (bool) {
         return factory.getKeepOpenedTimestamp(toAddress(_keep)) != 0;
     }
 
-    function _distributeReward(bytes32 _keep, uint256 amount) internal {
+    function _distributeReward(bytes32 _keep, uint256 amount) internal isAddress(_keep) {
         token.approve(toAddress(_keep), amount);
 
         IBondedECDSAKeep(toAddress(_keep)).distributeERC20Reward(
@@ -103,11 +104,20 @@ contract ECDSABackportRewards is Rewards {
         );
     }
 
-    function toAddress(bytes32 keepBytes) internal pure returns (address) {
+   function toAddress(bytes32 keepBytes) internal pure returns (address) {
         return address(bytes20(keepBytes));
     }
 
     function fromAddress(address keepAddress) internal pure returns (bytes32) {
         return bytes32(bytes20(keepAddress));
+    }
+
+    function validAddressBytes(bytes32 keepBytes) internal pure returns (bool) {
+        return fromAddress(toAddress(keepBytes)) == keepBytes;
+    }
+
+    modifier isAddress(bytes32 _keep) {
+        require(validAddressBytes(_keep), "Invalid keep address");
+        _;
     }
 }

--- a/solidity/contracts/ECDSABackportRewards.sol
+++ b/solidity/contracts/ECDSABackportRewards.sol
@@ -75,7 +75,12 @@ contract ECDSABackportRewards is Rewards {
         return factory.getKeepOpenedTimestamp(toAddress(_keep));
     }
 
-    function _isClosed(bytes32) internal view isAddress(_keep) returns (bool) {
+    function _isClosed(bytes32 _keep)
+        internal
+        view
+        isAddress(_keep)
+        returns (bool)
+    {
         // Even though we still have some of the keeps opened, all the keeps
         // created between May 13 2020 - Sep 14 2020 are considered closed.
         // Because of the deposits pause
@@ -86,7 +91,7 @@ contract ECDSABackportRewards is Rewards {
         return true;
     }
 
-    function _isTerminated(bytes32 groupIndexBytes)
+    function _isTerminated(bytes32 _keep)
         internal
         view
         isAddress(_keep)

--- a/solidity/contracts/ECDSARewards.sol
+++ b/solidity/contracts/ECDSARewards.sol
@@ -18,10 +18,9 @@ import "@keep-network/keep-core/contracts/Rewards.sol";
 import "./BondedECDSAKeepFactory.sol";
 import "./BondedECDSAKeep.sol";
 
-/// @title KEEP Random ECDSA Signer Subsidy Rewards for the Sep 2020 release.
+/// @title KEEP ECDSA Signer Subsidy Rewards for the Sep 2020 release.
 /// @notice Contract distributes KEEP rewards to signers that were part of
-/// the keeps which were created by the BondedECDSAKeepFactory contract:
-/// https://etherscan.io/address/0xA7d9E842EFB252389d613dA88EDa3731512e40bD
+/// the keeps which were created by the BondedECDSAKeepFactory contract.
 ///
 /// The amount of KEEP to be distributed is determined by funding the contract,
 /// and additional KEEP can be added at any time.
@@ -52,7 +51,7 @@ import "./BondedECDSAKeep.sol";
 contract ECDSARewards is Rewards {
     // BondedECDSAKeepFactory deployment date, Sep-14-2020 interval started.
     // https://etherscan.io/address/0xA7d9E842EFB252389d613dA88EDa3731512e40bD
-    uint256 internal constant ecdsaFirstIntervalStart = 1600087297;
+    uint256 internal constant ecdsaFirstIntervalStart = 1600041600;
 
     /// Weights of the 24 reward intervals assigned over
     // 24 * termLength days.

--- a/solidity/contracts/ECDSARewards.sol
+++ b/solidity/contracts/ECDSARewards.sol
@@ -65,7 +65,7 @@ contract ECDSARewards is Rewards {
     // Each interval is 30 days long.
     uint256 internal constant termLength = 30 days;
 
-    uint256 internal constant minimumECDSAKeepsPerInterval = 4;
+    uint256 internal constant minimumECDSAKeepsPerInterval = 1000;
 
     BondedECDSAKeepFactory factory;
 

--- a/solidity/contracts/ECDSARewards.sol
+++ b/solidity/contracts/ECDSARewards.sol
@@ -90,24 +90,24 @@ contract ECDSARewards is Rewards {
         return fromAddress(factory.getKeepAtIndex(i));
     }
 
-    function _getCreationTime(bytes32 _keep) internal view returns (uint256) {
+    function _getCreationTime(bytes32 _keep) internal isAddress(_keep) view returns (uint256) {
         return factory.getKeepOpenedTimestamp(toAddress(_keep));
     }
 
-    function _isClosed(bytes32 _keep) internal view returns (bool) {
+    function _isClosed(bytes32 _keep) internal isAddress(_keep) view returns (bool) {
         return BondedECDSAKeep(toAddress(_keep)).isClosed();
     }
 
-    function _isTerminated(bytes32 _keep) internal view returns (bool) {
+    function _isTerminated(bytes32 _keep) internal isAddress(_keep) view returns (bool) {
         return BondedECDSAKeep(toAddress(_keep)).isTerminated();
     }
 
     // A keep is recognized if it was opened by this factory.
-    function _recognizedByFactory(bytes32 _keep) internal view returns (bool) {
+    function _recognizedByFactory(bytes32 _keep) internal view isAddress(_keep) returns (bool) {
         return factory.getKeepOpenedTimestamp(toAddress(_keep)) != 0;
     }
 
-    function _distributeReward(bytes32 _keep, uint256 amount) internal {
+    function _distributeReward(bytes32 _keep, uint256 amount) internal isAddress(_keep) {
         token.approve(toAddress(_keep), amount);
 
         BondedECDSAKeep(toAddress(_keep)).distributeERC20Reward(
@@ -116,11 +116,20 @@ contract ECDSARewards is Rewards {
         );
     }
 
-    function toAddress(bytes32 keepBytes) internal pure returns (address) {
+   function toAddress(bytes32 keepBytes) internal pure returns (address) {
         return address(bytes20(keepBytes));
     }
 
     function fromAddress(address keepAddress) internal pure returns (bytes32) {
         return bytes32(bytes20(keepAddress));
+    }
+
+    function validAddressBytes(bytes32 keepBytes) internal pure returns (bool) {
+        return fromAddress(toAddress(keepBytes)) == keepBytes;
+    }
+
+    modifier isAddress(bytes32 _keep) {
+        require(validAddressBytes(_keep), "Invalid keep address");
+        _;
     }
 }

--- a/solidity/contracts/ECDSARewards.sol
+++ b/solidity/contracts/ECDSARewards.sol
@@ -56,10 +56,30 @@ contract ECDSARewards is Rewards {
     /// Weights of the 24 reward intervals assigned over
     // 24 * termLength days.
     uint256[] internal intervalWeights = [
-        4, 8, 10, 12, 15, 15,
-        15, 15, 15, 15, 15, 15,
-        15, 15, 15, 15, 15, 15,
-        15, 15, 15, 15, 15, 15
+        4,
+        8,
+        10,
+        12,
+        15,
+        15,
+        15,
+        15,
+        15,
+        15,
+        15,
+        15,
+        15,
+        15,
+        15,
+        15,
+        15,
+        15,
+        15,
+        15,
+        15,
+        15,
+        15,
+        15
     ];
 
     // Each interval is 30 days long.
@@ -90,24 +110,47 @@ contract ECDSARewards is Rewards {
         return fromAddress(factory.getKeepAtIndex(i));
     }
 
-    function _getCreationTime(bytes32 _keep) internal isAddress(_keep) view returns (uint256) {
+    function _getCreationTime(bytes32 _keep)
+        internal
+        view
+        isAddress(_keep)
+        returns (uint256)
+    {
         return factory.getKeepOpenedTimestamp(toAddress(_keep));
     }
 
-    function _isClosed(bytes32 _keep) internal isAddress(_keep) view returns (bool) {
+    function _isClosed(bytes32 _keep)
+        internal
+        view
+        isAddress(_keep)
+        returns (bool)
+    {
         return BondedECDSAKeep(toAddress(_keep)).isClosed();
     }
 
-    function _isTerminated(bytes32 _keep) internal isAddress(_keep) view returns (bool) {
+    function _isTerminated(bytes32 _keep)
+        internal
+        view
+        isAddress(_keep)
+        returns (bool)
+    {
         return BondedECDSAKeep(toAddress(_keep)).isTerminated();
     }
 
     // A keep is recognized if it was opened by this factory.
-    function _recognizedByFactory(bytes32 _keep) internal view isAddress(_keep) returns (bool) {
+    function _recognizedByFactory(bytes32 _keep)
+        internal
+        view
+        isAddress(_keep)
+        returns (bool)
+    {
         return factory.getKeepOpenedTimestamp(toAddress(_keep)) != 0;
     }
 
-    function _distributeReward(bytes32 _keep, uint256 amount) internal isAddress(_keep) {
+    function _distributeReward(bytes32 _keep, uint256 amount)
+        internal
+        isAddress(_keep)
+    {
         token.approve(toAddress(_keep), amount);
 
         BondedECDSAKeep(toAddress(_keep)).distributeERC20Reward(
@@ -116,7 +159,7 @@ contract ECDSARewards is Rewards {
         );
     }
 
-   function toAddress(bytes32 keepBytes) internal pure returns (address) {
+    function toAddress(bytes32 keepBytes) internal pure returns (address) {
         return address(bytes20(keepBytes));
     }
 

--- a/solidity/contracts/ECDSARewards.sol
+++ b/solidity/contracts/ECDSARewards.sol
@@ -1,0 +1,113 @@
+/**
+▓▓▌ ▓▓ ▐▓▓ ▓▓▓▓▓▓▓▓▓▓▌▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▄
+▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▌▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
+  ▓▓▓▓▓▓    ▓▓▓▓▓▓▓▀    ▐▓▓▓▓▓▓    ▐▓▓▓▓▓   ▓▓▓▓▓▓     ▓▓▓▓▓   ▐▓▓▓▓▓▌   ▐▓▓▓▓▓▓
+  ▓▓▓▓▓▓▄▄▓▓▓▓▓▓▓▀      ▐▓▓▓▓▓▓▄▄▄▄         ▓▓▓▓▓▓▄▄▄▄         ▐▓▓▓▓▓▌   ▐▓▓▓▓▓▓
+  ▓▓▓▓▓▓▓▓▓▓▓▓▓▀        ▐▓▓▓▓▓▓▓▓▓▓▌        ▓▓▓▓▓▓▓▓▓▓▌        ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓
+  ▓▓▓▓▓▓▀▀▓▓▓▓▓▓▄       ▐▓▓▓▓▓▓▀▀▀▀         ▓▓▓▓▓▓▀▀▀▀         ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▀
+  ▓▓▓▓▓▓   ▀▓▓▓▓▓▓▄     ▐▓▓▓▓▓▓     ▓▓▓▓▓   ▓▓▓▓▓▓     ▓▓▓▓▓   ▐▓▓▓▓▓▌
+▓▓▓▓▓▓▓▓▓▓ █▓▓▓▓▓▓▓▓▓ ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  ▓▓▓▓▓▓▓▓▓▓
+▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓ ▐▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓ ▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓▓  ▓▓▓▓▓▓▓▓▓▓
+
+                           Trust math, not hardware.
+*/
+
+pragma solidity 0.5.17;
+
+import "@keep-network/keep-core/contracts/Rewards.sol";
+import "./BondedECDSAKeepFactory.sol";
+import "./BondedECDSAKeep.sol";
+
+contract ECDSARewards is Rewards {
+    // BondedECDSAKeepFactory deployment date, Sep-14-2020 interval started.
+    // https://etherscan.io/address/0xA7d9E842EFB252389d613dA88EDa3731512e40bD
+    uint256 internal constant ecdsaFirstIntervalStart = 1600087297;
+
+    /// Weights of the 24 reward intervals assigned over
+    // 24 * backportECDSATermLength days.
+    uint256[] internal intervalWeights = [
+        4, 8, 10, 12, 15, 15,
+        15, 15, 15, 15, 15, 15,
+        15, 15, 15, 15, 15, 15,
+        15, 15, 15, 15, 15, 15
+    ];
+
+    // Each interval is 30 days long.
+    uint256 internal constant backportECDSATermLength = 30 days;
+
+    // TODO: Define..
+    uint256 internal constant minimumECDSAKeepsPerInterval = 2;
+
+    BondedECDSAKeepFactory factory;
+
+    constructor(address _token, address payable _factoryAddress)
+        public
+        Rewards(
+            _token,
+            ecdsaFirstIntervalStart,
+            intervalWeights,
+            backportECDSATermLength,
+            minimumECDSAKeepsPerInterval
+        )
+    {
+        factory = BondedECDSAKeepFactory(_factoryAddress);
+    }
+
+    function _getKeepCount() internal view returns (uint256) {
+        return factory.getKeepCount();
+    }
+
+    function _getKeepAtIndex(uint256 i) internal view returns (bytes32) {
+        return fromAddress(factory.getKeepAtIndex(i));
+    }
+
+    function _getCreationTime(bytes32 _keep) internal view returns (uint256) {
+        return factory.getKeepOpenedTimestamp(toAddress(_keep));
+    }
+
+    function _isClosed(bytes32 _keep) internal view returns (bool) {
+        return BondedECDSAKeep(toAddress(_keep)).isClosed();
+    }
+
+    function _isTerminated(bytes32 _keep)
+        internal
+        view
+        returns (bool)
+    {
+        return BondedECDSAKeep(toAddress(_keep)).isTerminated();
+    }
+
+    // A keep is recognized if it was opened by this factory.
+    function _recognizedByFactory(bytes32 _keep) internal view returns (bool) {
+        return factory.getKeepOpenedTimestamp(toAddress(_keep)) != 0;
+    }
+
+    function _distributeReward(bytes32 _keep, uint256 amount)
+        internal
+        isAddress(_keep)
+    {
+        token.approve(toAddress(_keep), amount);
+
+        BondedECDSAKeep(toAddress(_keep)).distributeERC20Reward(
+            address(token),
+            amount
+        );
+    }
+
+    function validAddressBytes(bytes32 keepBytes) internal pure returns (bool) {
+        return fromAddress(toAddress(keepBytes)) == keepBytes;
+    }
+
+    function toAddress(bytes32 keepBytes) internal pure returns (address) {
+        return address(bytes20(keepBytes));
+    }
+
+    function fromAddress(address keepAddress) internal pure returns (bytes32) {
+        return bytes32(bytes20(keepAddress));
+    }
+
+    modifier isAddress(bytes32 _keep) {
+        require(validAddressBytes(_keep), "Invalid keep address");
+        _;
+    }
+}

--- a/solidity/contracts/test/BondedECDSAKeepFactoryStub.sol
+++ b/solidity/contracts/test/BondedECDSAKeepFactoryStub.sol
@@ -46,7 +46,7 @@ contract BondedECDSAKeepFactoryStub is BondedECDSAKeepFactory {
         address _owner,
         address[] memory _members,
         uint256 _creationTimestamp
-    ) public payable returns (address keepAddress) {
+    ) public returns (address keepAddress) {
         keepAddress = createClone(masterKeepAddress);
         BondedECDSAKeep keep = BondedECDSAKeep(keepAddress);
         keep.initialize(
@@ -61,5 +61,21 @@ contract BondedECDSAKeepFactoryStub is BondedECDSAKeepFactory {
         );
         keeps.push(keepAddress);
         keepOpenedTimestamp[keepAddress] = _creationTimestamp;
+    }
+
+    /// @notice Mocks opening `_numberOfKeeps` with the opening timestamp of
+    /// the first keep starting at `_firstKeepCreationTimestamp`.
+    /// IMPORTANT! This function does not actually create new keep instances!
+    /// It would not be possible to create 100 keeps in one block because of
+    /// gas limits.
+    function stubBatchOpenFakeKeeps(
+        uint256 _numberOfKeeps,
+        uint256 _firstKeepCreationTimestamp
+    ) public {
+        for (uint256 i = 0; i < _numberOfKeeps; i++) {
+            address keepAddress = address(block.timestamp + i);
+            keeps.push(keepAddress);
+            keepOpenedTimestamp[keepAddress] = _firstKeepCreationTimestamp + i; 
+        }
     }
 }

--- a/solidity/test/rewards/TestECDSABackportRewards.js
+++ b/solidity/test/rewards/TestECDSABackportRewards.js
@@ -1,30 +1,10 @@
 const {accounts, contract, web3} = require("@openzeppelin/test-environment")
 const {createSnapshot, restoreSnapshot} = require("../helpers/snapshot")
+const {initialize, fund, createMembers} = require("./rewardsSetup")
 
 const {expectRevert} = require("@openzeppelin/test-helpers")
 
-const KeepToken = contract.fromArtifact("KeepToken")
-const StackLib = contract.fromArtifact("StackLib")
-const KeepRegistry = contract.fromArtifact("KeepRegistry")
-const BondedECDSAKeepFactoryStub = contract.fromArtifact(
-  "BondedECDSAKeepFactoryStub"
-)
-const KeepBonding = contract.fromArtifact("KeepBonding")
-const MinimumStakeSchedule = contract.fromArtifact("MinimumStakeSchedule")
-const GrantStaking = contract.fromArtifact("GrantStaking")
-const Locks = contract.fromArtifact("Locks")
-const TopUps = contract.fromArtifact("TopUps")
-const TokenStakingEscrow = contract.fromArtifact("TokenStakingEscrow")
-const TokenStaking = contract.fromArtifact("TokenStakingStub")
-const TokenGrant = contract.fromArtifact("TokenGrant")
-const BondedSortitionPoolFactory = contract.fromArtifact(
-  "BondedSortitionPoolFactory"
-)
-const RandomBeaconStub = contract.fromArtifact("RandomBeaconStub")
-const BondedECDSAKeep = contract.fromArtifact("BondedECDSAKeep")
 const ECDSABackportRewards = contract.fromArtifact("ECDSABackportRewards")
-
-const KeepTokenGrant = contract.fromArtifact("TokenGrant")
 
 const BN = web3.utils.BN
 
@@ -33,43 +13,41 @@ chai.use(require("bn-chai")(BN))
 const expect = chai.expect
 
 describe("ECDSABackportRewards", () => {
-  let registry
   let rewardsContract
   let keepToken
 
   let tokenStaking
-  let tokenGrant
   let keepFactory
-  let bondedSortitionPoolFactory
-  let keepBonding
-  let randomBeacon
   let keepMembers
 
   const owner = accounts[0]
 
-  const keepSize = 3
   const numberOfCreatedKeeps = 41
   const tokenDecimalMultiplier = web3.utils.toBN(10).pow(web3.utils.toBN(18))
   const firstKeepCreationTimestamp = 1589408352
 
   // 1,000,000,000 - total KEEP supply
   //   200,000,000 - 20% of the total supply goes to staker rewards
-  //   180,000,000 - 90% of staker rewards goes to the ECDSA stakers
+  //   180,000,000 - 90% of staker rewards goes to the ECDSA staker rewards
   //     1,800,000 - 1% of ECDSA staker rewards goes to May - Sep keeps
   const ECDSABackportKEEPRewards = web3.utils
     .toBN(1800000)
     .mul(tokenDecimalMultiplier)
 
   before(async () => {
-    await initializeNewFactory()
-    keepMembers = await createMembers()
+    const setup = await initialize()
+    tokenStaking = setup.tokenStaking
+    keepToken = setup.keepToken
+    keepFactory = setup.keepFactory
+
+    keepMembers = await createMembers(tokenStaking)
     rewardsContract = await ECDSABackportRewards.new(
       keepToken.address,
       keepFactory.address,
       {from: owner}
     )
 
-    await fund(ECDSABackportKEEPRewards)
+    await fund(keepToken, rewardsContract, ECDSABackportKEEPRewards)
     await createKeeps()
   })
 
@@ -136,91 +114,6 @@ describe("ECDSABackportRewards", () => {
     }
   }
 
-  async function initializeNewFactory() {
-    await BondedSortitionPoolFactory.detectNetwork()
-    await BondedSortitionPoolFactory.link(
-      "StackLib",
-      (await StackLib.new({from: owner})).address
-    )
-
-    keepToken = await KeepToken.new({from: owner})
-    const keepTokenGrant = await KeepTokenGrant.new(keepToken.address)
-    registry = await KeepRegistry.new({from: owner})
-
-    bondedSortitionPoolFactory = await BondedSortitionPoolFactory.new({
-      from: owner,
-    })
-    await TokenStaking.detectNetwork()
-    await TokenStaking.link(
-      "MinimumStakeSchedule",
-      (await MinimumStakeSchedule.new({from: owner})).address
-    )
-    await TokenStaking.link(
-      "GrantStaking",
-      (await GrantStaking.new({from: owner})).address
-    )
-    await TokenStaking.link("Locks", (await Locks.new({from: owner})).address)
-    await TokenStaking.link("TopUps", (await TopUps.new({from: owner})).address)
-
-    const stakingEscrow = await TokenStakingEscrow.new(
-      keepToken.address,
-      keepTokenGrant.address,
-      {from: owner}
-    )
-
-    const stakeInitializationPeriod = 30 // In seconds
-
-    tokenStaking = await TokenStaking.new(
-      keepToken.address,
-      keepTokenGrant.address,
-      stakingEscrow.address,
-      registry.address,
-      stakeInitializationPeriod,
-      {from: owner}
-    )
-    tokenGrant = await TokenGrant.new(keepToken.address, {from: owner})
-
-    keepBonding = await KeepBonding.new(
-      registry.address,
-      tokenStaking.address,
-      tokenGrant.address,
-      {from: owner}
-    )
-    randomBeacon = await RandomBeaconStub.new({from: owner})
-    const bondedECDSAKeepMasterContract = await BondedECDSAKeep.new({
-      from: owner,
-    })
-    keepFactory = await BondedECDSAKeepFactoryStub.new(
-      bondedECDSAKeepMasterContract.address,
-      bondedSortitionPoolFactory.address,
-      tokenStaking.address,
-      keepBonding.address,
-      randomBeacon.address,
-      {from: owner}
-    )
-
-    await registry.approveOperatorContract(keepFactory.address, {from: owner})
-  }
-
-  async function createMembers() {
-    const membersArr = []
-
-    // 3 members in each keep
-    for (let i = 0; i < keepSize; i++) {
-      const operator = accounts[i]
-      const beneficiary = accounts[keepSize + i]
-      await tokenStaking.setBeneficiary(operator, beneficiary)
-      const member = {
-        operator: operator,
-        beneficiary: beneficiary,
-      }
-
-      membersArr.push(member)
-    }
-
-    return membersArr
-  }
-
   async function createKeeps() {
     const members = keepMembers.map((m) => m.operator)
     let keepCreationTimestamp = firstKeepCreationTimestamp
@@ -228,12 +121,5 @@ describe("ECDSABackportRewards", () => {
       await keepFactory.stubOpenKeep(owner, members, keepCreationTimestamp)
       keepCreationTimestamp += 7200 // adding 2 hours interval between each opened keep
     }
-  }
-
-  async function fund(amount) {
-    await keepToken.approveAndCall(rewardsContract.address, amount, "0x0", {
-      from: owner,
-    })
-    await rewardsContract.markAsFunded({from: owner})
   }
 })

--- a/solidity/test/rewards/TestECDSARewards.js
+++ b/solidity/test/rewards/TestECDSARewards.js
@@ -13,14 +13,20 @@ const chai = require("chai")
 chai.use(require("bn-chai")(BN))
 const expect = chai.expect
 
-describe("ECDSARewards", () => {
+describe.only("ECDSARewards", () => {
   let rewardsContract
   let keepToken
 
   let tokenStaking
   let keepFactory
   let keepMembers
-  let expectedKEEPAllocation
+
+  const expectedIntervalAllocations = [
+    7128000.0, 13685760.0, 15738624.0, 16997713.92, 18697485.31, 15892862.52,
+    13508933.14, 11482593.17, 9760204.19, 8296173.56, 7051747.53, 5993985.4,
+    5094887.59, 4330654.45, 3681056.28, 3128897.84, 2659563.16, 2260628.69,
+    1921534.39, 1633304.23, 1388308.59, 1180062.31, 1003052.96, 852595.02
+  ]
 
   const owner = accounts[0]
 
@@ -62,13 +68,6 @@ describe("ECDSARewards", () => {
   })
 
   describe("interval allocation", async () => {
-    expectedKEEPAllocation = [
-      7128000.0, 13685760.0, 15738624.0, 16997713.92, 18697485.31, 15892862.52,
-      13508933.14, 11482593.17, 9760204.19, 8296173.56, 7051747.53, 5993985.4,
-      5094887.59, 4330654.45, 3681056.28, 3128897.84, 2659563.16, 2260628.69,
-      1921534.39, 1633304.23, 1388308.59, 1180062.31, 1003052.96, 852595.02
-    ]
-
     it("should equal to expected allocations when 5 keeps were created per interval", async () => {
       await verifyIntervalAllocations(5)
     })
@@ -92,8 +91,8 @@ describe("ECDSARewards", () => {
         tokenDecimalMultiplier
       )
 
-      expect(actualBalance).to.gte.BN(expectedKEEPAllocation - precision)
-      expect(actualBalance).to.lte.BN(expectedKEEPAllocation + precision)
+      expect(actualBalance).to.gte.BN(expectedIntervalAllocations - precision)
+      expect(actualBalance).to.lte.BN(expectedIntervalAllocations + precision)
     }
   }
 

--- a/solidity/test/rewards/TestECDSARewards.js
+++ b/solidity/test/rewards/TestECDSARewards.js
@@ -44,10 +44,10 @@ describe.only("ECDSARewards", () => {
   const totalRewardsAllocation = web3.utils.toBN(178200000).mul(tokenDecimalMultiplier)
 
   before(async () => {
-    const setup = await initialize()
-    tokenStaking = setup.tokenStaking
-    keepToken = setup.keepToken
-    keepFactory = setup.keepFactory
+    const contracts = await initialize()
+    tokenStaking = contracts.tokenStaking
+    keepToken = contracts.keepToken
+    keepFactory = contracts.keepFactory
 
     keepMembers = await createMembers(tokenStaking)
     rewardsContract = await ECDSARewards.new(

--- a/solidity/test/rewards/TestECDSARewards.js
+++ b/solidity/test/rewards/TestECDSARewards.js
@@ -29,7 +29,7 @@ describe("ECDSARewards", () => {
   // actual value.
   const precision = 1
   const tokenDecimalMultiplier = web3.utils.toBN(10).pow(web3.utils.toBN(18))
-  const firstKeepCreationTimestamp = 1600087297 // Sep 14 2020
+  const firstKeepCreationTimestamp = 1600041600 // Sep 14 2020
 
   // 1,000,000,000 - total KEEP supply
   //   200,000,000 - 20% of the total supply goes to staker rewards

--- a/solidity/test/rewards/TestECDSARewards.js
+++ b/solidity/test/rewards/TestECDSARewards.js
@@ -41,7 +41,7 @@ describe.only("ECDSARewards", () => {
   //   200,000,000 - 20% of the total supply goes to staker rewards
   //   180,000,000 - 90% of staker rewards goes to the ECDSA staker rewards
   //   178,200,000 - 99% of ECDSA staker rewards goes to keeps opened after Sep 14 2020
-  const KEEPRewards = web3.utils.toBN(178200000).mul(tokenDecimalMultiplier)
+  const totalRewardsAllocation = web3.utils.toBN(178200000).mul(tokenDecimalMultiplier)
 
   before(async () => {
     const setup = await initialize()
@@ -56,7 +56,7 @@ describe.only("ECDSARewards", () => {
       {from: owner}
     )
 
-    await fund(keepToken, rewardsContract, KEEPRewards)
+    await fund(keepToken, rewardsContract, totalRewardsAllocation)
   })
 
   beforeEach(async () => {

--- a/solidity/test/rewards/TestECDSARewards.js
+++ b/solidity/test/rewards/TestECDSARewards.js
@@ -58,8 +58,8 @@ describe("ECDSARewards", () => {
 
   // 1,000,000,000 - total KEEP supply
   //   200,000,000 - 20% of the total supply goes to staker rewards
-  //   180,000,000 - 90% of staker rewards goes to the ECDSA stakers
-  //   178,200,000 - 89% of ECDSA staker rewards goes to keeps opened after Sep 14 2020
+  //   180,000,000 - 90% of staker rewards goes to the ECDSA staker rewards
+  //   178,200,000 - 99% of ECDSA staker rewards goes to keeps opened after Sep 14 2020
   const KEEPRewards = web3.utils.toBN(178200000).mul(tokenDecimalMultiplier)
 
   before(async () => {

--- a/solidity/test/rewards/TestECDSARewards.js
+++ b/solidity/test/rewards/TestECDSARewards.js
@@ -133,10 +133,6 @@ describe.only("ECDSARewards", () => {
 
     it("should not count terminated groups when distributing rewards", async () => {
       await createKeeps(2, firstKeepCreationTimestamp)
-      // reward for the first interval: 7128000 KEEP
-      // keeps created: 2, but the min is 4 => 7128000 / 4 = 1782000 KEEP per keep
-      // member receives: 1782000 / 3 = 594000 (3 signers per keep)
-      const expectedBeneficiaryBalance = new BN(594000)
 
       await timeJumpToEndOfInterval(0)
 
@@ -149,7 +145,12 @@ describe.only("ECDSARewards", () => {
       await keep.publicMarkAsClosed()
 
       await rewardsContract.receiveReward(keepAddress)
-      // Only the second keep was properly closed.
+
+      // reward for the first interval: 7128000 KEEP
+      // keeps created: 2, but the min is 4 => 7128000 / 4 = 1782000 KEEP per keep
+      // first keep was terminated, only the second keep was closed properly
+      // member receives: 1782000 / 3 = 594000 (3 signers per keep)
+      const expectedBeneficiaryBalance = new BN(594000)
       await assertKeepBalanceOfBeneficiaries(expectedBeneficiaryBalance)
 
       // the remaining 5346000 stays in unallocated rewards but the fact

--- a/solidity/test/rewards/TestECDSARewards.js
+++ b/solidity/test/rewards/TestECDSARewards.js
@@ -1,0 +1,281 @@
+const {accounts, contract, web3} = require("@openzeppelin/test-environment")
+const {createSnapshot, restoreSnapshot} = require("../helpers/snapshot")
+
+const {expectRevert, time} = require("@openzeppelin/test-helpers")
+
+const KeepToken = contract.fromArtifact("KeepToken")
+const StackLib = contract.fromArtifact("StackLib")
+const KeepRegistry = contract.fromArtifact("KeepRegistry")
+const BondedECDSAKeepFactoryStub = contract.fromArtifact(
+  "BondedECDSAKeepFactoryStub"
+)
+const KeepBonding = contract.fromArtifact("KeepBonding")
+const MinimumStakeSchedule = contract.fromArtifact("MinimumStakeSchedule")
+const GrantStaking = contract.fromArtifact("GrantStaking")
+const Locks = contract.fromArtifact("Locks")
+const TopUps = contract.fromArtifact("TopUps")
+const TokenStakingEscrow = contract.fromArtifact("TokenStakingEscrow")
+const TokenStaking = contract.fromArtifact("TokenStakingStub")
+const TokenGrant = contract.fromArtifact("TokenGrant")
+const BondedSortitionPoolFactory = contract.fromArtifact(
+  "BondedSortitionPoolFactory"
+)
+const RandomBeaconStub = contract.fromArtifact("RandomBeaconStub")
+const BondedECDSAKeep = contract.fromArtifact("BondedECDSAKeepStub")
+const ECDSARewards = contract.fromArtifact("ECDSARewards")
+
+const KeepTokenGrant = contract.fromArtifact("TokenGrant")
+
+const BN = web3.utils.BN
+
+const chai = require("chai")
+chai.use(require("bn-chai")(BN))
+const expect = chai.expect
+
+describe("ECDSARewards", () => {
+  let registry
+  let rewardsContract
+  let keepToken
+
+  let tokenStaking
+  let tokenGrant
+  let keepFactory
+  let bondedSortitionPoolFactory
+  let keepBonding
+  let randomBeacon
+  let keepMembers
+  let expectedKEEPAllocation
+
+  const owner = accounts[0]
+
+  const keepSize = 3
+  const precision = 1
+  const tokenDecimalMultiplier = web3.utils.toBN(10).pow(web3.utils.toBN(18))
+  const firstKeepCreationTimestamp = 1600087297 // Sep 14 2020
+
+  // 1,000,000,000 - total KEEP supply
+  //   200,000,000 - 20% of the total supply goes to staker rewards
+  //   180,000,000 - 90% of staker rewards goes to the ECDSA stakers
+  //   178,200,000 - 89% of ECDSA staker rewards goes to keeps opened after Sep 14 2020
+  const KEEPRewards = web3.utils.toBN(178200000).mul(tokenDecimalMultiplier)
+
+  before(async () => {
+    await BondedSortitionPoolFactory.detectNetwork()
+    await BondedSortitionPoolFactory.link(
+      "StackLib",
+      (await StackLib.new({from: owner})).address
+    )
+
+    await initializeNewFactory()
+    keepMembers = await createMembers()
+    rewardsContract = await ECDSARewards.new(
+      keepToken.address,
+      keepFactory.address,
+      {from: owner}
+    )
+
+    await fund(KEEPRewards)
+  })
+
+  beforeEach(async () => {
+    await createSnapshot()
+  })
+
+  afterEach(async () => {
+    await restoreSnapshot()
+  })
+
+  describe("interval allocation", async () => {
+    expectedKEEPAllocation = [
+      7128000.0, 13685760.0, 15738624.0, 16997713.92, 18697485.31, 15892862.52,
+      13508933.14, 11482593.17, 9760204.19, 8296173.56, 7051747.53, 5993985.4,
+      5094887.59, 4330654.45, 3681056.28, 3128897.84, 2659563.16, 2260628.69,
+      1921534.39, 1633304.23, 1388308.59, 1180062.31, 1003052.96, 852595.02,
+    ]
+
+    it("should equal to expected allocations when 5 keeps were created per interval", async () => {
+      await verifyIntervalAllocations(5)
+    })
+
+    it("should equal to expected allocations when 1 keep was created per interval", async () => {
+      await verifyIntervalAllocations(1)
+    })
+  })
+
+  async function verifyIntervalAllocations(keepToCreatePerInterval) {
+    let keepCreationTimestamp = firstKeepCreationTimestamp
+
+    for (let i = 0; i < 24; i++) {
+      await createKeeps(keepToCreatePerInterval, keepCreationTimestamp)
+
+      keepCreationTimestamp = await timeJumpToEndOfInterval(i)
+
+      await rewardsContract.allocateRewards(i)
+
+      const actualBalance = (await rewardsContract.getAllocatedRewards(i)).div(
+        tokenDecimalMultiplier
+      )
+
+      expect(actualBalance).to.gte.BN(expectedKEEPAllocation - precision)
+      expect(actualBalance).to.lte.BN(expectedKEEPAllocation + precision)
+    }
+  }
+
+  describe("rewards distribution", async () => {
+    it("should correctly distribute rewards between beneficiaries", async () => {
+      await createKeeps(8, firstKeepCreationTimestamp)
+      // reward for the first interval: 7128000 KEEP
+      // keeps created: 8 => 891000 KEEP per keep
+      // member receives: 891000 / 3 = 297000 (3 signers per keep)
+      const expectedBeneficiaryBalance = new BN(297000)
+
+      keepCreationTimestamp = await timeJumpToEndOfInterval(0)
+
+      let keepAddress = await keepFactory.getKeepAtIndex(0)
+      let keep = await BondedECDSAKeep.at(keepAddress)
+      await keep.publicMarkAsClosed()
+
+      await rewardsContract.receiveReward(keepAddress)
+
+      await assertKeepBalanceOfBeneficiaries(expectedBeneficiaryBalance)
+
+      // verify second keep in this interval
+      keepAddress = await keepFactory.getKeepAtIndex(1)
+      keep = await BondedECDSAKeep.at(keepAddress)
+      await keep.publicMarkAsClosed()
+
+      await rewardsContract.receiveReward(keepAddress)
+
+      // 297000 * 2 = 594000
+      await assertKeepBalanceOfBeneficiaries(expectedBeneficiaryBalance.muln(2))
+    })
+  })
+
+  async function assertKeepBalanceOfBeneficiaries(expectedBalance) {
+    // Solidity is not very good when it comes to floating point precision,
+    // we are allowing for ~1 KEEP difference margin between expected and
+    // actual value.
+    const precision = 1
+
+    for (let i = 0; i < keepMembers.length; i++) {
+      const actualBalance = (
+        await keepToken.balanceOf(keepMembers[i].beneficiary)
+      ).div(tokenDecimalMultiplier)
+
+      expect(actualBalance).to.gte.BN(expectedBalance.subn(precision))
+      expect(actualBalance).to.lte.BN(expectedBalance.addn(precision))
+    }
+  }
+
+  async function initializeNewFactory() {
+    await BondedSortitionPoolFactory.detectNetwork()
+    await BondedSortitionPoolFactory.link(
+      "StackLib",
+      (await StackLib.new({from: owner})).address
+    )
+
+    keepToken = await KeepToken.new({from: owner})
+    const keepTokenGrant = await KeepTokenGrant.new(keepToken.address)
+    registry = await KeepRegistry.new({from: owner})
+
+    bondedSortitionPoolFactory = await BondedSortitionPoolFactory.new({
+      from: owner,
+    })
+    await TokenStaking.detectNetwork()
+    await TokenStaking.link(
+      "MinimumStakeSchedule",
+      (await MinimumStakeSchedule.new({from: owner})).address
+    )
+    await TokenStaking.link(
+      "GrantStaking",
+      (await GrantStaking.new({from: owner})).address
+    )
+    await TokenStaking.link("Locks", (await Locks.new({from: owner})).address)
+    await TokenStaking.link("TopUps", (await TopUps.new({from: owner})).address)
+
+    const stakingEscrow = await TokenStakingEscrow.new(
+      keepToken.address,
+      keepTokenGrant.address,
+      {from: owner}
+    )
+
+    const stakeInitializationPeriod = 30 // In seconds
+
+    tokenStaking = await TokenStaking.new(
+      keepToken.address,
+      keepTokenGrant.address,
+      stakingEscrow.address,
+      registry.address,
+      stakeInitializationPeriod,
+      {from: owner}
+    )
+    tokenGrant = await TokenGrant.new(keepToken.address, {from: owner})
+
+    keepBonding = await KeepBonding.new(
+      registry.address,
+      tokenStaking.address,
+      tokenGrant.address,
+      {from: owner}
+    )
+    randomBeacon = await RandomBeaconStub.new({from: owner})
+    const bondedECDSAKeepMasterContract = await BondedECDSAKeep.new({
+      from: owner,
+    })
+    keepFactory = await BondedECDSAKeepFactoryStub.new(
+      bondedECDSAKeepMasterContract.address,
+      bondedSortitionPoolFactory.address,
+      tokenStaking.address,
+      keepBonding.address,
+      randomBeacon.address,
+      {from: owner}
+    )
+
+    await registry.approveOperatorContract(keepFactory.address, {from: owner})
+  }
+
+  async function createMembers() {
+    const membersArr = []
+
+    // 3 members in each keep
+    for (let i = 0; i < keepSize; i++) {
+      const operator = accounts[i]
+      const beneficiary = accounts[keepSize + i]
+      await tokenStaking.setBeneficiary(operator, beneficiary)
+      const member = {
+        operator: operator,
+        beneficiary: beneficiary,
+      }
+
+      membersArr.push(member)
+    }
+
+    return membersArr
+  }
+
+  async function createKeeps(numberOfKeepsToOpen, keepCreationTimestamp) {
+    let timestamp = new BN(keepCreationTimestamp)
+    const members = keepMembers.map((m) => m.operator)
+    for (let i = 0; i < numberOfKeepsToOpen; i++) {
+      await keepFactory.stubOpenKeep(keepFactory.address, members, timestamp)
+      timestamp = timestamp.addn(7200) // adding 2 hours interval between each opened keep
+    }
+  }
+
+  async function fund(amount) {
+    await keepToken.approveAndCall(rewardsContract.address, amount, "0x0", {
+      from: owner,
+    })
+    await rewardsContract.markAsFunded({from: owner})
+  }
+
+  async function timeJumpToEndOfInterval(intervalNumber) {
+    const endOf = await rewardsContract.endOf(intervalNumber)
+    const now = await time.latest()
+
+    if (now.lt(endOf)) {
+      await time.increaseTo(endOf.addn(60))
+    }
+
+    return await time.latest()
+  }
+})

--- a/solidity/test/rewards/TestECDSARewards.js
+++ b/solidity/test/rewards/TestECDSARewards.js
@@ -41,7 +41,9 @@ describe.only("ECDSARewards", () => {
   //   200,000,000 - 20% of the total supply goes to staker rewards
   //   180,000,000 - 90% of staker rewards goes to the ECDSA staker rewards
   //   178,200,000 - 99% of ECDSA staker rewards goes to keeps opened after Sep 14 2020
-  const totalRewardsAllocation = web3.utils.toBN(178200000).mul(tokenDecimalMultiplier)
+  const totalRewardsAllocation = web3.utils
+    .toBN(178200000)
+    .mul(tokenDecimalMultiplier)
 
   before(async () => {
     const contracts = await initialize()
@@ -145,11 +147,6 @@ describe.only("ECDSARewards", () => {
       const keepAddress = await keepFactory.getKeepAtIndex(1)
       const keep = await BondedECDSAKeepStub.at(keepAddress)
       await keep.publicMarkAsClosed()
-
-      await expectRevert(
-        rewardsContract.receiveReward(keepTerminatedAddress),
-        "Keep is not closed"
-      )
 
       await rewardsContract.receiveReward(keepAddress)
       // Only the second keep was properly closed.

--- a/solidity/test/rewards/TestECDSARewards.js
+++ b/solidity/test/rewards/TestECDSARewards.js
@@ -49,6 +49,9 @@ describe("ECDSARewards", () => {
   const owner = accounts[0]
 
   const keepSize = 3
+  // Solidity is not very good when it comes to floating point precision,
+  // we are allowing for ~1 KEEP difference margin between expected and
+  // actual value.
   const precision = 1
   const tokenDecimalMultiplier = web3.utils.toBN(10).pow(web3.utils.toBN(18))
   const firstKeepCreationTimestamp = 1600087297 // Sep 14 2020
@@ -224,11 +227,6 @@ describe("ECDSARewards", () => {
   })
 
   async function assertKeepBalanceOfBeneficiaries(expectedBalance) {
-    // Solidity is not very good when it comes to floating point precision,
-    // we are allowing for ~1 KEEP difference margin between expected and
-    // actual value.
-    const precision = 1
-
     for (let i = 0; i < keepMembers.length; i++) {
       const actualBalance = (
         await keepToken.balanceOf(keepMembers[i].beneficiary)

--- a/solidity/test/rewards/rewardsSetup.js
+++ b/solidity/test/rewards/rewardsSetup.js
@@ -1,0 +1,129 @@
+const {accounts, contract} = require("@openzeppelin/test-environment")
+
+const KeepToken = contract.fromArtifact("KeepToken")
+const StackLib = contract.fromArtifact("StackLib")
+const KeepRegistry = contract.fromArtifact("KeepRegistry")
+const BondedECDSAKeepFactoryStub = contract.fromArtifact(
+  "BondedECDSAKeepFactoryStub"
+)
+const KeepBonding = contract.fromArtifact("KeepBonding")
+const MinimumStakeSchedule = contract.fromArtifact("MinimumStakeSchedule")
+const GrantStaking = contract.fromArtifact("GrantStaking")
+const Locks = contract.fromArtifact("Locks")
+const TopUps = contract.fromArtifact("TopUps")
+const TokenStakingEscrow = contract.fromArtifact("TokenStakingEscrow")
+const TokenStaking = contract.fromArtifact("TokenStakingStub")
+const TokenGrant = contract.fromArtifact("TokenGrant")
+const BondedSortitionPoolFactory = contract.fromArtifact(
+  "BondedSortitionPoolFactory"
+)
+const RandomBeaconStub = contract.fromArtifact("RandomBeaconStub")
+const BondedECDSAKeepStub = contract.fromArtifact("BondedECDSAKeepStub")
+const KeepTokenGrant = contract.fromArtifact("TokenGrant")
+
+async function initialize() {
+  const owner = accounts[0]
+
+  await BondedSortitionPoolFactory.detectNetwork()
+  await BondedSortitionPoolFactory.link(
+    "StackLib",
+    (await StackLib.new({from: owner})).address
+  )
+
+  keepToken = await KeepToken.new({from: owner})
+  const keepTokenGrant = await KeepTokenGrant.new(keepToken.address)
+  const registry = await KeepRegistry.new({from: owner})
+
+  const bondedSortitionPoolFactory = await BondedSortitionPoolFactory.new({
+    from: owner,
+  })
+  await TokenStaking.detectNetwork()
+  await TokenStaking.link(
+    "MinimumStakeSchedule",
+    (await MinimumStakeSchedule.new({from: owner})).address
+  )
+  await TokenStaking.link(
+    "GrantStaking",
+    (await GrantStaking.new({from: owner})).address
+  )
+  await TokenStaking.link("Locks", (await Locks.new({from: owner})).address)
+  await TokenStaking.link("TopUps", (await TopUps.new({from: owner})).address)
+
+  const stakingEscrow = await TokenStakingEscrow.new(
+    keepToken.address,
+    keepTokenGrant.address,
+    {from: owner}
+  )
+
+  const stakeInitializationPeriod = 30 // In seconds
+
+  tokenStaking = await TokenStaking.new(
+    keepToken.address,
+    keepTokenGrant.address,
+    stakingEscrow.address,
+    registry.address,
+    stakeInitializationPeriod,
+    {from: owner}
+  )
+  const tokenGrant = await TokenGrant.new(keepToken.address, {from: owner})
+
+  const keepBonding = await KeepBonding.new(
+    registry.address,
+    tokenStaking.address,
+    tokenGrant.address,
+    {from: owner}
+  )
+  const randomBeacon = await RandomBeaconStub.new({from: owner})
+  const bondedECDSAKeepMasterContract = await BondedECDSAKeepStub.new({
+    from: owner,
+  })
+  keepFactory = await BondedECDSAKeepFactoryStub.new(
+    bondedECDSAKeepMasterContract.address,
+    bondedSortitionPoolFactory.address,
+    tokenStaking.address,
+    keepBonding.address,
+    randomBeacon.address,
+    {from: owner}
+  )
+
+  await registry.approveOperatorContract(keepFactory.address, {from: owner})
+
+  return {
+    tokenStaking: tokenStaking,
+    keepToken: keepToken,
+    keepFactory: keepFactory,
+  }
+}
+
+async function fund(keepToken, rewardsContract, amount) {
+  const owner = accounts[0]
+
+  await keepToken.approveAndCall(rewardsContract.address, amount, "0x0", {
+    from: owner,
+  })
+  await rewardsContract.markAsFunded({from: owner})
+}
+
+async function createMembers(tokenStaking) {
+  const membersArr = []
+  const keepSize = 3
+
+  // 3 members in each keep
+  for (let i = 0; i < keepSize; i++) {
+    const operator = accounts[i]
+    const beneficiary = accounts[keepSize + i]
+    await tokenStaking.setBeneficiary(operator, beneficiary)
+    const member = {
+      operator: operator,
+      beneficiary: beneficiary,
+    }
+
+    membersArr.push(member)
+  }
+
+  return membersArr
+}
+
+module.exports.initialize = initialize
+module.exports.fund = fund
+module.exports.createMembers = createMembers

--- a/solidity/test/rewards/rewardsSetup.js
+++ b/solidity/test/rewards/rewardsSetup.js
@@ -105,7 +105,7 @@ async function fund(keepToken, rewardsContract, amount) {
 }
 
 async function createMembers(tokenStaking) {
-  const membersArr = []
+  const members = []
   const keepSize = 3
 
   // 3 members in each keep
@@ -118,10 +118,10 @@ async function createMembers(tokenStaking) {
       beneficiary: beneficiary,
     }
 
-    membersArr.push(member)
+    members.push(member)
   }
 
-  return membersArr
+  return members
 }
 
 module.exports.initialize = initialize


### PR DESCRIPTION
This PR is a continuation of KEEP Rewards work done in https://github.com/keep-network/keep-ecdsa/pull/513/files and keep-network/keep-core#1863.

Here we add Rewards distribution for keep-ecdsa for the period of time starting on Sep 14 2020.

ECDSABackportRewards will distribute KEEP between involved signers. We count keeps starting from bonded ECDSA Keep Factory Deployment on Sep 14 until rewards are fully distributed.

Upon deployment of this contract, keep stakers can claim their rewards calling `receiveReward(keepAddress)`.