### PR TITLE
Improve Ethereum client wrappers adoption

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/gogo/protobuf v1.3.1
 	github.com/google/gofuzz v1.1.0
 	github.com/ipfs/go-log v1.0.4
-	github.com/keep-network/keep-common v1.2.1-0.20201020114759-19c123cbd4f4
+	github.com/keep-network/keep-common v1.2.1-0.20201103151750-c52f5d480c10
 	github.com/keep-network/keep-core v1.3.0
 	github.com/keep-network/tbtc v1.1.1-0.20201026093513-cb9246987718
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -335,6 +335,8 @@ github.com/keep-network/keep-common v1.2.0 h1:hVd2tTd7vL+9CQP5Ntk5kjs+GYvkgrRNBc
 github.com/keep-network/keep-common v1.2.0/go.mod h1:emxogTbBdey7M3jOzfxZOdfn139kN2mI2b2wA6AHKKo=
 github.com/keep-network/keep-common v1.2.1-0.20201020114759-19c123cbd4f4 h1:CivupPSFswHACua5xZGKdeYxsCQ2cmRomTIBh8kfk70=
 github.com/keep-network/keep-common v1.2.1-0.20201020114759-19c123cbd4f4/go.mod h1:emxogTbBdey7M3jOzfxZOdfn139kN2mI2b2wA6AHKKo=
+github.com/keep-network/keep-common v1.2.1-0.20201103151750-c52f5d480c10 h1:KuZP1ArRAK1X4PunfteJX+QnP/XSfvfmi/ZR2a6kXTU=
+github.com/keep-network/keep-common v1.2.1-0.20201103151750-c52f5d480c10/go.mod h1:emxogTbBdey7M3jOzfxZOdfn139kN2mI2b2wA6AHKKo=
 github.com/keep-network/keep-core v1.3.0 h1:7Tb33EmO/ntHOEbOiYciRlBhqu5Ln6KemWCaYK0Z6LA=
 github.com/keep-network/keep-core v1.3.0/go.mod h1:1KsSSTQoN754TrFLW7kLy50pOG2CQ4BOfnJqdvEG7FA=
 github.com/keep-network/tbtc v1.1.1-0.20201026093513-cb9246987718 h1:/ZNMBY7y6hfzCYA8mgtHnspGO26OmWV3sDehyGnqRyY=

--- a/pkg/chain/ethereum/ethereum.go
+++ b/pkg/chain/ethereum/ethereum.go
@@ -2,6 +2,7 @@
 package ethereum
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 	"sort"
@@ -560,5 +561,13 @@ func (ec *EthereumChain) PastSignatureSubmittedEvents(
 
 // BlockTimestamp returns given block's timestamp.
 func (ec *EthereumChain) BlockTimestamp(blockNumber *big.Int) (uint64, error) {
-	return ec.blockTimestampFn(blockNumber)
+	ctx, cancelCtx := context.WithTimeout(context.Background(), 1*time.Minute)
+	defer cancelCtx()
+
+	header, err := ec.client.HeaderByNumber(ctx, blockNumber)
+	if err != nil {
+		return 0, err
+	}
+
+	return header.Time, nil
 }


### PR DESCRIPTION
Refs: #574
Depends on: #585
Depends on: https://github.com/keep-network/keep-common/pull/55

Changed the way Ethereum client is used in the Ethereum chain implementation. Specifically, got rid of the bare client
usages. Instead of that, the wrapped client which provides logging and rate-limiting capabilities is used everywhere.