### PR TITLE
[Backport] Let the client start with no minimum stake

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -127,7 +127,7 @@ func Start(c *cli.Context) error {
 		return fmt.Errorf("could not check the stake: [%v]", err)
 	}
 	if !hasMinimumStake {
-		return fmt.Errorf(
+		logger.Errorf(
 			"no minimum KEEP stake or operator is not authorized to use it; " +
 				"please make sure the operator address in the configuration " +
 				"is correct and it has KEEP tokens delegated and the operator " +


### PR DESCRIPTION
This PR is a backport of `v1.4.1` fix done on `releases/v1.4` release branch in PR https://github.com/keep-network/keep-ecdsa/pull/614

If the client has no minimum stake we now print an error instead of exiting. Operators whose stake dropped below the minimum as a result of slashing but that are still in active keeps, should be able to run and operate their nodes normally.