### PR TITLE
Adjust ECDSA keep rewards by lifespan

### DIFF
--- a/solidity/contracts/ECDSARewards.sol
+++ b/solidity/contracts/ECDSARewards.sol
@@ -196,12 +196,18 @@ contract ECDSARewards is Rewards {
     function sendHeartbeat(bytes32 _keep) public {
         require(!_isClosed(_keep),"Keep is closed");
         require(!_isTerminated(_keep), "Keep is terminated");
+        address keepAddress = toAddress(_keep);
 
         // Assumes bonds don't change while the keep is active
-        BondedECDSAKeep keep = BondedECDSAKeep(toAddress(_keep));
-        uint128 keepBond = uint128(keep.checkBondAmount());
+        Heartbeat previousHeartbeat = keepHeartbeats[keepAddress];
+        uint128 keepBond = previousHeartbeat.bondValue;
 
-        keepHeartbeats[address(keep)] = Heartbeat(
+        if (keepBond == 0) {
+            BondedECDSAKeep keep = BondedECDSAKeep(keepAddress);
+            keepBond = uint128(keep.checkBondAmount());
+        }
+
+        keepHeartbeats[keepAddress] = Heartbeat(
             uint128(block.timestamp),
             keepBond
         );

--- a/solidity/contracts/ECDSARewards.sol
+++ b/solidity/contracts/ECDSARewards.sol
@@ -195,7 +195,7 @@ contract ECDSARewards is Rewards {
 
     function getHeartbeat(bytes32 _keep) public view returns (uint256, uint256) {
         address keepAddress = toAddress(_keep);
-        Heartbeat recordedHeartbeat = keepHeartbeats[keepAddress];
+        Heartbeat memory recordedHeartbeat = keepHeartbeats[keepAddress];
         uint256 timestamp = uint256(recordedHeartbeat.timestamp);
         uint256 bondValue = uint256(recordedHeartbeat.bondValue);
         return (timestamp, bondValue);
@@ -207,7 +207,7 @@ contract ECDSARewards is Rewards {
         address keepAddress = toAddress(_keep);
 
         // Assumes bonds don't change while the keep is active
-        Heartbeat previousHeartbeat = keepHeartbeats[keepAddress];
+        Heartbeat memory previousHeartbeat = keepHeartbeats[keepAddress];
         uint128 keepBond = previousHeartbeat.bondValue;
 
         if (keepBond == 0) {

--- a/solidity/contracts/ECDSARewards.sol
+++ b/solidity/contracts/ECDSARewards.sol
@@ -193,6 +193,14 @@ contract ECDSARewards is Rewards {
         token.safeTransfer(beneficiary, withdrawableRewards);
     }
 
+    function getHeartbeat(bytes32 _keep) public view returns (uint256, uint256) {
+        address keepAddress = toAddress(_keep);
+        Heartbeat recordedHeartbeat = keepHeartbeats[keepAddress];
+        uint256 timestamp = uint256(recordedHeartbeat.timestamp);
+        uint256 bondValue = uint256(recordedHeartbeat.bondValue);
+        return (timestamp, bondValue);
+    }
+
     function sendHeartbeat(bytes32 _keep) public {
         require(!_isClosed(_keep),"Keep is closed");
         require(!_isTerminated(_keep), "Keep is terminated");


### PR DESCRIPTION
Refs: #602

Reward includes a constant fraction that is paid to all happily closed keeps, and a variable fraction which is paid based on the lifespan of the keep.

Keep lifespans are estimated by having users report closed keeps. If the closure of a keep has not been reported, assume it lasted long enough to be eligible for maximum reward.