### PR TITLE
Validate operator and authorizer for zero address

### DIFF
--- a/solidity/contracts/fully-backed/FullyBackedBonding.sol
+++ b/solidity/contracts/fully-backed/FullyBackedBonding.sol
@@ -83,6 +83,9 @@ contract FullyBackedBonding is
     ) external payable {
         address owner = msg.sender;
 
+        require(operator != address(0), "Invalid operator address");
+        require(authorizer != address(0), "Invalid authorizer address");
+
         require(
             operators[operator].owner == address(0),
             "Operator already in use"

--- a/solidity/test/FullyBackedBondingTest.js
+++ b/solidity/test/FullyBackedBondingTest.js
@@ -6,6 +6,7 @@ const FullyBackedBonding = contract.fromArtifact("FullyBackedBonding")
 const TestEtherReceiver = contract.fromArtifact("TestEtherReceiver")
 
 const {expectEvent, expectRevert, time} = require("@openzeppelin/test-helpers")
+const {ZERO_ADDRESS} = require("@openzeppelin/test-helpers/src/constants")
 
 const BN = web3.utils.BN
 
@@ -189,6 +190,36 @@ describe("FullyBackedBonding", function () {
         from: owner,
         value: minimumDelegationValue,
       })
+    })
+
+    it("reverts if zero address for operator provided", async () => {
+      await expectRevert(
+        bonding.delegate(ZERO_ADDRESS, beneficiary, authorizer, {
+          from: owner,
+          value: minimumDelegationValue,
+        }),
+        "Invalid operator address"
+      )
+    })
+
+    it("reverts if zero address for beneficiary provided", async () => {
+      await expectRevert(
+        bonding.delegate(operator, ZERO_ADDRESS, authorizer, {
+          from: owner,
+          value: minimumDelegationValue,
+        }),
+        "Beneficiary not defined for the operator"
+      )
+    })
+
+    it("reverts if zero address for authorizer provided", async () => {
+      await expectRevert(
+        bonding.delegate(operator, beneficiary, ZERO_ADDRESS, {
+          from: owner,
+          value: minimumDelegationValue,
+        }),
+        "Invalid authorizer address"
+      )
     })
 
     it("reverts if operator is already in use", async () => {


### PR DESCRIPTION
Added validation for operator and authorizer addresses provided on
delegation. We don't allow the user to provide zero addresses as it
doesn't make sense. We are already validating the same for the beneficiary
address in the deposit function.