### PR TITLE
Allowing stakers to receive rewards for multiple keeps

### DIFF
--- a/solidity/contracts/ECDSARewards.sol
+++ b/solidity/contracts/ECDSARewards.sol
@@ -102,7 +102,7 @@ contract ECDSARewards is Rewards {
         factory = BondedECDSAKeepFactory(_factoryAddress);
     }
 
-    /// @notice Stakers can receive KEEP rewards from multiple keeps of their choice 
+    /// @notice Stakers can receive KEEP rewards from multiple keeps of their choice
     /// in one transaction to reduce total cost comparing to single calls for rewards.
     /// It is a caller responsibility to determine the cost and consumed gas when
     /// receiving rewards from multiple keeps.

--- a/solidity/contracts/ECDSARewards.sol
+++ b/solidity/contracts/ECDSARewards.sol
@@ -102,6 +102,16 @@ contract ECDSARewards is Rewards {
         factory = BondedECDSAKeepFactory(_factoryAddress);
     }
 
+    // Stakers can receive KEEP rewards from multiple keeps of their choice in
+    // one transaction to reduce total cost comparing to single calls for rewards.
+    // It is a caller responsibility to determine the cost and consumed gas when
+    // receiving rewards from multiple keeps.
+    function receiveReward(bytes32[] memory keepIdentifiers) public {
+        for (uint256 i = 0; i < keepIdentifiers.length; i++) {
+            receiveReward(keepIdentifiers[i]);
+        }
+    }
+
     function _getKeepCount() internal view returns (uint256) {
         return factory.getKeepCount();
     }

--- a/solidity/contracts/ECDSARewards.sol
+++ b/solidity/contracts/ECDSARewards.sol
@@ -102,11 +102,12 @@ contract ECDSARewards is Rewards {
         factory = BondedECDSAKeepFactory(_factoryAddress);
     }
 
-    // Stakers can receive KEEP rewards from multiple keeps of their choice in
-    // one transaction to reduce total cost comparing to single calls for rewards.
-    // It is a caller responsibility to determine the cost and consumed gas when
-    // receiving rewards from multiple keeps.
-    function receiveReward(bytes32[] memory keepIdentifiers) public {
+    /// @notice Stakers can receive KEEP rewards from multiple keeps of their choice 
+    /// in one transaction to reduce total cost comparing to single calls for rewards.
+    /// It is a caller responsibility to determine the cost and consumed gas when
+    /// receiving rewards from multiple keeps.
+    /// @param keepIdentifiers An array of keep addresses.
+    function receiveRewards(bytes32[] memory keepIdentifiers) public {
         for (uint256 i = 0; i < keepIdentifiers.length; i++) {
             receiveReward(keepIdentifiers[i]);
         }

--- a/solidity/contracts/test/BondedECDSAKeepFactoryStub.sol
+++ b/solidity/contracts/test/BondedECDSAKeepFactoryStub.sol
@@ -75,7 +75,7 @@ contract BondedECDSAKeepFactoryStub is BondedECDSAKeepFactory {
         for (uint256 i = 0; i < _numberOfKeeps; i++) {
             address keepAddress = address(block.timestamp.add(i));
             keeps.push(keepAddress);
-            keepOpenedTimestamp[keepAddress] = _firstKeepCreationTimestamp.add(i); 
+            keepOpenedTimestamp[keepAddress] = _firstKeepCreationTimestamp.add(i);
         }
     }
 }

--- a/solidity/test/rewards/TestECDSARewards.js
+++ b/solidity/test/rewards/TestECDSARewards.js
@@ -220,7 +220,7 @@ describe("ECDSARewards", () => {
         await keepFactory.stubOpenKeep(owner, operators, firstIntervalStart)
       }
 
-      await timeJumpToEndOfInterval(0)
+      await timeJumpToEndOfIntervalIfApplicable(0)
 
       const keepAddress = await keepFactory.getKeepAtIndex(0)
       const keepAddress1 = await keepFactory.getKeepAtIndex(1)


### PR DESCRIPTION
In order to reduce cost of single multiple transactions when claiming rewards, we implement a function that takes an array of keep addresses and process all claims in a single transaction.
A caller is responsible to determine the cost and consumed gas for this transaction.

Refs https://github.com/keep-network/keep-ecdsa/issues/446