### PR TITLE
Staker Rewards: Check requirements while calculating rewards

### DIFF
--- a/staker-rewards/lib/rewards-calculator.js
+++ b/staker-rewards/lib/rewards-calculator.js
@@ -131,8 +131,8 @@ export default class RewardsCalculator {
       violations.push("minimumStakeAtStart")
     }
 
-    if (requirements.minimumUnbondedValueRegisteredAtStart === false) {
-      violations.push("minimumUnbondedValueRegisteredAtStart")
+    if (requirements.poolRequirementFulfilledAtStart === false) {
+      violations.push("poolRequirementFulfilledAtStart")
     }
 
     if (operatorSLA.keygenSLA !== "N/A" && operatorSLA.keygenSLA < 90) {

--- a/staker-rewards/lib/rewards-calculator.js
+++ b/staker-rewards/lib/rewards-calculator.js
@@ -203,5 +203,7 @@ function OperatorRewards(
     (this.boost = boost),
     (this.rewardWeight = rewardWeight),
     (this.totalRewards = totalRewards),
-    (this.requirementsViolations = requirementsViolations)
+    (this.requirementsViolations = requirementsViolations),
+    (this.SLAViolated =
+      requirementsViolations.filter((r) => r.includes("SLA")).length > 0)
 }

--- a/staker-rewards/lib/rewards-calculator.js
+++ b/staker-rewards/lib/rewards-calculator.js
@@ -26,6 +26,10 @@ export default class RewardsCalculator {
     for (const operatorParameters of operatorsParameters) {
       const { keepStaked, ethTotal } = operatorParameters.operatorAssets
 
+      const requirementsViolations = this.checkRequirementsViolations(
+        operatorParameters
+      )
+
       const ethScore = this.calculateETHScore(ethTotal)
       const boost = this.calculateBoost(keepStaked, ethTotal, minimumStake)
       const rewardWeight = ethScore.multipliedBy(boost)
@@ -35,6 +39,7 @@ export default class RewardsCalculator {
         ethScore,
         boost,
         rewardWeight,
+        requirementsViolations,
       })
     }
 
@@ -52,12 +57,15 @@ export default class RewardsCalculator {
     const operatorsRewards = []
 
     for (const operatorRewardsFactors of operatorsRewardsFactors) {
-      const { rewardWeight } = operatorRewardsFactors
+      const { rewardWeight, requirementsViolations } = operatorRewardsFactors
       const rewardRatio = rewardWeightSum.isGreaterThan(new BigNumber(0))
         ? rewardWeight.dividedBy(rewardWeightSum)
         : new BigNumber(0)
 
-      const totalRewards = this.interval.totalRewards.multipliedBy(rewardRatio)
+      const totalRewards =
+        requirementsViolations.length > 0
+          ? new BigNumber(0)
+          : this.interval.totalRewards.multipliedBy(rewardRatio)
 
       operatorsRewards.push(
         new OperatorRewards(
@@ -65,7 +73,8 @@ export default class RewardsCalculator {
           operatorRewardsFactors.ethScore,
           operatorRewardsFactors.boost,
           rewardWeight,
-          totalRewards
+          totalRewards,
+          requirementsViolations
         )
       )
     }
@@ -81,6 +90,45 @@ export default class RewardsCalculator {
     )
 
     return new BigNumber(minimumStake)
+  }
+
+  checkRequirementsViolations(operatorParameters) {
+    const violations = []
+    const { isFraudulent, requirements, operatorSLA } = operatorParameters
+
+    if (isFraudulent === true) {
+      violations.push("isFraudulent")
+    }
+
+    if (requirements.factoryAuthorizedAtStart === false) {
+      violations.push("factoryAuthorizedAtStart")
+    }
+
+    if (requirements.poolAuthorizedAtStart === false) {
+      violations.push("poolAuthorizedAtStart")
+    }
+
+    if (requirements.poolDeauthorizedInInterval === true) {
+      violations.push("poolDeauthorizedInInterval")
+    }
+
+    if (requirements.minimumStakeAtStart === false) {
+      violations.push("minimumStakeAtStart")
+    }
+
+    if (requirements.minimumUnbondedValueRegisteredAtStart === false) {
+      violations.push("minimumUnbondedValueRegisteredAtStart")
+    }
+
+    if (operatorSLA.keygenSLA !== "N/A" && operatorSLA.keygenSLA < 90) {
+      violations.push("keygenSLA")
+    }
+
+    if (operatorSLA.signatureSLA !== "N/A" && operatorSLA.signatureSLA < 95) {
+      violations.push("signatureSLA")
+    }
+
+    return violations
   }
 
   calculateETHScore(ethTotal) {
@@ -116,11 +164,13 @@ function OperatorRewards(
   ethScore,
   boost,
   rewardWeight,
-  totalRewards
+  totalRewards,
+  requirementsViolations
 ) {
   ;(this.operator = operator),
     (this.ethScore = ethScore),
     (this.boost = boost),
     (this.rewardWeight = rewardWeight),
-    (this.totalRewards = totalRewards)
+    (this.totalRewards = totalRewards),
+    (this.requirementsViolations = requirementsViolations)
 }

--- a/staker-rewards/lib/rewards-calculator.js
+++ b/staker-rewards/lib/rewards-calculator.js
@@ -135,12 +135,28 @@ export default class RewardsCalculator {
       violations.push("poolRequirementFulfilledAtStart")
     }
 
-    if (operatorSLA.keygenSLA !== "N/A" && operatorSLA.keygenSLA < 90) {
-      violations.push("keygenSLA")
+    if (operatorSLA.keygenSLA !== "N/A") {
+      if (operatorSLA.keygenCount < 10) {
+        if (operatorSLA.keygenFailCount > 1) {
+          violations.push("keygenSLA")
+        }
+      } else {
+        if (operatorSLA.keygenSLA < 90) {
+          violations.push("keygenSLA")
+        }
+      }
     }
 
-    if (operatorSLA.signatureSLA !== "N/A" && operatorSLA.signatureSLA < 95) {
-      violations.push("signatureSLA")
+    if (operatorSLA.signatureSLA !== "N/A") {
+      if (operatorSLA.signatureCount < 20) {
+        if (operatorSLA.signatureFailCount > 1) {
+          violations.push("signatureSLA")
+        }
+      } else {
+        if (operatorSLA.signatureSLA < 95) {
+          violations.push("signatureSLA")
+        }
+      }
     }
 
     return violations

--- a/staker-rewards/rewards.js
+++ b/staker-rewards/rewards.js
@@ -96,6 +96,7 @@ async function run() {
            ${operatorRewards.boost.toFormat(decimalPlaces, format)} 
            ${operatorRewards.rewardWeight.toFormat(decimalPlaces, format)} 
            ${operatorRewards.totalRewards.toFormat(decimalPlaces, format)}
+           ${operatorRewards.requirementsViolations}
           `.replace(/\s+/gm, " ")
       )
     )
@@ -252,7 +253,8 @@ function OperatorSummary(operator, operatorParameters, operatorRewards) {
     (this.ethScore = operatorRewards.ethScore),
     (this.boost = operatorRewards.boost),
     (this.rewardWeight = operatorRewards.rewardWeight),
-    (this.totalRewards = operatorRewards.totalRewards)
+    (this.totalRewards = operatorRewards.totalRewards),
+    (this.requirementsViolations = operatorRewards.requirementsViolations)
 }
 
 function shortenSummaryValues(summary) {

--- a/staker-rewards/rewards.js
+++ b/staker-rewards/rewards.js
@@ -93,6 +93,7 @@ async function run() {
            ${operatorRewards.signatureCount} 
            ${operatorRewards.signatureFailCount}
            ${operatorRewards.signatureSLA} 
+           ${operatorRewards.SLAViolated}
            ${operatorRewards.keepStaked.toFormat(format)} 
            ${operatorRewards.ethBonded.toFormat(format)} 
            ${operatorRewards.ethUnbonded.toFormat(format)}
@@ -114,7 +115,6 @@ async function run() {
              BigNumber.ROUND_DOWN,
              format
            )}
-           ${operatorRewards.requirementsViolations}
           `.replace(/\n/g, "\t")
       )
     )
@@ -266,6 +266,7 @@ function OperatorSummary(operator, operatorParameters, operatorRewards) {
     (this.signatureFailCount =
       operatorParameters.operatorSLA.signatureFailCount),
     (this.signatureSLA = operatorParameters.operatorSLA.signatureSLA),
+    (this.SLAViolated = operatorRewards.SLAViolated),
     (this.keepStaked = operatorParameters.operatorAssets.keepStaked),
     (this.ethBonded = operatorParameters.operatorAssets.ethBonded),
     (this.ethUnbonded = operatorParameters.operatorAssets.ethUnbonded),
@@ -274,8 +275,7 @@ function OperatorSummary(operator, operatorParameters, operatorRewards) {
     (this.ethScore = operatorRewards.ethScore),
     (this.boost = operatorRewards.boost),
     (this.rewardWeight = operatorRewards.rewardWeight),
-    (this.totalRewards = operatorRewards.totalRewards),
-    (this.requirementsViolations = operatorRewards.requirementsViolations)
+    (this.totalRewards = operatorRewards.totalRewards)
 }
 
 function shortenSummaryValues(summary) {

--- a/staker-rewards/test/rewards-calculator.test.js
+++ b/staker-rewards/test/rewards-calculator.test.js
@@ -28,7 +28,7 @@ const createOperatorParameters = (operator, keepStaked, ethTotal) => ({
     poolAuthorizedAtStart: true,
     poolDeauthorizedInInterval: false,
     minimumStakeAtStart: true,
-    minimumUnbondedValueRegisteredAtStart: true,
+    poolRequirementFulfilledAtStart: true,
   },
   operatorSLA: {
     keygenSLA: 90,
@@ -277,14 +277,14 @@ describe("rewards calculator", async () => {
     assert.equal(rewards.totalRewards.isEqualTo(new BigNumber(0)), true)
   })
 
-  it("should set total rewards to zero if no minimum unbonded value registered at start", async () => {
+  it("should set total rewards to zero if pool requirement is not fulfilled at start", async () => {
     const mockContext = createMockContext()
 
     setupContractsMock(mockContext)
 
     const operatorParameters = createOperatorParameters(operator, 70000, 100)
 
-    operatorParameters.requirements.minimumUnbondedValueRegisteredAtStart = false
+    operatorParameters.requirements.poolRequirementFulfilledAtStart = false
 
     const rewardsCalculator = await RewardsCalculator.initialize(
       mockContext,

--- a/staker-rewards/test/rewards-calculator.test.js
+++ b/staker-rewards/test/rewards-calculator.test.js
@@ -22,6 +22,18 @@ const createOperatorParameters = (operator, keepStaked, ethTotal) => ({
     keepStaked: new BigNumber(keepStaked).multipliedBy(1e18),
     ethTotal: new BigNumber(ethTotal).multipliedBy(1e18),
   },
+  isFraudulent: false,
+  requirements: {
+    factoryAuthorizedAtStart: true,
+    poolAuthorizedAtStart: true,
+    poolDeauthorizedInInterval: false,
+    minimumStakeAtStart: true,
+    minimumUnbondedValueRegisteredAtStart: true,
+  },
+  operatorSLA: {
+    keygenSLA: 90,
+    signatureSLA: 95,
+  },
 })
 
 const setupContractsMock = (context) => {
@@ -163,5 +175,165 @@ describe("rewards calculator", async () => {
       rewards.totalRewards.isEqualTo(new BigNumber(1800000).multipliedBy(1e18)),
       true
     )
+  })
+
+  it("should set total rewards to zero if operator is fraudulent", async () => {
+    const mockContext = createMockContext()
+
+    setupContractsMock(mockContext)
+
+    const operatorParameters = createOperatorParameters(operator, 70000, 100)
+
+    operatorParameters.isFraudulent = true
+
+    const rewardsCalculator = await RewardsCalculator.initialize(
+      mockContext,
+      interval,
+      [operatorParameters]
+    )
+
+    const rewards = rewardsCalculator.getOperatorRewards(operator)
+
+    assert.equal(rewards.totalRewards.isEqualTo(new BigNumber(0)), true)
+  })
+
+  it("should set total rewards to zero if factory is not authorized at start", async () => {
+    const mockContext = createMockContext()
+
+    setupContractsMock(mockContext)
+
+    const operatorParameters = createOperatorParameters(operator, 70000, 100)
+
+    operatorParameters.requirements.factoryAuthorizedAtStart = false
+
+    const rewardsCalculator = await RewardsCalculator.initialize(
+      mockContext,
+      interval,
+      [operatorParameters]
+    )
+
+    const rewards = rewardsCalculator.getOperatorRewards(operator)
+
+    assert.equal(rewards.totalRewards.isEqualTo(new BigNumber(0)), true)
+  })
+
+  it("should set total rewards to zero if pool is not authorized at start", async () => {
+    const mockContext = createMockContext()
+
+    setupContractsMock(mockContext)
+
+    const operatorParameters = createOperatorParameters(operator, 70000, 100)
+
+    operatorParameters.requirements.poolAuthorizedAtStart = false
+
+    const rewardsCalculator = await RewardsCalculator.initialize(
+      mockContext,
+      interval,
+      [operatorParameters]
+    )
+
+    const rewards = rewardsCalculator.getOperatorRewards(operator)
+
+    assert.equal(rewards.totalRewards.isEqualTo(new BigNumber(0)), true)
+  })
+
+  it("should set total rewards to zero if pool is deauthorized in interval", async () => {
+    const mockContext = createMockContext()
+
+    setupContractsMock(mockContext)
+
+    const operatorParameters = createOperatorParameters(operator, 70000, 100)
+
+    operatorParameters.requirements.poolDeauthorizedInInterval = true
+
+    const rewardsCalculator = await RewardsCalculator.initialize(
+      mockContext,
+      interval,
+      [operatorParameters]
+    )
+
+    const rewards = rewardsCalculator.getOperatorRewards(operator)
+
+    assert.equal(rewards.totalRewards.isEqualTo(new BigNumber(0)), true)
+  })
+
+  it("should set total rewards to zero if no minimum stake at start", async () => {
+    const mockContext = createMockContext()
+
+    setupContractsMock(mockContext)
+
+    const operatorParameters = createOperatorParameters(operator, 70000, 100)
+
+    operatorParameters.requirements.minimumStakeAtStart = false
+
+    const rewardsCalculator = await RewardsCalculator.initialize(
+      mockContext,
+      interval,
+      [operatorParameters]
+    )
+
+    const rewards = rewardsCalculator.getOperatorRewards(operator)
+
+    assert.equal(rewards.totalRewards.isEqualTo(new BigNumber(0)), true)
+  })
+
+  it("should set total rewards to zero if no minimum unbonded value registered at start", async () => {
+    const mockContext = createMockContext()
+
+    setupContractsMock(mockContext)
+
+    const operatorParameters = createOperatorParameters(operator, 70000, 100)
+
+    operatorParameters.requirements.minimumUnbondedValueRegisteredAtStart = false
+
+    const rewardsCalculator = await RewardsCalculator.initialize(
+      mockContext,
+      interval,
+      [operatorParameters]
+    )
+
+    const rewards = rewardsCalculator.getOperatorRewards(operator)
+
+    assert.equal(rewards.totalRewards.isEqualTo(new BigNumber(0)), true)
+  })
+
+  it("should set total rewards to zero if keygen SLA is not met", async () => {
+    const mockContext = createMockContext()
+
+    setupContractsMock(mockContext)
+
+    const operatorParameters = createOperatorParameters(operator, 70000, 100)
+
+    operatorParameters.operatorSLA.keygenSLA = 89.99
+
+    const rewardsCalculator = await RewardsCalculator.initialize(
+      mockContext,
+      interval,
+      [operatorParameters]
+    )
+
+    const rewards = rewardsCalculator.getOperatorRewards(operator)
+
+    assert.equal(rewards.totalRewards.isEqualTo(new BigNumber(0)), true)
+  })
+
+  it("should set total rewards to zero if signature SLA is not met", async () => {
+    const mockContext = createMockContext()
+
+    setupContractsMock(mockContext)
+
+    const operatorParameters = createOperatorParameters(operator, 70000, 100)
+
+    operatorParameters.operatorSLA.signatureSLA = 94.99
+
+    const rewardsCalculator = await RewardsCalculator.initialize(
+      mockContext,
+      interval,
+      [operatorParameters]
+    )
+
+    const rewards = rewardsCalculator.getOperatorRewards(operator)
+
+    assert.equal(rewards.totalRewards.isEqualTo(new BigNumber(0)), true)
   })
 })


### PR DESCRIPTION
Refs: #602
Depends on: #638

This pull request introduces requirements checks at the rewards calculation stage. The `totalRewards` parameter is set to `0` if at least one requirement violation occurred for the given operator. Possible violations are:
- `isFraudulent` is `true`
- `factoryAuthorizedAtStart` is `false`
- `poolAuthorizedAtStart` is `false`
- `poolDeauthorizedInInterval` is `true`
- `minimumStakeAtStart` is `false`
- `poolRequirementFulfilledAtStart` is `false`
- `keygenSLA` is less than `90` for `keygenCount >= 10` OR `keygenFailCount > 1` for `keygenCount < 10`
- `signatureSLA` is less than `95` for `signatureCount >= 20` OR `signatureFailCount > 1` for `signatureCount < 20`