### PR TITLE
Add signer publication delay

### DIFF
--- a/pkg/extensions/tbtc/tbtc.go
+++ b/pkg/extensions/tbtc/tbtc.go
@@ -879,6 +879,11 @@ func (t *tbtc) getSignerActionDelay(
 		return 0, err
 	}
 
+	// just in case this function is not invoked in the right context
+	if signerIndex < 0 {
+		return 0, fmt.Errorf("signer index is less than zero")
+	}
+
 	return time.Duration(signerIndex) * t.signerActionDelayStep, nil
 }
 

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -457,8 +457,9 @@ func (n *Node) waitSignerPublicationDelay(
 	signerIndex, err := n.getSignerIndex(keepAddress)
 	if err != nil {
 		logger.Error(
-			"could not determine signer publication delay: [%v]; "+
-				"signer publication delay will not be preserved",
+			"could not determine signer publication delay for keep [%s]: "+
+				"[%v]; signer publication delay will not be preserved",
+			keepAddress.String(),
 			err,
 		)
 		return
@@ -467,15 +468,22 @@ func (n *Node) waitSignerPublicationDelay(
 	// just in case this function is not invoked in the right context
 	if signerIndex < 0 {
 		logger.Error(
-			"could not determine signer publication delay: "+
+			"could not determine signer publication delay for keep [%s]: "+
 				"[signer index is less than zero]; "+
 				"signer publication delay will not be preserved",
+			keepAddress.String(),
 			err,
 		)
 		return
 	}
 
 	delay := time.Duration(signerIndex) * signerPublicationDelayStep
+
+	logger.Infof(
+		"waiting [%v] before publishing signature for keep [%s]",
+		delay,
+		keepAddress.String(),
+	)
 
 	time.Sleep(delay)
 }

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -372,11 +372,6 @@ func (n *Node) publishSignature(
 		// and there are enough confirmations from the chain.
 		// We are fine, leaving.
 		if !isAwaitingSignature && n.confirmSignature(keepAddress, digest) {
-			logger.Infof(
-				"signature for keep [%s] already submitted: [%+x]",
-				keepAddress.String(),
-				digest,
-			)
 			return nil
 		}
 
@@ -404,11 +399,6 @@ func (n *Node) publishSignature(
 			// confirmations from the chain before making a decision about
 			// leaving the submission process.
 			if !isAwaitingSignature && n.confirmSignature(keepAddress, digest) {
-				logger.Infof(
-					"signature for keep [%s] already submitted: [%+x]",
-					keepAddress.String(),
-					digest,
-				)
 				return nil
 			}
 


### PR DESCRIPTION
Closes:  #553
Depends on: #610

This PR introduces a delay mechanism that forces signers to wait an amount of time before publishing the signature for a given keep. The value of the delay is the product of the signer index and a constant step (5 minutes). So:

- member 0 doesn't wait and start the publication process immediately
- member 1 waits 5 minutes 
- member 2 waits 10 minutes

This change should prevent signers to publish the signature at the same time. Publishing at the same time is not optimal as only the first transaction succeeds while the second and third revert and burn some gas by the way.