### PR TITLE
ECDSA staker rewards cap set to 3M keep tokens per interval

### DIFF
--- a/solidity/contracts/ECDSARewards.sol
+++ b/solidity/contracts/ECDSARewards.sol
@@ -49,6 +49,10 @@ import "./BondedECDSAKeep.sol";
 /// Reporting a terminated keep returns its allocated reward to the pool of
 /// unallocated rewards.
 contract ECDSARewards is Rewards {
+    // The amount of tokens each individual beneficiary address
+    // can receive in a single interval is capped to 3M tokens.
+    uint256 public beneficiaryRewardCap = 3000000 * 10**18;
+
     // BondedECDSAKeepFactory deployment date, Sep-14-2020 interval started.
     // https://etherscan.io/address/0xA7d9E842EFB252389d613dA88EDa3731512e40bD
     uint256 internal constant ecdsaFirstIntervalStart = 1600041600;
@@ -87,10 +91,6 @@ contract ECDSARewards is Rewards {
 
     uint256 internal constant minimumECDSAKeepsPerInterval = 1000;
 
-    // The amount of tokens each individual beneficiary address
-    // can receive in a single interval is capped.
-    // TODO: set actual value
-    uint256 internal beneficiaryRewardCap = 400000 * 10**18;
     // The total amount of rewards allocated to the given beneficiary address,
     // in the given interval.
     // `allocatedRewards[beneficiary][interval] -> amount`

--- a/solidity/contracts/test/ECDSARewardsStub.sol
+++ b/solidity/contracts/test/ECDSARewardsStub.sol
@@ -6,8 +6,6 @@ import "../../contracts/ECDSARewards.sol";
 /// @dev This contract is for testing purposes only.
 contract ECDSARewardsStub is ECDSARewards {
 
-    uint256 internal tokenDecimalMultiplier = 10**18;
-
     constructor(
         address _token,
         address payable _factoryAddress,
@@ -22,6 +20,6 @@ contract ECDSARewardsStub is ECDSARewards {
     {}
 
     function setBeneficiaryRewardCap(uint256 _beneficiaryRewardCap) public {
-        beneficiaryRewardCap = _beneficiaryRewardCap.mul(tokenDecimalMultiplier);
+        beneficiaryRewardCap = _beneficiaryRewardCap;
     }
 }

--- a/solidity/test/rewards/TestECDSARewards.js
+++ b/solidity/test/rewards/TestECDSARewards.js
@@ -23,7 +23,6 @@ describe("ECDSARewards", () => {
 
   const tokenDecimalMultiplier = web3.utils.toBN(10).pow(web3.utils.toBN(18))
   const firstIntervalStart = 1600041600 // Sep 14 2020
-  const beneficiaryRewardCap = 10000
 
   // 1,000,000,000 - total KEEP supply
   //   200,000,000 - 20% of the total supply goes to staker rewards
@@ -51,7 +50,6 @@ describe("ECDSARewards", () => {
     )
 
     await fund(keepToken, rewardsContract, totalRewardsAllocation)
-    await rewardsContract.setBeneficiaryRewardCap(beneficiaryRewardCap)
   })
 
   beforeEach(async () => {
@@ -240,6 +238,12 @@ describe("ECDSARewards", () => {
     })
 
     it("should cap the maximum reward per beneficiary", async () => {
+      // There is currently no way to implement a test with the original
+      // 3M KEEP cap for beneficiary given block gas limit and test execution
+      // time. Hence, we set the limit to 10k KEEP for test purposes.
+      const rewardsCap = web3.utils.toBN(10000).mul(tokenDecimalMultiplier)
+      await rewardsContract.setBeneficiaryRewardCap(rewardsCap)
+
       for (let i = 0; i < 10; i++) {
         await keepFactory.stubOpenKeep(owner, operators, firstIntervalStart)
       }
@@ -279,6 +283,11 @@ describe("ECDSARewards", () => {
       ).div(tokenDecimalMultiplier)
 
       expect(actualUnallocatedRewards).to.eq.BN(expectedUnallocatedRewards)
+    })
+
+    it("should keep per-interval beneficiary reward cap at 3M KEEP", async () => {
+      const cap = await rewardsContract.beneficiaryRewardCap()
+      expect(cap).to.eq.BN(web3.utils.toBN(3000000).mul(tokenDecimalMultiplier))
     })
   })
 


### PR DESCRIPTION
Refs #446

An individual beneficiary can not receive more than 3M KEEP tokens in a single interval. This amount is about 20% of the second interval full allocation.

I have made `beneficiaryRewardCap` a public constant. It's a different situation to the rest of the constants defined in `ECDSARewards` as they are only used as constructor parameters for the parent contract.

Added test to make sure this value is set at `3M * 10^18` just to prevent accidental change and ensure the order of operators is correct.