### PR TITLE
Release solidity/v1.3.0

### DIFF
--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "1.3.0-pre.0",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -942,9 +942,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "1.3.1-pre.5",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.3.1-pre.5.tgz",
-      "integrity": "sha512-zV1LyfWZeMS2tnLRKyL8UFCTD2MnvK92ta+U+iAz3QPqIE20MI+33hkKFMFVJxI7zIQJqNJj18eEUR8m4fG9Iw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.4.0.tgz",
+      "integrity": "sha512-qKI06lp6J7K2rNMC4dj9ufgH4L+e5NomtHv44M8qhzTK2J8rrUPIURtkTichLToDfMjUAdfSSzXYzeiaVCnaxQ==",
       "requires": {
         "@openzeppelin/upgrades": "^2.7.2",
         "openzeppelin-solidity": "2.4.0"

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "1.3.0",
+  "version": "1.4.0-pre.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -942,9 +942,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.4.0.tgz",
-      "integrity": "sha512-qKI06lp6J7K2rNMC4dj9ufgH4L+e5NomtHv44M8qhzTK2J8rrUPIURtkTichLToDfMjUAdfSSzXYzeiaVCnaxQ==",
+      "version": "1.5.0-pre.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.5.0-pre.0.tgz",
+      "integrity": "sha512-A1tY5TBD0y4q/XbYtOtTlgwzGP/4Lwhm5/fiQd/HJW5xh7m97UkfIOwdn49fJIo/Q3xsBqHASfvm0Fb0b0Zk/w==",
       "requires": {
         "@openzeppelin/upgrades": "^2.7.2",
         "openzeppelin-solidity": "2.4.0"

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "1.3.0-pre.0",
+  "version": "1.3.0",
   "description": "Smart contracts for ECDSA Keep",
   "repository": {
     "type": "git",
@@ -34,8 +34,8 @@
   },
   "homepage": "https://github.com/keep-network/keep-ecdsa",
   "dependencies": {
-    "@keep-network/keep-core": ">1.3.1-pre <1.3.1-rc",
-    "@keep-network/sortition-pools": ">1.2.0-pre <1.2.0-rc",
+    "@keep-network/keep-core": "1.4.0",
+    "@keep-network/sortition-pools": "1.2.0-pre.3",
     "@openzeppelin/upgrades": "^2.7.2",
     "openzeppelin-solidity": "2.3.0"
   },

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "1.3.0",
+  "version": "1.4.0-pre.0",
   "description": "Smart contracts for ECDSA Keep",
   "repository": {
     "type": "git",
@@ -34,8 +34,8 @@
   },
   "homepage": "https://github.com/keep-network/keep-ecdsa",
   "dependencies": {
-    "@keep-network/keep-core": "1.4.0",
-    "@keep-network/sortition-pools": "1.2.0-pre.3",
+    "@keep-network/keep-core": ">1.5.0-pre <1.5.0-rc",
+    "@keep-network/sortition-pools": ">1.2.0-pre <1.2.0-rc",
     "@openzeppelin/upgrades": "^2.7.2",
     "openzeppelin-solidity": "2.3.0"
   },


### PR DESCRIPTION
f9331e2 which is tagged as `solidity/v1.3.0`: 
- Bumps up version in `package.json` to `1.3.0`
- Sets `keep-core` dependency to `1.4.0`
- Sets `sortition-pools` dependency to `1.2.0-pre.3` as there is an independent workstream there for ETH-only staking and a part of `keep-ecdsa` codebase depends on it.

b5c8281 gets the version and dependencies back into development mode:
- Bumps up version in `package.json` to `1.4.0-pre.0`
- Sets `keep-core` dependency to `>1.5.0-pre <1.5.0-rc`
- Brings back `sortition-pools` dependency to `>1.2.0-pre <1.2.0-rc`