### PR TITLE
Staker rewards script: Fetch operators based on ETH deposits

### DIFF
--- a/staker-rewards/rewards.js
+++ b/staker-rewards/rewards.js
@@ -7,6 +7,7 @@ import FraudDetector from "./lib/fraud-detector.js"
 import SLACalculator from "./lib/sla-calculator.js"
 import AssetsCalculator from "./lib/assets-calculator.js"
 import RewardsCalculator from "./lib/rewards-calculator.js"
+import { getPastEvents } from "./lib/contract-helper.js"
 
 async function run() {
   try {
@@ -111,15 +112,13 @@ async function determineIntervalBlockspan(context, interval) {
 }
 
 async function calculateOperatorsRewards(context, interval) {
-  const { cache } = context
-
   const fraudDetector = await FraudDetector.initialize(context)
   const slaCalculator = await SLACalculator.initialize(context, interval)
   const assetsCalculator = await AssetsCalculator.initialize(context, interval)
 
   const operatorsParameters = []
 
-  for (const operator of getOperators(cache)) {
+  for (const operator of await getOperators(context)) {
     const isFraudulent = await fraudDetector.isOperatorFraudulent(operator)
     const operatorSLA = slaCalculator.calculateOperatorSLA(operator)
     const operatorAssets = await assetsCalculator.calculateOperatorAssets(
@@ -156,15 +155,19 @@ async function calculateOperatorsRewards(context, interval) {
   return operatorsSummary
 }
 
-// TODO: Change the way operators are fetched. Currently only the ones which
-//  have members in existing keeps are taken into account. Instead of that,
-//  we should take all operators which are registered in the sorition pool.
-function getOperators(cache) {
+async function getOperators(context) {
+  console.log(`Fetching operators list...`)
+
   const operators = new Set()
 
-  cache
-    .getKeeps()
-    .forEach((keep) => keep.members.forEach((member) => operators.add(member)))
+  const events = await getPastEvents(
+    context.web3,
+    await context.contracts.KeepBonding.deployed(),
+    "UnbondedValueDeposited",
+    context.contracts.factoryDeploymentBlock
+  )
+
+  events.forEach((event) => operators.add(event.returnValues.operator))
 
   return operators
 }


### PR DESCRIPTION
Refs: #602 
Depends on: #632 

The operators list in the staker reward script should be constructed using all unique operators from `UnbondedValueDeposited` events ever emitted. This way all operators who made an ETH deposit are taken into account.