### PR TITLE
TBTC extension optimizations

### DIFF
--- a/pkg/chain/local/tbtc.go
+++ b/pkg/chain/local/tbtc.go
@@ -46,6 +46,7 @@ type localChainLogger struct {
 	retrieveSignerPubkeyCalls       int
 	provideRedemptionSignatureCalls int
 	increaseRedemptionFeeCalls      int
+	keepAddressCalls                int
 }
 
 func (lcl *localChainLogger) logRetrieveSignerPubkeyCall() {
@@ -64,12 +65,20 @@ func (lcl *localChainLogger) ProvideRedemptionSignatureCalls() int {
 	return lcl.provideRedemptionSignatureCalls
 }
 
-func (lcl *localChainLogger) logIncreaseRedemptionFeeCalls() {
+func (lcl *localChainLogger) logIncreaseRedemptionFeeCall() {
 	lcl.increaseRedemptionFeeCalls++
 }
 
 func (lcl *localChainLogger) IncreaseRedemptionFeeCalls() int {
 	return lcl.increaseRedemptionFeeCalls
+}
+
+func (lcl *localChainLogger) logKeepAddressCall() {
+	lcl.keepAddressCalls++
+}
+
+func (lcl *localChainLogger) KeepAddressCalls() int {
+	return lcl.keepAddressCalls
 }
 
 type TBTCLocalChain struct {
@@ -302,6 +311,8 @@ func (tlc *TBTCLocalChain) KeepAddress(depositAddress string) (string, error) {
 	tlc.tbtcLocalChainMutex.Lock()
 	defer tlc.tbtcLocalChainMutex.Unlock()
 
+	tlc.logger.logKeepAddressCall()
+
 	deposit, ok := tlc.deposits[depositAddress]
 	if !ok {
 		return "", fmt.Errorf("no deposit with address [%v]", depositAddress)
@@ -415,7 +426,7 @@ func (tlc *TBTCLocalChain) IncreaseRedemptionFee(
 	tlc.tbtcLocalChainMutex.Lock()
 	defer tlc.tbtcLocalChainMutex.Unlock()
 
-	tlc.logger.logIncreaseRedemptionFeeCalls()
+	tlc.logger.logIncreaseRedemptionFeeCall()
 
 	if _, exists := tlc.alwaysFailingTransactions["IncreaseRedemptionFee"]; exists {
 		return fmt.Errorf("always failing transaction")

--- a/pkg/extensions/tbtc/tbtc.go
+++ b/pkg/extensions/tbtc/tbtc.go
@@ -26,10 +26,23 @@ import (
 var logger = log.Logger("tbtc-extension")
 
 const (
-	maxActAttempts               = 3
-	pastEventsLookbackBlocks     = 10000
-	defaultBlockConfirmations    = 12
-	monitoringCachePeriod        = 24 * time.Hour
+	// Maximum number of action attempts before giving up and returning
+	// a monitoring error.
+	maxActAttempts = 3
+
+	// Determines how many blocks from the past should be included
+	// during the past events lookup.
+	pastEventsLookbackBlocks = 10000
+
+	// Number of blocks which should elapse before confirming
+	// the given chain state expectations.
+	defaultBlockConfirmations = 12
+
+	// Determines how long the monitoring cache will maintain
+	// its entries.
+	monitoringCachePeriod = 24 * time.Hour
+
+	// Used to calculate the action delay factor for the given signer index.
 	defaultSignerActionDelayStep = 5 * time.Minute
 )
 

--- a/pkg/extensions/tbtc/tbtc.go
+++ b/pkg/extensions/tbtc/tbtc.go
@@ -38,11 +38,13 @@ const (
 	// the given chain state expectations.
 	defaultBlockConfirmations = 12
 
-	// Determines how long the monitoring cache will maintain
-	// its entries.
+	// Determines how long the monitoring cache will maintain its entries about
+	// which deposits should be monitored by this client instance.
 	monitoringCachePeriod = 24 * time.Hour
 
-	// Used to calculate the action delay factor for the given signer index.
+	// Used to calculate the action delay factor for the given signer index
+	// to avoid all signers executing the same action for deposit at the
+	// same time.
 	defaultSignerActionDelayStep = 5 * time.Minute
 )
 
@@ -817,7 +819,8 @@ func (t *tbtc) shouldMonitorDeposit(depositAddress string) bool {
 	signerIndex, err := t.getSignerIndex(depositAddress)
 	if err != nil {
 		logger.Errorf(
-			"could not get signer index for deposit [%v]: [%v]",
+			"could not check if deposit [%v] should be monitored: "+
+				"failed to get signer index: [%v]",
 			depositAddress,
 			err,
 		)

--- a/pkg/extensions/tbtc/tbtc_test.go
+++ b/pkg/extensions/tbtc/tbtc_test.go
@@ -51,7 +51,10 @@ func TestRetrievePubkey_TimeoutElapsed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	signers := append(local.RandomSigningGroup(2), tbtcChain.Address())
+	signers := append(
+		[]common.Address{tbtcChain.Address()},
+		local.RandomSigningGroup(2)...,
+	)
 
 	tbtcChain.CreateDeposit(depositAddress, signers)
 
@@ -112,7 +115,10 @@ func TestRetrievePubkey_StopEventOccurred(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	signers := append(local.RandomSigningGroup(2), tbtcChain.Address())
+	signers := append(
+		[]common.Address{tbtcChain.Address()},
+		local.RandomSigningGroup(2)...,
+	)
 
 	tbtcChain.CreateDeposit(depositAddress, signers)
 
@@ -183,7 +189,10 @@ func TestRetrievePubkey_KeepClosedEventOccurred(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	signers := append(local.RandomSigningGroup(2), tbtcChain.Address())
+	signers := append(
+		[]common.Address{tbtcChain.Address()},
+		local.RandomSigningGroup(2)...,
+	)
 
 	tbtcChain.CreateDeposit(depositAddress, signers)
 
@@ -251,7 +260,10 @@ func TestRetrievePubkey_KeepTerminatedEventOccurred(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	signers := append(local.RandomSigningGroup(2), tbtcChain.Address())
+	signers := append(
+		[]common.Address{tbtcChain.Address()},
+		local.RandomSigningGroup(2)...,
+	)
 
 	tbtcChain.CreateDeposit(depositAddress, signers)
 
@@ -319,7 +331,10 @@ func TestRetrievePubkey_ActionFailed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	signers := append(local.RandomSigningGroup(2), tbtcChain.Address())
+	signers := append(
+		[]common.Address{tbtcChain.Address()},
+		local.RandomSigningGroup(2)...,
+	)
 
 	tbtcChain.CreateDeposit(depositAddress, signers)
 
@@ -363,7 +378,10 @@ func TestRetrievePubkey_ContextCancelled_WithoutWorkingMonitoring(t *testing.T) 
 	// cancel the context before any start event occurs
 	cancelCtx()
 
-	signers := append(local.RandomSigningGroup(2), tbtcChain.Address())
+	signers := append(
+		[]common.Address{tbtcChain.Address()},
+		local.RandomSigningGroup(2)...,
+	)
 
 	tbtcChain.CreateDeposit(depositAddress, signers)
 
@@ -401,7 +419,10 @@ func TestRetrievePubkey_ContextCancelled_WithWorkingMonitoring(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	signers := append(local.RandomSigningGroup(2), tbtcChain.Address())
+	signers := append(
+		[]common.Address{tbtcChain.Address()},
+		local.RandomSigningGroup(2)...,
+	)
 
 	tbtcChain.CreateDeposit(depositAddress, signers)
 
@@ -487,7 +508,10 @@ func TestProvideRedemptionSignature_TimeoutElapsed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	signers := append(local.RandomSigningGroup(2), tbtcChain.Address())
+	signers := append(
+		[]common.Address{tbtcChain.Address()},
+		local.RandomSigningGroup(2)...,
+	)
 
 	tbtcChain.CreateDeposit(depositAddress, signers)
 
@@ -563,7 +587,10 @@ func TestProvideRedemptionSignature_StopEventOccurred_DepositGotRedemptionSignat
 		t.Fatal(err)
 	}
 
-	signers := append(local.RandomSigningGroup(2), tbtcChain.Address())
+	signers := append(
+		[]common.Address{tbtcChain.Address()},
+		local.RandomSigningGroup(2)...,
+	)
 
 	tbtcChain.CreateDeposit(depositAddress, signers)
 
@@ -654,7 +681,10 @@ func TestProvideRedemptionSignature_StopEventOccurred_DepositRedeemed(
 		t.Fatal(err)
 	}
 
-	signers := append(local.RandomSigningGroup(2), tbtcChain.Address())
+	signers := append(
+		[]common.Address{tbtcChain.Address()},
+		local.RandomSigningGroup(2)...,
+	)
 
 	tbtcChain.CreateDeposit(depositAddress, signers)
 
@@ -736,7 +766,10 @@ func TestProvideRedemptionSignature_KeepClosedEventOccurred(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	signers := append(local.RandomSigningGroup(2), tbtcChain.Address())
+	signers := append(
+		[]common.Address{tbtcChain.Address()},
+		local.RandomSigningGroup(2)...,
+	)
 
 	tbtcChain.CreateDeposit(depositAddress, signers)
 
@@ -815,7 +848,10 @@ func TestProvideRedemptionSignature_KeepTerminatedEventOccurred(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	signers := append(local.RandomSigningGroup(2), tbtcChain.Address())
+	signers := append(
+		[]common.Address{tbtcChain.Address()},
+		local.RandomSigningGroup(2)...,
+	)
 
 	tbtcChain.CreateDeposit(depositAddress, signers)
 
@@ -894,7 +930,10 @@ func TestProvideRedemptionSignature_ActionFailed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	signers := append(local.RandomSigningGroup(2), tbtcChain.Address())
+	signers := append(
+		[]common.Address{tbtcChain.Address()},
+		local.RandomSigningGroup(2)...,
+	)
 
 	tbtcChain.CreateDeposit(depositAddress, signers)
 
@@ -956,7 +995,10 @@ func TestProvideRedemptionSignature_ContextCancelled_WithoutWorkingMonitoring(
 	// cancel the context before any start event occurs
 	cancelCtx()
 
-	signers := append(local.RandomSigningGroup(2), tbtcChain.Address())
+	signers := append(
+		[]common.Address{tbtcChain.Address()},
+		local.RandomSigningGroup(2)...,
+	)
 
 	tbtcChain.CreateDeposit(depositAddress, signers)
 
@@ -1007,7 +1049,10 @@ func TestProvideRedemptionSignature_ContextCancelled_WithWorkingMonitoring(
 		t.Fatal(err)
 	}
 
-	signers := append(local.RandomSigningGroup(2), tbtcChain.Address())
+	signers := append(
+		[]common.Address{tbtcChain.Address()},
+		local.RandomSigningGroup(2)...,
+	)
 
 	tbtcChain.CreateDeposit(depositAddress, signers)
 
@@ -1120,7 +1165,10 @@ func TestProvideRedemptionProof_TimeoutElapsed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	signers := append(local.RandomSigningGroup(2), tbtcChain.Address())
+	signers := append(
+		[]common.Address{tbtcChain.Address()},
+		local.RandomSigningGroup(2)...,
+	)
 
 	tbtcChain.CreateDeposit(depositAddress, signers)
 
@@ -1214,7 +1262,10 @@ func TestProvideRedemptionProof_StopEventOccurred_DepositRedemptionRequested(
 		t.Fatal(err)
 	}
 
-	signers := append(local.RandomSigningGroup(2), tbtcChain.Address())
+	signers := append(
+		[]common.Address{tbtcChain.Address()},
+		local.RandomSigningGroup(2)...,
+	)
 
 	tbtcChain.CreateDeposit(depositAddress, signers)
 
@@ -1325,7 +1376,10 @@ func TestProvideRedemptionProof_StopEventOccurred_DepositRedeemed(
 		t.Fatal(err)
 	}
 
-	signers := append(local.RandomSigningGroup(2), tbtcChain.Address())
+	signers := append(
+		[]common.Address{tbtcChain.Address()},
+		local.RandomSigningGroup(2)...,
+	)
 
 	tbtcChain.CreateDeposit(depositAddress, signers)
 
@@ -1416,7 +1470,10 @@ func TestProvideRedemptionProof_KeepClosedEventOccurred(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	signers := append(local.RandomSigningGroup(2), tbtcChain.Address())
+	signers := append(
+		[]common.Address{tbtcChain.Address()},
+		local.RandomSigningGroup(2)...,
+	)
 
 	tbtcChain.CreateDeposit(depositAddress, signers)
 
@@ -1512,7 +1569,10 @@ func TestProvideRedemptionProof_KeepTerminatedEventOccurred(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	signers := append(local.RandomSigningGroup(2), tbtcChain.Address())
+	signers := append(
+		[]common.Address{tbtcChain.Address()},
+		local.RandomSigningGroup(2)...,
+	)
 
 	tbtcChain.CreateDeposit(depositAddress, signers)
 
@@ -1608,7 +1668,10 @@ func TestProvideRedemptionProof_ActionFailed(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	signers := append(local.RandomSigningGroup(2), tbtcChain.Address())
+	signers := append(
+		[]common.Address{tbtcChain.Address()},
+		local.RandomSigningGroup(2)...,
+	)
 
 	tbtcChain.CreateDeposit(depositAddress, signers)
 
@@ -1679,7 +1742,10 @@ func TestProvideRedemptionProof_ContextCancelled_WithoutWorkingMonitoring(
 	// cancel the context before any start event occurs
 	cancelCtx()
 
-	signers := append(local.RandomSigningGroup(2), tbtcChain.Address())
+	signers := append(
+		[]common.Address{tbtcChain.Address()},
+		local.RandomSigningGroup(2)...,
+	)
 
 	tbtcChain.CreateDeposit(depositAddress, signers)
 
@@ -1744,7 +1810,10 @@ func TestProvideRedemptionProof_ContextCancelled_WithWorkingMonitoring(
 		t.Fatal(err)
 	}
 
-	signers := append(local.RandomSigningGroup(2), tbtcChain.Address())
+	signers := append(
+		[]common.Address{tbtcChain.Address()},
+		local.RandomSigningGroup(2)...,
+	)
 
 	tbtcChain.CreateDeposit(depositAddress, signers)
 


### PR DESCRIPTION
Refs: #574
Depends on: https://github.com/keep-network/keep-ecdsa/pull/592

Here we add some TBTC extension optimizations that should reduce costs related to Ethereum integration. Specifically:

- We introduce a time cache for the monitoring filter. Determining whether a deposit should be tracked requires two ETH calls. This check is performed for each deposit multiple times as a response to monitored state transition events and all duplicates of those events. This can result in a significant number of unnecessary ETH calls. Introducing a time cache here should greatly reduce the number of calls.
- We implement a signer-based action delay factor. Currently, all monitoring signers act at the same time. As result, only the first transaction is always successful while the rest revert and burn some amount of gas by the way. The change introduced here forces each signer to wait an additional time, according to its signer index, before acting. This should prevent other signers to act if a successful action has been already made.