### PR TITLE
Adding a test to report terminations for multiple keeps at once

### DIFF
--- a/solidity/contracts/ECDSARewards.sol
+++ b/solidity/contracts/ECDSARewards.sol
@@ -113,6 +113,15 @@ contract ECDSARewards is Rewards {
         }
     }
 
+    /// @notice Report about the terminated keeps in batch. All the allocated
+    /// rewards in these keeps will be returned to the unallocated pool.
+    /// @param keepIdentifiers An array of keep addresses.
+    function reportTerminations(bytes32[] memory keepIdentifiers) public {
+        for (uint256 i = 0; i < keepIdentifiers.length; i++) {
+            reportTermination(keepIdentifiers[i]);
+        }
+    }
+
     function _getKeepCount() internal view returns (uint256) {
         return factory.getKeepCount();
     }

--- a/solidity/contracts/ECDSARewards.sol
+++ b/solidity/contracts/ECDSARewards.sol
@@ -102,26 +102,6 @@ contract ECDSARewards is Rewards {
         factory = BondedECDSAKeepFactory(_factoryAddress);
     }
 
-    /// @notice Stakers can receive KEEP rewards from multiple keeps of their choice
-    /// in one transaction to reduce total cost comparing to single calls for rewards.
-    /// It is a caller responsibility to determine the cost and consumed gas when
-    /// receiving rewards from multiple keeps.
-    /// @param keepIdentifiers An array of keep addresses.
-    function receiveRewards(bytes32[] memory keepIdentifiers) public {
-        for (uint256 i = 0; i < keepIdentifiers.length; i++) {
-            receiveReward(keepIdentifiers[i]);
-        }
-    }
-
-    /// @notice Report about the terminated keeps in batch. All the allocated
-    /// rewards in these keeps will be returned to the unallocated pool.
-    /// @param keepIdentifiers An array of keep addresses.
-    function reportTerminations(bytes32[] memory keepIdentifiers) public {
-        for (uint256 i = 0; i < keepIdentifiers.length; i++) {
-            reportTermination(keepIdentifiers[i]);
-        }
-    }
-
     function _getKeepCount() internal view returns (uint256) {
         return factory.getKeepCount();
     }

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -942,9 +942,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "1.3.1-pre.3",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.3.1-pre.3.tgz",
-      "integrity": "sha512-QP5rM6CgI0iINYBxfiLZCMjiUIvo421dAsL4yN7g1kZ3iA5NmgVAhA9vCKOIvX/mTPRGEfA896aVmKj1ytUCfQ==",
+      "version": "1.3.1-pre.4",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.3.1-pre.4.tgz",
+      "integrity": "sha512-WrRhbDVlXd7m1HkSm9hzjKRgOj7ZEGZ/b8bTewD+LU2rh0dfxdG5gijzp2T3pyFZ+ofDZ/E7GjbIgVfYc/sYzw==",
       "requires": {
         "@openzeppelin/upgrades": "^2.7.2",
         "openzeppelin-solidity": "2.4.0"

--- a/solidity/test/rewards/TestECDSARewards.js
+++ b/solidity/test/rewards/TestECDSARewards.js
@@ -188,6 +188,57 @@ describe("ECDSARewards", () => {
       expect(unallocatedInKeep).to.eq.BN(178192872) // 178,185,744 + 7,128
     })
 
+    it("should report group terminations in batch", async () => {
+      // Open 5 keeps
+      for (let i = 0; i < 5; i++) {
+        await keepFactory.stubOpenKeep(owner, operators, firstIntervalStart + i)
+      }
+
+      await timeJumpToEndOfIntervalIfApplicable(0)
+
+      const keepTerminatedAddresses = []
+      // Mark 3 keeps as terminated
+      for (let i = 0; i < 3; i++) {
+        const keepTerminatedAddress = await keepFactory.getKeepAtIndex(i)
+        const keepTerminated = await BondedECDSAKeepStub.at(
+          keepTerminatedAddress
+        )
+        await keepTerminated.publicMarkAsTerminated()
+        keepTerminatedAddresses.push(keepTerminatedAddress)
+      }
+
+      const keepClosedAddresses = []
+      // Mark 2 keeps as closed properly
+      for (let i = 3; i < 5; i++) {
+        const keepAddress = await keepFactory.getKeepAtIndex(i)
+        const keep = await BondedECDSAKeepStub.at(keepAddress)
+        await keep.publicMarkAsClosed()
+        keepClosedAddresses.push(keepAddress)
+      }
+
+      await rewardsContract.receiveRewards(keepClosedAddresses)
+
+      // Full allocation for the first interval is 7,128,000 KEEP.
+      // Because just 5 keeps were created, the allocation is:
+      // 7,128,000 * 0.5% = 35,640.
+      // The reward per keep is 35,640 / 5 = 7,128
+      // 178,200,000 - 35,640 = 178,164,360 stays in unallocated rewards
+      let actualUnallocated = await rewardsContract.unallocatedRewards()
+      actual = actualUnallocated.div(tokenDecimalMultiplier)
+      expect(actual).to.eq.BN(178164360)
+
+      // The fact that three keeps were terminated needs to be
+      // reported to recalculate the unallocated amount.
+      await rewardsContract.reportTerminations(keepTerminatedAddresses)
+
+      // Rewards returned to the unallocated pool upon termination:
+      // 7,128 * 3 = 21,384
+      actualUnallocated = await rewardsContract.unallocatedRewards()
+      actual = actualUnallocated.div(tokenDecimalMultiplier)
+      // 178,164,360 + 21,384 = 178,185,744
+      expect(actual).to.eq.BN(178185744)
+    })
+
     it("should cap the maximum reward per beneficiary", async () => {
       for (let i = 0; i < 10; i++) {
         await keepFactory.stubOpenKeep(owner, operators, firstIntervalStart)


### PR DESCRIPTION
Refs #446

Adding the functionality to report termination of multiple keeps with one call. This should save transactions cost.