### PR TITLE
Rewards cap tests

### DIFF
--- a/solidity/contracts/ECDSARewards.sol
+++ b/solidity/contracts/ECDSARewards.sol
@@ -93,7 +93,7 @@ contract ECDSARewards is Rewards {
     // The amount of tokens each individual beneficiary address
     // can receive in a single interval is capped.
     // TODO: set actual value
-    uint256 internal constant beneficiaryRewardCap = 400000 * 10**18;
+    uint256 internal beneficiaryRewardCap = 400000 * 10**18;
     // The total amount of rewards allocated to the given beneficiary address,
     // in the given interval.
     // `allocatedRewards[beneficiary][interval] -> amount`

--- a/solidity/contracts/test/ECDSARewardsStub.sol
+++ b/solidity/contracts/test/ECDSARewardsStub.sol
@@ -19,9 +19,4 @@ contract ECDSARewardsStub is ECDSARewards {
     {
         beneficiaryRewardCap = 10000 * 10**18;
     }
-
-    function getBeneficiaryRewardCap() public view returns (uint256) {
-        return beneficiaryRewardCap;
-    }
-
 }

--- a/solidity/contracts/test/ECDSARewardsStub.sol
+++ b/solidity/contracts/test/ECDSARewardsStub.sol
@@ -1,0 +1,27 @@
+pragma solidity 0.5.17;
+
+import "../../contracts/ECDSARewards.sol";
+
+/// @title ECDSA Rewards Stub for ecdsa rewards testing
+/// @dev This contract is for testing purposes only.
+contract ECDSARewardsStub is ECDSARewards {
+    constructor(
+        address _token,
+        address payable _factoryAddress,
+        address _tokenStakingAddress
+    )
+        public
+        ECDSARewards(
+            _token,
+            _factoryAddress,
+            _tokenStakingAddress
+        )
+    {
+        beneficiaryRewardCap = 10000 * 10**18;
+    }
+
+    function getBeneficiaryRewardCap() public view returns (uint256) {
+        return beneficiaryRewardCap;
+    }
+
+}

--- a/solidity/contracts/test/ECDSARewardsStub.sol
+++ b/solidity/contracts/test/ECDSARewardsStub.sol
@@ -5,6 +5,9 @@ import "../../contracts/ECDSARewards.sol";
 /// @title ECDSA Rewards Stub for ecdsa rewards testing
 /// @dev This contract is for testing purposes only.
 contract ECDSARewardsStub is ECDSARewards {
+
+    uint256 internal tokenDecimalMultiplier = 10**18;
+
     constructor(
         address _token,
         address payable _factoryAddress,
@@ -16,7 +19,9 @@ contract ECDSARewardsStub is ECDSARewards {
             _factoryAddress,
             _tokenStakingAddress
         )
-    {
-        beneficiaryRewardCap = 10000 * 10**18;
+    {}
+
+    function setBeneficiaryRewardCap(uint256 _beneficiaryRewardCap) public {
+        beneficiaryRewardCap = _beneficiaryRewardCap.mul(tokenDecimalMultiplier);
     }
 }

--- a/solidity/test/rewards/TestECDSARewards.js
+++ b/solidity/test/rewards/TestECDSARewards.js
@@ -23,6 +23,7 @@ describe("ECDSARewards", () => {
 
   const tokenDecimalMultiplier = web3.utils.toBN(10).pow(web3.utils.toBN(18))
   const firstIntervalStart = 1600041600 // Sep 14 2020
+  const beneficiaryRewardCap = 10000
 
   // 1,000,000,000 - total KEEP supply
   //   200,000,000 - 20% of the total supply goes to staker rewards
@@ -50,6 +51,7 @@ describe("ECDSARewards", () => {
     )
 
     await fund(keepToken, rewardsContract, totalRewardsAllocation)
+    await rewardsContract.setBeneficiaryRewardCap(beneficiaryRewardCap)
   })
 
   beforeEach(async () => {

--- a/solidity/test/rewards/TestECDSARewards.js
+++ b/solidity/test/rewards/TestECDSARewards.js
@@ -11,7 +11,7 @@ const chai = require("chai")
 chai.use(require("bn-chai")(BN))
 const expect = chai.expect
 
-describe.only("ECDSARewards", () => {
+describe("ECDSARewards", () => {
   let keepToken
   let tokenStaking
   let keepFactory

--- a/solidity/test/rewards/TestECDSARewards.js
+++ b/solidity/test/rewards/TestECDSARewards.js
@@ -172,7 +172,7 @@ describe("ECDSARewards", () => {
       // First keep was terminated, only the second keep was closed properly.
       // Member receives: 7128 / 3 = 2376 (3 signers per keep)
       const expectedBeneficiaryAllocation = new BN(2376)
-      await assertAllocatedRewards(expectedBeneficiaryAllocation, 0, operators)
+      await assertAllocatedRewards(expectedBeneficiaryAllocation, 0)
 
       // The 178,200,000 - 14,256 = 178,185,744 stays in unallocated
       // rewards and the fact one keep was terminated needs to be reported to
@@ -205,7 +205,7 @@ describe("ECDSARewards", () => {
       }
 
       await rewardsContract.receiveRewards(keepAddresses)
-      await withdrawRewards(0, operators)
+      await withdrawRewards(0)
 
       // Full allocation for the first interval would be
       // 178,200,000 * 4% = 7,128,000.
@@ -244,7 +244,7 @@ describe("ECDSARewards", () => {
       await keep.publicMarkAsClosed()
 
       await rewardsContract.receiveReward(keepAddress)
-      await withdrawRewards(0, operators)
+      await withdrawRewards(0)
 
       // Full allocation for the first interval would be
       // 178,200,000 * 4% = 7,128,000.
@@ -261,7 +261,7 @@ describe("ECDSARewards", () => {
       await keep.publicMarkAsClosed()
 
       await rewardsContract.receiveReward(keepAddress)
-      await withdrawRewards(0, operators)
+      await withdrawRewards(0)
 
       await assertKeepBalanceOfBeneficiaries(expectedBeneficiaryBalance.muln(2))
     })
@@ -280,7 +280,7 @@ describe("ECDSARewards", () => {
 
       await rewardsContract.receiveReward(keepAddress)
 
-      await withdrawRewards(0, operators)
+      await withdrawRewards(0)
 
       for (let i = 0; i < operators.length; i++) {
         await expectRevert(
@@ -306,7 +306,7 @@ describe("ECDSARewards", () => {
 
       await rewardsContract.receiveReward(keepAddress)
 
-      await withdrawRewards(0, operators)
+      await withdrawRewards(0)
 
       await expectRevert(
         rewardsContract.receiveReward(keepAddress),
@@ -331,7 +331,7 @@ describe("ECDSARewards", () => {
       await keep1.publicMarkAsClosed()
 
       await rewardsContract.receiveRewards(keepAddresses)
-      await withdrawRewards(0, operators)
+      await withdrawRewards(0)
 
       // Full allocation for the first interval would be
       // 178,200,000 * 4% = 7,128,000.
@@ -363,7 +363,7 @@ describe("ECDSARewards", () => {
       // keeps created: 10 => 7,128 KEEP per keep
       // member receives: 7,128 / 3 = 2,376 (3 signers per keep)
       await rewardsContract.receiveReward(keepAddress0)
-      await withdrawRewards(0, operators)
+      await withdrawRewards(0)
 
       let expectedBeneficiaryBalance = new BN(2376)
       await assertKeepBalanceOfBeneficiaries(expectedBeneficiaryBalance)
@@ -376,7 +376,7 @@ describe("ECDSARewards", () => {
       await keep1.publicMarkAsClosed()
 
       await rewardsContract.receiveReward(keepAddress1)
-      await withdrawRewards(0, operators)
+      await withdrawRewards(0)
 
       // each member was in 2 properly closed keeps: 2,376 * 2 = 4,752
       expectedBeneficiaryBalance = new BN(4752)
@@ -413,13 +413,13 @@ describe("ECDSARewards", () => {
       // 2,376 * 2 = 4,752
       const expectedBalanceFromTwoKeeps = expectedBeneficiaryBalance.muln(2)
 
-      await assertWithdrawableRewards(expectedBalanceFromTwoKeeps, 0, operators)
-      await assertWithdrawnRewards(new BN(0), 0, operators)
+      await assertWithdrawableRewards(expectedBalanceFromTwoKeeps, 0)
+      await assertWithdrawnRewards(new BN(0), 0)
 
-      await withdrawRewards(0, operators)
+      await withdrawRewards(0)
 
-      await assertWithdrawableRewards(new BN(0), 0, operators)
-      await assertWithdrawnRewards(expectedBalanceFromTwoKeeps, 0, operators)
+      await assertWithdrawableRewards(new BN(0), 0)
+      await assertWithdrawnRewards(expectedBalanceFromTwoKeeps, 0)
     })
   })
 
@@ -439,7 +439,7 @@ describe("ECDSARewards", () => {
     }
   }
 
-  async function assertAllocatedRewards(expectedBalance, interval, operators) {
+  async function assertAllocatedRewards(expectedBalance, interval) {
     const precision = 1
 
     for (let i = 0; i < operators.length; i++) {
@@ -454,7 +454,7 @@ describe("ECDSARewards", () => {
     }
   }
 
-  async function assertWithdrawnRewards(expectedBalance, interval, operators) {
+  async function assertWithdrawnRewards(expectedBalance, interval) {
     const precision = 1
 
     for (let i = 0; i < operators.length; i++) {
@@ -469,11 +469,7 @@ describe("ECDSARewards", () => {
     }
   }
 
-  async function assertWithdrawableRewards(
-    expectedBalance,
-    interval,
-    operators
-  ) {
+  async function assertWithdrawableRewards(expectedBalance, interval) {
     const precision = 1
 
     for (let i = 0; i < operators.length; i++) {
@@ -488,7 +484,7 @@ describe("ECDSARewards", () => {
     }
   }
 
-  async function withdrawRewards(interval, operators) {
+  async function withdrawRewards(interval) {
     for (let i = 0; i < operators.length; i++) {
       await rewardsContract.withdrawRewards(interval, operators[i], {
         from: operators[i],

--- a/solidity/test/rewards/TestECDSARewards.js
+++ b/solidity/test/rewards/TestECDSARewards.js
@@ -308,7 +308,7 @@ describe("ECDSARewards", () => {
       await assertWithdrawnRewards(expectedBalanceFromTwoKeeps, 0, operators)
     })
 
-    it("should cap the maximum reward per keep operator", async () => {
+    it("should cap the maximum reward per keep beneficiary", async () => {
       for (let i = 0; i < 10; i++) {
         await keepFactory.stubOpenKeep(owner, operators, firstIntervalStart)
       }
@@ -335,13 +335,23 @@ describe("ECDSARewards", () => {
       // 178,200,000 * 4% = 7,128,000.
       // Because just 1% of minimum keep quota is met, the allocation is
       // 7,128,000 * 1% = 71,280.
-      // keeps created: 10 => 7,128 KEEP per keep
-      // member receives: 7,128 / 3 = 2,376 (3 signers per keep)
-      // each member was in 5 properly closed keeps: 2,376 * 5 = 11,880
+      // Keeps created: 10 => 7,128 KEEP per keep
+      // Member receives: 7,128 / 3 = 2,376 (3 signers per keep)
+      // Each member was in 5 properly closed keeps: 2,376 * 5 = 11,880
       // 11,880 exceeds the maximum rewards cap per beneficiary, which is 10,000
-      // expected beneficiary balance should be equal to max cap.
+      // Expected beneficiary balance should be equal to max cap.
       const expectedBeneficiaryBalance = new BN(10000)
       await assertKeepBalanceOfBeneficiaries(expectedBeneficiaryBalance)
+
+      // Each beneficiary has a surplus of 11,880 - 10,000 = 1,880 that has to be
+      // returned back to the unallocated pool rewards: 1,880 * 3 = 5,640
+      // Expected unallocated pool: 178,200,000 - 71,280 + 5,640 = 178,134,360
+      const expectedUnallocatedRewards = new BN(178134360)
+      const actualUnallocatedRewards = (
+        await rewardsContract.unallocatedRewards()
+      ).div(tokenDecimalMultiplier)
+
+      expect(actualUnallocatedRewards).to.eq.BN(expectedUnallocatedRewards)
     })
 
     it("should correctly receive rewards from multiple keeps", async () => {


### PR DESCRIPTION
Depends on https://github.com/keep-network/keep-ecdsa/pull/584
Refs #446

Adding tests around the maximum cap rewards per ECDSA keep operator.