### PR TITLE
Fixing tests when future intervals are over

### DIFF
--- a/solidity/contracts/test/BondedECDSAKeepFactoryStub.sol
+++ b/solidity/contracts/test/BondedECDSAKeepFactoryStub.sol
@@ -73,9 +73,9 @@ contract BondedECDSAKeepFactoryStub is BondedECDSAKeepFactory {
         uint256 _firstKeepCreationTimestamp
     ) public {
         for (uint256 i = 0; i < _numberOfKeeps; i++) {
-            address keepAddress = address(block.timestamp + i);
+            address keepAddress = address(block.timestamp.add(i));
             keeps.push(keepAddress);
-            keepOpenedTimestamp[keepAddress] = _firstKeepCreationTimestamp + i; 
+            keepOpenedTimestamp[keepAddress] = _firstKeepCreationTimestamp.add(i); 
         }
     }
 }

--- a/solidity/test/rewards/TestECDSARewards.js
+++ b/solidity/test/rewards/TestECDSARewards.js
@@ -79,16 +79,8 @@ describe("ECDSARewards", () => {
       await keepFactory.stubBatchOpenFakeKeeps(100, firstIntervalStart)
       await rewardsContract.allocateRewards(0)
 
-      const endOf = await rewardsContract.endOf(0)
-      let now = await time.latest()
-      // create 50 keeps in the second interval
-      if (now.lt(endOf)) {
-        await time.increaseTo(endOf.addn(1))
-        now = await time.latest()
-        await keepFactory.stubBatchOpenFakeKeeps(50, now)
-      } else {
-        await keepFactory.stubBatchOpenFakeKeeps(50, endOf.addn(1))
-      }
+      const firstIntervalEnd = await rewardsContract.endOf(0)
+      await keepFactory.stubBatchOpenFakeKeeps(50, firstIntervalEnd.addn(1))
 
       await timeJumpToEndOfIntervalIfApplicable(1)
 
@@ -105,15 +97,8 @@ describe("ECDSARewards", () => {
     })
 
     it("should equal expected allocation in third interval", async () => {
-      const endOf = await rewardsContract.endOf(1)
-      let now = await time.latest()
-      if (now.lt(endOf)) {
-        await time.increaseTo(endOf.addn(1))
-        now = await time.latest()
-        await keepFactory.stubBatchOpenFakeKeeps(40, now)
-      } else {
-        await keepFactory.stubBatchOpenFakeKeeps(40, endOf.addn(1))
-      }
+      const secondIntervalEnd = await rewardsContract.endOf(1)
+      await keepFactory.stubBatchOpenFakeKeeps(40, secondIntervalEnd.addn(1))
 
       await timeJumpToEndOfIntervalIfApplicable(2)
 


### PR DESCRIPTION
In this PR we are changing the way of keeps creation. All the tests were passing before, because we were in the interval 0. When the time comes for future intervals, some tests would've failed.

Refs https://github.com/keep-network/keep-ecdsa/issues/446