### PR TITLE
Staker Rewards: Minimum stake and unbonded value at interval start checks

### DIFF
--- a/staker-rewards/lib/context.js
+++ b/staker-rewards/lib/context.js
@@ -11,6 +11,7 @@ import TokenStakingJson from "@keep-network/keep-core/artifacts/TokenStaking.jso
 import BondedECDSAKeepFactoryJson from "@keep-network/keep-ecdsa/artifacts/BondedECDSAKeepFactory.json"
 import BondedECDSAKeepJson from "@keep-network/keep-ecdsa/artifacts/BondedECDSAKeep.json"
 import KeepBondingJson from "@keep-network/keep-ecdsa/artifacts/KeepBonding.json"
+import BondedSortitionPoolJson from "@keep-network/keep-ecdsa/artifacts/BondedSortitionPool.json"
 
 const sanctionedApplicationAddress =
   "0xe20A5C79b39bC8C363f0f49ADcFa82C2a01ab64a"
@@ -37,6 +38,8 @@ export default class Context {
 
     const KeepBonding = new Contract(KeepBondingJson, web3)
 
+    const BondedSortitionPool = new Contract(BondedSortitionPoolJson, web3)
+
     const factoryDeploymentBlock = await getDeploymentBlockNumber(
       BondedECDSAKeepFactoryJson,
       web3
@@ -47,6 +50,7 @@ export default class Context {
       BondedECDSAKeepFactory: BondedECDSAKeepFactory,
       BondedECDSAKeep: BondedECDSAKeep,
       KeepBonding: KeepBonding,
+      BondedSortitionPool: BondedSortitionPool,
       sanctionedApplicationAddress: sanctionedApplicationAddress,
       factoryDeploymentBlock: factoryDeploymentBlock,
     }

--- a/staker-rewards/lib/context.js
+++ b/staker-rewards/lib/context.js
@@ -13,7 +13,7 @@ import BondedECDSAKeepJson from "@keep-network/keep-ecdsa/artifacts/BondedECDSAK
 import KeepBondingJson from "@keep-network/keep-ecdsa/artifacts/KeepBonding.json"
 import BondedSortitionPoolJson from "@keep-network/keep-ecdsa/artifacts/BondedSortitionPool.json"
 
-const sanctionedApplicationAddress =
+export const SANCTIONED_APPLICATION_ADDRESS =
   "0xe20A5C79b39bC8C363f0f49ADcFa82C2a01ab64a"
 
 export default class Context {
@@ -51,7 +51,7 @@ export default class Context {
       BondedECDSAKeep: BondedECDSAKeep,
       KeepBonding: KeepBonding,
       BondedSortitionPool: BondedSortitionPool,
-      sanctionedApplicationAddress: sanctionedApplicationAddress,
+      sanctionedApplicationAddress: SANCTIONED_APPLICATION_ADDRESS,
       factoryDeploymentBlock: factoryDeploymentBlock,
     }
 

--- a/staker-rewards/lib/numbers.js
+++ b/staker-rewards/lib/numbers.js
@@ -1,0 +1,6 @@
+import BigNumber from "bignumber.js"
+
+export const decimalPlaces = 2
+
+export const shorten18Decimals = (value) =>
+  new BigNumber(value).dividedBy(new BigNumber(1e18)).toFixed(decimalPlaces)

--- a/staker-rewards/lib/numbers.js
+++ b/staker-rewards/lib/numbers.js
@@ -1,6 +1,7 @@
 import BigNumber from "bignumber.js"
 
 export const decimalPlaces = 2
+export const noDecimalPlaces = 0
 
 export const shorten18Decimals = (value) =>
   new BigNumber(value).dividedBy(new BigNumber(1e18)).toFixed(decimalPlaces)

--- a/staker-rewards/lib/requirements.js
+++ b/staker-rewards/lib/requirements.js
@@ -239,7 +239,7 @@ export default class Requirements {
 
   // If the operator has at least minimum unbonded value available they have
   // to be registered in the sortition pool. Operators who are not in the sortition
-  // pool because all of their ether is locked are still getting rewards because
+  // pool because all of their ether is bonded are still getting rewards because
   // that ether is still under the system’s management.
   async checkWasInPoolIfRequiredAtIntervalStart(operator) {
     const unbondedValueAtStart = new BigNumber(

--- a/staker-rewards/lib/requirements.js
+++ b/staker-rewards/lib/requirements.js
@@ -174,7 +174,7 @@ export default class Requirements {
       operator
     )
 
-    const minimumUnbondedValueRegisteredAtStart = await this.checkUnbondedValueRegisteredAtIntervalStart(
+    const inPoolIfRequired = await this.checkWasInPoolIfRequiredAtIntervalStart(
       operator
     )
 
@@ -184,7 +184,7 @@ export default class Requirements {
       poolAuthorizedAtStart,
       poolDeauthorizedInInterval,
       minimumStakeAtStart,
-      minimumUnbondedValueRegisteredAtStart
+      inPoolIfRequired
     )
   }
 
@@ -241,7 +241,7 @@ export default class Requirements {
   // to be registered in the sortition pool. Operators who are not in the sortition
   // pool because all of their ether is locked are still getting rewards because
   // that ether is still under the system’s management.
-  async checkUnbondedValueRegisteredAtIntervalStart(operator) {
+  async checkWasInPoolIfRequiredAtIntervalStart(operator) {
     const unbondedValueAtStart = new BigNumber(
       await callWithRetry(
         this.keepBonding.methods.unbondedValue(operator),
@@ -275,12 +275,12 @@ export function OperatorRequirements(
   poolAuthorizedAtStart,
   poolDeauthorizedInInterval,
   minimumStakeAtStart,
-  minimumUnbondedValueRegisteredAtStart
+  wasInPoolIfRequiredAtIntervalStart
 ) {
   ;(this.address = address),
     (this.factoryAuthorizedAtStart = factoryAuthorizedAtStart),
     (this.poolAuthorizedAtStart = poolAuthorizedAtStart),
     (this.minimumStakeAtStart = minimumStakeAtStart),
-    (this.minimumUnbondedValueRegisteredAtStart = minimumUnbondedValueRegisteredAtStart),
+    (this.wasInPoolIfRequiredAtIntervalStart = wasInPoolIfRequiredAtIntervalStart),
     (this.poolDeauthorizedInInterval = poolDeauthorizedInInterval)
 }

--- a/staker-rewards/lib/requirements.js
+++ b/staker-rewards/lib/requirements.js
@@ -275,12 +275,12 @@ export function OperatorRequirements(
   poolAuthorizedAtStart,
   poolDeauthorizedInInterval,
   minimumStakeAtStart,
-  wasInPoolIfRequiredAtIntervalStart
+  wasInPoolIfRequiredAtStart
 ) {
   ;(this.address = address),
     (this.factoryAuthorizedAtStart = factoryAuthorizedAtStart),
     (this.poolAuthorizedAtStart = poolAuthorizedAtStart),
     (this.minimumStakeAtStart = minimumStakeAtStart),
-    (this.wasInPoolIfRequiredAtIntervalStart = wasInPoolIfRequiredAtIntervalStart),
+    (this.wasInPoolIfRequiredAtStart = wasInPoolIfRequiredAtStart),
     (this.poolDeauthorizedInInterval = poolDeauthorizedInInterval)
 }

--- a/staker-rewards/lib/requirements.js
+++ b/staker-rewards/lib/requirements.js
@@ -161,9 +161,34 @@ export default class Requirements {
     this.context.cache.storeTransactions(transactions)
   }
 
-  async checkAuthorizations(operator) {
-    console.debug(`Checking authorizations for operator ${operator}`)
+  async check(operator) {
+    console.log(`Checking requirements for operator ${operator}`)
 
+    const {
+      factoryAuthorizedAtStart,
+      poolAuthorizedAtStart,
+      poolDeauthorizedInInterval,
+    } = await this.checkAuthorizations(operator)
+
+    const minimumStakeAtStart = await this.checkMinimumStakeAtIntervalStart(
+      operator
+    )
+
+    const minimumUnbondedValueRegisteredAtStart = await this.checkUnbondedValueRegisteredAtIntervalStart(
+      operator
+    )
+
+    return new OperatorRequirements(
+      operator,
+      factoryAuthorizedAtStart,
+      poolAuthorizedAtStart,
+      poolDeauthorizedInInterval,
+      minimumStakeAtStart,
+      minimumUnbondedValueRegisteredAtStart
+    )
+  }
+
+  async checkAuthorizations(operator) {
     // Authorizations at the interval start.
     const {
       wasFactoryAuthorized: factoryAuthorizedAtStart,
@@ -175,12 +200,11 @@ export default class Requirements {
       operator
     )
 
-    return new OperatorAuthorizations(
-      operator,
+    return {
       factoryAuthorizedAtStart,
       poolAuthorizedAtStart,
-      poolDeauthorizedInInterval
-    )
+      poolDeauthorizedInInterval,
+    }
   }
 
   async checkAuthorizationsAtIntervalStart(operator) {
@@ -245,14 +269,18 @@ export default class Requirements {
   }
 }
 
-export function OperatorAuthorizations(
+export function OperatorRequirements(
   address,
   factoryAuthorizedAtStart,
   poolAuthorizedAtStart,
-  poolDeauthorizedInInterval
+  poolDeauthorizedInInterval,
+  minimumStakeAtStart,
+  minimumUnbondedValueRegisteredAtStart
 ) {
   ;(this.address = address),
     (this.factoryAuthorizedAtStart = factoryAuthorizedAtStart),
     (this.poolAuthorizedAtStart = poolAuthorizedAtStart),
+    (this.minimumStakeAtStart = minimumStakeAtStart),
+    (this.minimumUnbondedValueRegisteredAtStart = minimumUnbondedValueRegisteredAtStart),
     (this.poolDeauthorizedInInterval = poolDeauthorizedInInterval)
 }

--- a/staker-rewards/lib/requirements.js
+++ b/staker-rewards/lib/requirements.js
@@ -174,7 +174,7 @@ export default class Requirements {
       operator
     )
 
-    const inPoolIfRequired = await this.checkWasInPoolIfRequiredAtIntervalStart(
+    const poolRequirementFulfilledAtStart = await this.checkWasInPoolIfRequiredAtIntervalStart(
       operator
     )
 
@@ -184,7 +184,7 @@ export default class Requirements {
       poolAuthorizedAtStart,
       poolDeauthorizedInInterval,
       minimumStakeAtStart,
-      inPoolIfRequired
+      poolRequirementFulfilledAtStart
     )
   }
 
@@ -275,12 +275,12 @@ export function OperatorRequirements(
   poolAuthorizedAtStart,
   poolDeauthorizedInInterval,
   minimumStakeAtStart,
-  wasInPoolIfRequiredAtStart
+  poolRequirementFulfilledAtStart
 ) {
   ;(this.address = address),
     (this.factoryAuthorizedAtStart = factoryAuthorizedAtStart),
     (this.poolAuthorizedAtStart = poolAuthorizedAtStart),
     (this.minimumStakeAtStart = minimumStakeAtStart),
-    (this.wasInPoolIfRequiredAtStart = wasInPoolIfRequiredAtStart),
+    (this.poolRequirementFulfilledAtStart = poolRequirementFulfilledAtStart),
     (this.poolDeauthorizedInInterval = poolDeauthorizedInInterval)
 }

--- a/staker-rewards/lib/rewards-calculator.js
+++ b/staker-rewards/lib/rewards-calculator.js
@@ -1,6 +1,7 @@
 import clc from "cli-color"
 import { callWithRetry } from "./contract-helper.js"
 import BigNumber from "bignumber.js"
+import { decimalPlaces, noDecimalPlaces } from "./numbers.js"
 
 export default class RewardsCalculator {
   constructor(context, interval) {
@@ -44,7 +45,9 @@ export default class RewardsCalculator {
       new BigNumber(0)
     )
 
-    console.log(clc.yellow(`Rewards weight sum ${rewardWeightSum.toFixed(2)}`))
+    console.log(
+      clc.yellow(`Rewards weight sum ${rewardWeightSum.toFixed(decimalPlaces)}`)
+    )
 
     const operatorsRewards = []
 
@@ -69,7 +72,7 @@ export default class RewardsCalculator {
 
     const totalRewardsSum = operatorsRewards.reduce(
       (accumulator, rewards) =>
-        accumulator.plus(rewards.totalRewards.toFixed(0)),
+        accumulator.plus(rewards.totalRewards.toFixed(noDecimalPlaces)),
       new BigNumber(0)
     )
 

--- a/staker-rewards/rewards.js
+++ b/staker-rewards/rewards.js
@@ -1,6 +1,7 @@
 import clc from "cli-color"
 import BlockByDate from "ethereum-block-by-date"
 import BigNumber from "bignumber.js"
+import { decimalPlaces, shorten18Decimals } from "./lib/numbers.js"
 
 import Context from "./lib/context.js"
 import FraudDetector from "./lib/fraud-detector.js"
@@ -8,8 +9,6 @@ import Requirements from "./lib/requirements.js"
 import SLACalculator from "./lib/sla-calculator.js"
 import AssetsCalculator from "./lib/assets-calculator.js"
 import RewardsCalculator from "./lib/rewards-calculator.js"
-
-const decimalPlaces = 2
 
 async function run() {
   // URL to the websocket endpoint of the Ethereum node.
@@ -250,9 +249,6 @@ function OperatorSummary(operator, operatorParameters, operatorRewards) {
 }
 
 function shortenSummaryValues(summary) {
-  const shorten18Decimals = (value) =>
-    value.dividedBy(new BigNumber(1e18)).toFixed(decimalPlaces)
-
   summary.keepStaked = shorten18Decimals(summary.keepStaked)
   summary.ethBonded = shorten18Decimals(summary.ethBonded)
   summary.ethUnbonded = shorten18Decimals(summary.ethUnbonded)

--- a/staker-rewards/rewards.js
+++ b/staker-rewards/rewards.js
@@ -84,7 +84,7 @@ async function run() {
            ${operatorRewards.poolAuthorizedAtStart} 
            ${operatorRewards.poolDeauthorizedInInterval} 
            ${operatorRewards.minimumStakeAtStart} 
-           ${operatorRewards.minimumUnbondedValueRegisteredAtStart} 
+           ${operatorRewards.wasInPoolIfRequiredAtIntervalStart} 
            ${operatorRewards.keygenCount}
            ${operatorRewards.keygenFailCount} 
            ${operatorRewards.keygenSLA} 
@@ -241,8 +241,8 @@ function OperatorSummary(operator, operatorParameters, operatorRewards) {
       operatorParameters.requirements.poolDeauthorizedInInterval),
     (this.minimumStakeAtStart =
       operatorParameters.requirements.minimumStakeAtStart),
-    (this.minimumUnbondedValueRegisteredAtStart =
-      operatorParameters.requirements.minimumUnbondedValueRegisteredAtStart),
+    (this.wasInPoolIfRequiredAtIntervalStart =
+      operatorParameters.requirements.wasInPoolIfRequiredAtIntervalStart),
     (this.keygenCount = operatorParameters.operatorSLA.keygenCount),
     (this.keygenFailCount = operatorParameters.operatorSLA.keygenFailCount),
     (this.keygenSLA = operatorParameters.operatorSLA.keygenSLA),

--- a/staker-rewards/rewards.js
+++ b/staker-rewards/rewards.js
@@ -86,7 +86,7 @@ async function run() {
            ${operatorRewards.poolAuthorizedAtStart} 
            ${operatorRewards.poolDeauthorizedInInterval} 
            ${operatorRewards.minimumStakeAtStart} 
-           ${operatorRewards.wasInPoolIfRequiredAtStart} 
+           ${operatorRewards.poolRequirementFulfilledAtStart} 
            ${operatorRewards.keygenCount}
            ${operatorRewards.keygenFailCount} 
            ${operatorRewards.keygenSLA} 
@@ -245,8 +245,8 @@ function OperatorSummary(operator, operatorParameters, operatorRewards) {
       operatorParameters.requirements.poolDeauthorizedInInterval),
     (this.minimumStakeAtStart =
       operatorParameters.requirements.minimumStakeAtStart),
-    (this.wasInPoolIfRequiredAtStart =
-      operatorParameters.requirements.wasInPoolIfRequiredAtStart),
+    (this.poolRequirementFulfilledAtStart =
+      operatorParameters.requirements.poolRequirementFulfilledAtStart),
     (this.keygenCount = operatorParameters.operatorSLA.keygenCount),
     (this.keygenFailCount = operatorParameters.operatorSLA.keygenFailCount),
     (this.keygenSLA = operatorParameters.operatorSLA.keygenSLA),

--- a/staker-rewards/rewards.js
+++ b/staker-rewards/rewards.js
@@ -86,7 +86,7 @@ async function run() {
            ${operatorRewards.poolAuthorizedAtStart} 
            ${operatorRewards.poolDeauthorizedInInterval} 
            ${operatorRewards.minimumStakeAtStart} 
-           ${operatorRewards.wasInPoolIfRequiredAtIntervalStart} 
+           ${operatorRewards.wasInPoolIfRequiredAtStart} 
            ${operatorRewards.keygenCount}
            ${operatorRewards.keygenFailCount} 
            ${operatorRewards.keygenSLA} 
@@ -243,8 +243,8 @@ function OperatorSummary(operator, operatorParameters, operatorRewards) {
       operatorParameters.requirements.poolDeauthorizedInInterval),
     (this.minimumStakeAtStart =
       operatorParameters.requirements.minimumStakeAtStart),
-    (this.wasInPoolIfRequiredAtIntervalStart =
-      operatorParameters.requirements.wasInPoolIfRequiredAtIntervalStart),
+    (this.wasInPoolIfRequiredAtStart =
+      operatorParameters.requirements.wasInPoolIfRequiredAtStart),
     (this.keygenCount = operatorParameters.operatorSLA.keygenCount),
     (this.keygenFailCount = operatorParameters.operatorSLA.keygenFailCount),
     (this.keygenSLA = operatorParameters.operatorSLA.keygenSLA),

--- a/staker-rewards/rewards.js
+++ b/staker-rewards/rewards.js
@@ -77,6 +77,11 @@ async function run() {
       console.log(
         `${operatorRewards.operator}
            ${operatorRewards.isFraudulent} 
+           ${operatorRewards.factoryAuthorizedAtStart} 
+           ${operatorRewards.poolAuthorizedAtStart} 
+           ${operatorRewards.poolDeauthorizedInInterval} 
+           ${operatorRewards.minimumStakeAtStart} 
+           ${operatorRewards.minimumUnbondedValueRegisteredAtStart} 
            ${operatorRewards.keygenCount}
            ${operatorRewards.keygenFailCount} 
            ${operatorRewards.keygenSLA} 
@@ -156,9 +161,7 @@ async function calculateOperatorsRewards(context, interval) {
 
   for (const operator of getOperators(cache)) {
     const isFraudulent = await fraudDetector.isOperatorFraudulent(operator)
-    const operatorAuthorizations = await requirements.checkAuthorizations(
-      operator
-    )
+    const operatorRequirements = await requirements.check(operator)
     const operatorSLA = slaCalculator.calculateOperatorSLA(operator)
     const operatorAssets = await assetsCalculator.calculateOperatorAssets(
       operator
@@ -168,7 +171,7 @@ async function calculateOperatorsRewards(context, interval) {
       new OperatorParameters(
         operator,
         isFraudulent,
-        operatorAuthorizations,
+        operatorRequirements,
         operatorSLA,
         operatorAssets
       )
@@ -211,13 +214,13 @@ function getOperators(cache) {
 function OperatorParameters(
   operator,
   isFraudulent,
-  authorizations,
+  requirements,
   operatorSLA,
   operatorAssets
 ) {
   ;(this.operator = operator),
     (this.isFraudulent = isFraudulent),
-    (this.authorizations = authorizations),
+    (this.requirements = requirements),
     (this.operatorSLA = operatorSLA),
     (this.operatorAssets = operatorAssets)
 }
@@ -226,11 +229,15 @@ function OperatorSummary(operator, operatorParameters, operatorRewards) {
   ;(this.operator = operator),
     (this.isFraudulent = operatorParameters.isFraudulent),
     (this.factoryAuthorizedAtStart =
-      operatorParameters.authorizations.factoryAuthorizedAtStart),
+      operatorParameters.requirements.factoryAuthorizedAtStart),
     (this.poolAuthorizedAtStart =
-      operatorParameters.authorizations.poolAuthorizedAtStart),
+      operatorParameters.requirements.poolAuthorizedAtStart),
     (this.poolDeauthorizedInInterval =
-      operatorParameters.authorizations.poolDeauthorizedInInterval),
+      operatorParameters.requirements.poolDeauthorizedInInterval),
+    (this.minimumStakeAtStart =
+      operatorParameters.requirements.minimumStakeAtStart),
+    (this.minimumUnbondedValueRegisteredAtStart =
+      operatorParameters.requirements.minimumUnbondedValueRegisteredAtStart),
     (this.keygenCount = operatorParameters.operatorSLA.keygenCount),
     (this.keygenFailCount = operatorParameters.operatorSLA.keygenFailCount),
     (this.keygenSLA = operatorParameters.operatorSLA.keygenSLA),

--- a/staker-rewards/rewards.js
+++ b/staker-rewards/rewards.js
@@ -1,7 +1,11 @@
 import clc from "cli-color"
 import BlockByDate from "ethereum-block-by-date"
 import BigNumber from "bignumber.js"
-import { decimalPlaces, shorten18Decimals } from "./lib/numbers.js"
+import {
+  decimalPlaces,
+  noDecimalPlaces,
+  shorten18Decimals,
+} from "./lib/numbers.js"
 
 import Context from "./lib/context.js"
 import FraudDetector from "./lib/fraud-detector.js"
@@ -10,8 +14,6 @@ import SLACalculator from "./lib/sla-calculator.js"
 import AssetsCalculator from "./lib/assets-calculator.js"
 import RewardsCalculator from "./lib/rewards-calculator.js"
 import { getPastEvents } from "./lib/contract-helper.js"
-
-const noDecimalPlaces = 0
 
 async function run() {
   // URL to the websocket endpoint of the Ethereum node.

--- a/staker-rewards/rewards.js
+++ b/staker-rewards/rewards.js
@@ -140,7 +140,9 @@ function validateIntervalTotalRewards(interval) {
   }
 
   console.log(
-    clc.green(`Interval total rewards: ${interval.totalRewards} KEEP`)
+    clc.green(
+      `Interval total rewards: ${shorten18Decimals(interval.totalRewards)} KEEP`
+    )
   )
 }
 

--- a/staker-rewards/test/data/test-blockchain.json
+++ b/staker-rewards/test/data/test-blockchain.json
@@ -69,6 +69,32 @@
               "poolAddress": "0xA3748633c6786e1842b5cC44fa43db1ecC710501",
               "output": false
             }
+          ],
+          "unbondedValue": [
+            {
+              "operator": "0xA000000000000000000000000000000000000001",
+              "output": "99999999999999999"
+            },
+            {
+              "operator": "0xA000000000000000000000000000000000000002",
+              "output": "100000000000000000"
+            },
+            {
+              "operator": "0xA000000000000000000000000000000000000003",
+              "output": "100000000000000000"
+            },
+            {
+              "operator": "0xA000000000000000000000000000000000000004",
+              "output": "100000000000000001"
+            },
+            {
+              "operator": "0xA000000000000000000000000000000000000005",
+              "output": "100000000000000001"
+            },
+            {
+              "operator": "0xA000000000000000000000000000000000000006",
+              "output": "2000000000000000000000"
+            }
           ]
         }
       },
@@ -86,6 +112,53 @@
             },
             {
               "operator": "0xA000000000000000000000000000000000000003",
+              "output": false
+            }
+          ],
+          "hasMinimumStake": [
+            {
+              "operator": "0xA000000000000000000000000000000000000001",
+              "output": true
+            },
+            {
+              "operator": "0xA000000000000000000000000000000000000002",
+              "output": false
+            }
+          ],
+          "isOperatorRegistered": [
+            {
+              "operator": "0xA000000000000000000000000000000000000001",
+              "application": "0xe20A5C79b39bC8C363f0f49ADcFa82C2a01ab64a",
+              "output": false
+            },
+            {
+              "operator": "0xA000000000000000000000000000000000000002",
+              "application": "0xe20A5C79b39bC8C363f0f49ADcFa82C2a01ab64a",
+              "output": true
+            },
+            {
+              "operator": "0xA000000000000000000000000000000000000003",
+              "application": "0xe20A5C79b39bC8C363f0f49ADcFa82C2a01ab64a",
+              "output": false
+            },
+            {
+              "operator": "0xA000000000000000000000000000000000000003",
+              "application": "0x0000000000000000ea61b1966ea0d08F55f2CEAC",
+              "output": true
+            },
+            {
+              "operator": "0xA000000000000000000000000000000000000004",
+              "application": "0xe20A5C79b39bC8C363f0f49ADcFa82C2a01ab64a",
+              "output": true
+            },
+            {
+              "operator": "0xA000000000000000000000000000000000000005",
+              "application": "0xe20A5C79b39bC8C363f0f49ADcFa82C2a01ab64a",
+              "output": false
+            },
+            {
+              "operator": "0xA000000000000000000000000000000000000006",
+              "application": "0xe20A5C79b39bC8C363f0f49ADcFa82C2a01ab64a",
               "output": false
             }
           ]

--- a/staker-rewards/test/helpers/blockchain.js
+++ b/staker-rewards/test/helpers/blockchain.js
@@ -24,7 +24,10 @@ export function mockMethod(
     const state = getStateAtBlock(contractAddress, blockNumber)
 
     const result =
-      state && state.methods && state.methods[method].find(inputCheck)
+      state &&
+      state.methods &&
+      state.methods[method] &&
+      state.methods[method].find(inputCheck)
 
     return (result && result.output) || defaultOutput
   }

--- a/staker-rewards/test/helpers/mock.js
+++ b/staker-rewards/test/helpers/mock.js
@@ -2,6 +2,7 @@ import BN from "bn.js"
 
 import testCache from "../data/test-cache.json"
 import transactionsCache from "../data/test-transactions.json"
+import { SANCTIONED_APPLICATION_ADDRESS } from "../../lib/context.js"
 
 export const createMockContext = () => ({
   cache: {
@@ -19,5 +20,5 @@ export const createMockContext = () => ({
         new BN(value).div(new BN("1000000000000000000")).toString(),
     },
   },
-  contracts: {},
+  contracts: { sanctionedApplicationAddress: SANCTIONED_APPLICATION_ADDRESS },
 })

--- a/staker-rewards/test/requirements.test.js
+++ b/staker-rewards/test/requirements.test.js
@@ -214,7 +214,7 @@ describe("requirements", async () => {
     it("for operator that has no minimum unbonded value", async () => {
       const operator = "0xA000000000000000000000000000000000000001"
 
-      const result = await requirements.checkUnbondedValueRegisteredAtIntervalStart(
+      const result = await requirements.checkWasInPoolIfRequiredAtIntervalStart(
         operator
       )
 
@@ -224,7 +224,7 @@ describe("requirements", async () => {
     it("for operator that has exactly minimum unbonded value and is registered", async () => {
       const operator = "0xA000000000000000000000000000000000000002"
 
-      const result = await requirements.checkUnbondedValueRegisteredAtIntervalStart(
+      const result = await requirements.checkWasInPoolIfRequiredAtIntervalStart(
         operator
       )
 
@@ -234,7 +234,7 @@ describe("requirements", async () => {
     it("for operator that has exactly minimum unbonded value and is not registered", async () => {
       const operator = "0xA000000000000000000000000000000000000003"
 
-      const result = await requirements.checkUnbondedValueRegisteredAtIntervalStart(
+      const result = await requirements.checkWasInPoolIfRequiredAtIntervalStart(
         operator
       )
 
@@ -244,7 +244,7 @@ describe("requirements", async () => {
     it("for operator that has more than minimum unbonded value and is registered", async () => {
       const operator = "0xA000000000000000000000000000000000000004"
 
-      const result = await requirements.checkUnbondedValueRegisteredAtIntervalStart(
+      const result = await requirements.checkWasInPoolIfRequiredAtIntervalStart(
         operator
       )
 
@@ -254,7 +254,7 @@ describe("requirements", async () => {
     it("for operator that has more than minimum unbonded value and is not registered", async () => {
       const operator = "0xA000000000000000000000000000000000000005"
 
-      const result = await requirements.checkUnbondedValueRegisteredAtIntervalStart(
+      const result = await requirements.checkWasInPoolIfRequiredAtIntervalStart(
         operator
       )
 
@@ -264,7 +264,7 @@ describe("requirements", async () => {
     it("for operator that has very high unbonded value and is not registered", async () => {
       const operator = "0xA000000000000000000000000000000000000006"
 
-      const result = await requirements.checkUnbondedValueRegisteredAtIntervalStart(
+      const result = await requirements.checkWasInPoolIfRequiredAtIntervalStart(
         operator
       )
 

--- a/staker-rewards/test/requirements.test.js
+++ b/staker-rewards/test/requirements.test.js
@@ -150,7 +150,7 @@ describe("requirements", async () => {
       })
     })
 
-    it("finds if deauthorized during interval", async () => {
+    it("finds if the pool was unauthorized during interval", async () => {
       const operator = "0xA000000000000000000000000000000000000002"
 
       const result = await requirements.checkAuthorizations(operator)


### PR DESCRIPTION
In this PR we define two more requirements checks:

>* If the operator does not have a minimum KEEP stake at T_start, they are not getting any rewards for interval T. 
>
>* If the operator has more ETH_unbonded than the minimum unbonded value and is not in the sortition pool at T_start, they are not getting any rewards for interval T.
Note: This point can be summarized basically as: if you are eligible to be in the sortition pool, you have to be in the sortition pool. Operators who are not in the sortition pool because all of their ETH is locked are still getting rewards because that ETH is still under the system’s management.

TODO:
- [x] unit tests 

Depends on: https://github.com/keep-network/keep-ecdsa/pull/633
Refs: #602