### PR TITLE
Transfer rewards to the beneficiary

### DIFF
--- a/solidity/contracts/ECDSARewardsDistributor.sol
+++ b/solidity/contracts/ECDSARewardsDistributor.sol
@@ -93,8 +93,6 @@ contract ECDSARewardsDistributor is Ownable {
         _setClaimed(merkleRoot, index);
 
         address beneficiary = tokenStaking.beneficiaryOf(operator);
-        require(beneficiary != address(0), "Beneficiary address not set");
-
         require(IERC20(token).transfer(beneficiary, amount), "Transfer failed");
 
         emit RewardsClaimed(merkleRoot, index, operator, beneficiary, amount);

--- a/solidity/test/rewards/TestECDSARewardsDistributorEscrow.js
+++ b/solidity/test/rewards/TestECDSARewardsDistributorEscrow.js
@@ -4,6 +4,7 @@ const {expectRevert} = require("@openzeppelin/test-helpers")
 const {expect} = require("chai")
 
 const KeepToken = contract.fromArtifact("KeepToken")
+const TokenStakingStub = contract.fromArtifact("TokenStakingStub")
 const PhasedEscrow = contract.fromArtifact("PhasedEscrow")
 const ECDSARewardsEscrowBeneficiary = contract.fromArtifact(
   "ECDSARewardsEscrowBeneficiary"
@@ -26,9 +27,14 @@ describe("ECDSARewardsDistributorEscrow", () => {
 
   before(async () => {
     token = await KeepToken.new({from: owner})
-    rewardsDistributor = await ECDSARewardsDistributor.new(token.address, {
-      from: owner,
-    })
+    tokenStaking = await TokenStakingStub.new({from: owner})
+    rewardsDistributor = await ECDSARewardsDistributor.new(
+      token.address,
+      tokenStaking.address,
+      {
+        from: owner,
+      }
+    )
     escrow = await ECDSARewardsDistributorEscrow.new(
       token.address,
       rewardsDistributor.address,

--- a/solidity/test/staker-rewards/MerkleDistributorTest.js
+++ b/solidity/test/staker-rewards/MerkleDistributorTest.js
@@ -287,7 +287,7 @@ describe("MerkleDistributor", () => {
 
       await expectRevert(
         rewardsDistributor.claim(merkleRoot, index, operator, amount, proof),
-        "Beneficiary address not set"
+        "ERC20: transfer to the zero address"
       )
     })
   })

--- a/solidity/test/staker-rewards/MerkleDistributorTest.js
+++ b/solidity/test/staker-rewards/MerkleDistributorTest.js
@@ -29,7 +29,7 @@ describe("MerkleDistributor", () => {
       testValues.interval0.claims,
       testValues.interval1.claims
     )) {
-      await tokenStaking.setBeneficiary(claim.account, claim.beneficiary)
+      await tokenStaking.setBeneficiary(claim.operator, claim.beneficiary)
     }
   })
 
@@ -99,7 +99,7 @@ describe("MerkleDistributor", () => {
     it("should successfuly claim rewards and emit an event", async () => {
       const merkleRoot = merkle0.merkleRoot
       const index = merkle0.claims[0].index
-      const account = merkle0.claims[0].account
+      const operator = merkle0.claims[0].operator
       const amount = merkle0.claims[0].amount
       const proof = merkle0.claims[0].proof
       const beneficiary = merkle0.claims[0].beneficiary
@@ -107,7 +107,7 @@ describe("MerkleDistributor", () => {
       const claimed = await rewardsDistributor.claim(
         merkleRoot,
         index,
-        account,
+        operator,
         amount,
         proof
       )
@@ -117,7 +117,7 @@ describe("MerkleDistributor", () => {
       expectEvent(claimed, "RewardsClaimed", {
         merkleRoot,
         index,
-        account,
+        operator,
         beneficiary,
         amount,
       })
@@ -132,7 +132,7 @@ describe("MerkleDistributor", () => {
       for (let i = 0; i < merkle0.claims.length; i++) {
         const merkleRoot = merkle0.merkleRoot
         const index = merkle0.claims[i].index
-        const account = merkle0.claims[i].account
+        const operator = merkle0.claims[i].operator
         const amount = merkle0.claims[i].amount
         const proof = merkle0.claims[i].proof
         const beneficiary = merkle0.claims[i].beneficiary
@@ -142,7 +142,7 @@ describe("MerkleDistributor", () => {
         await rewardsDistributor.claim(
           merkleRoot,
           index,
-          account,
+          operator,
           amount,
           proof
         )
@@ -163,7 +163,7 @@ describe("MerkleDistributor", () => {
     it("should revert claiming transaction when proof is not valid", async () => {
       const merkleRoot = merkle0.merkleRoot
       const index = merkle0.claims[0].index
-      const account = merkle0.claims[0].account
+      const operator = merkle0.claims[0].operator
       const amount = merkle0.claims[0].amount
       const proof = [
         "0x1111111111111111111111111111111111111111111111111111111111111111",
@@ -171,7 +171,7 @@ describe("MerkleDistributor", () => {
       ]
 
       await expectRevert(
-        rewardsDistributor.claim(merkleRoot, index, account, amount, proof),
+        rewardsDistributor.claim(merkleRoot, index, operator, amount, proof),
         "Invalid proof"
       )
     })
@@ -185,23 +185,23 @@ describe("MerkleDistributor", () => {
 
       let merkleRoot = merkle0.merkleRoot
       let index = merkle0.claims[0].index
-      let account = merkle0.claims[0].account
+      let operator = merkle0.claims[0].operator
       let amount = merkle0.claims[0].amount
       let proof = merkle0.claims[0].proof
 
       claimedAmounts = claimedAmounts.addn(parseInt(amount))
 
-      await rewardsDistributor.claim(merkleRoot, index, account, amount, proof)
+      await rewardsDistributor.claim(merkleRoot, index, operator, amount, proof)
 
       merkleRoot = merkle1.merkleRoot
       index = merkle1.claims[1].index
-      account = merkle1.claims[1].account
+      operator = merkle1.claims[1].operator
       amount = merkle1.claims[1].amount
       proof = merkle1.claims[1].proof
 
       claimedAmounts = claimedAmounts.addn(parseInt(amount))
 
-      await rewardsDistributor.claim(merkleRoot, index, account, amount, proof)
+      await rewardsDistributor.claim(merkleRoot, index, operator, amount, proof)
 
       const actualBalance = await keepToken.balanceOf(
         rewardsDistributor.address
@@ -216,27 +216,27 @@ describe("MerkleDistributor", () => {
     it("should revert when claiming a reward twice", async () => {
       let merkleRoot = merkle0.merkleRoot
       let index = merkle0.claims[0].index
-      let account = merkle0.claims[0].account
+      let operator = merkle0.claims[0].operator
       let amount = merkle0.claims[0].amount
       let proof = merkle0.claims[0].proof
 
-      await rewardsDistributor.claim(merkleRoot, index, account, amount, proof)
+      await rewardsDistributor.claim(merkleRoot, index, operator, amount, proof)
 
       await expectRevert(
-        rewardsDistributor.claim(merkleRoot, index, account, amount, proof),
+        rewardsDistributor.claim(merkleRoot, index, operator, amount, proof),
         "Reward already claimed"
       )
 
       merkleRoot = merkle1.merkleRoot
       index = merkle1.claims[1].index
-      account = merkle1.claims[1].account
+      operator = merkle1.claims[1].operator
       amount = merkle1.claims[1].amount
       proof = merkle1.claims[1].proof
 
-      await rewardsDistributor.claim(merkleRoot, index, account, amount, proof)
+      await rewardsDistributor.claim(merkleRoot, index, operator, amount, proof)
 
       await expectRevert(
-        rewardsDistributor.claim(merkleRoot, index, account, amount, proof),
+        rewardsDistributor.claim(merkleRoot, index, operator, amount, proof),
         "Reward already claimed"
       )
     })
@@ -244,7 +244,7 @@ describe("MerkleDistributor", () => {
     it("should check if the reward was claimed", async () => {
       const merkleRoot = merkle0.merkleRoot
       const index = merkle0.claims[0].index
-      const account = merkle0.claims[0].account
+      const operator = merkle0.claims[0].operator
       const amount = merkle0.claims[0].amount
       const proof = merkle0.claims[0].proof
 
@@ -254,7 +254,7 @@ describe("MerkleDistributor", () => {
       )
       expect(isRewardClaimed).to.be.false
 
-      await rewardsDistributor.claim(merkleRoot, index, account, amount, proof)
+      await rewardsDistributor.claim(merkleRoot, index, operator, amount, proof)
 
       isRewardClaimed = await rewardsDistributor.isClaimed(merkleRoot, index)
       expect(isRewardClaimed).to.be.true
@@ -264,29 +264,29 @@ describe("MerkleDistributor", () => {
       const merkleRoot =
         "0x1111111111111111111111111111111111111111111111111111111111111111"
       const index = "0"
-      const account = "0x012ed55a0876Ea9e58277197DC14CbA47571CE28"
+      const operator = "0x012ed55a0876Ea9e58277197DC14CbA47571CE28"
       const amount = "42"
       const proof = [
         "0x2222222222222222222222222222222222222222222222222222222222222222",
       ]
 
       await expectRevert(
-        rewardsDistributor.claim(merkleRoot, index, account, amount, proof),
+        rewardsDistributor.claim(merkleRoot, index, operator, amount, proof),
         "Rewards must be allocated for a given merkle root"
       )
     })
 
-    it("should revert when beneficiary is not set for a given account", async () => {
+    it("should revert when beneficiary is not set for a given operator", async () => {
       const merkleRoot = merkle0.merkleRoot
       const index = merkle0.claims[0].index
-      const account = merkle0.claims[0].account
+      const operator = merkle0.claims[0].operator
       const amount = merkle0.claims[0].amount
       const proof = merkle0.claims[0].proof
 
-      await tokenStaking.setBeneficiary(account, ZERO_ADDRESS)
+      await tokenStaking.setBeneficiary(operator, ZERO_ADDRESS)
 
       await expectRevert(
-        rewardsDistributor.claim(merkleRoot, index, account, amount, proof),
+        rewardsDistributor.claim(merkleRoot, index, operator, amount, proof),
         "Beneficiary address not set"
       )
     })

--- a/solidity/test/staker-rewards/rewardsData.js
+++ b/solidity/test/staker-rewards/rewardsData.js
@@ -17,6 +17,7 @@ const testValues = {
           "0x023527b3cb4eb23b75f8554373ef468c6cc5a446a5bbf5b26133d684a82dc8ee",
           "0xa8390642d0b4fcbcfd25bd2787f9e498ce1f24c3d630f57a1560354a5b4dd06e",
         ],
+        beneficiary: "0x82Eda22AE1d4B16C11261F770C07092b0A62136a",
       },
       {
         index: "6",
@@ -31,6 +32,7 @@ const testValues = {
           "0x023527b3cb4eb23b75f8554373ef468c6cc5a446a5bbf5b26133d684a82dc8ee",
           "0xa8390642d0b4fcbcfd25bd2787f9e498ce1f24c3d630f57a1560354a5b4dd06e",
         ],
+        beneficiary: "0x6ab392c2134a6cE826cFBb0045175fAcCF504F69",
       },
       {
         index: "77",
@@ -45,6 +47,7 @@ const testValues = {
           "0x023527b3cb4eb23b75f8554373ef468c6cc5a446a5bbf5b26133d684a82dc8ee",
           "0xa8390642d0b4fcbcfd25bd2787f9e498ce1f24c3d630f57a1560354a5b4dd06e",
         ],
+        beneficiary: "0xfc8437956EeaCCE97996Ad01af59b828F3F5A808",
       },
     ],
   },
@@ -63,6 +66,7 @@ const testValues = {
           "0x162ab1201ce6d116732a2a8793945a23244afb8f79242255d3c34fea6aeceb73",
           "0x172864ef2714d9feaf400fe1342b595b61fc740234de3a7cd4e3d4eb8be3fc36",
         ],
+        beneficiary: "0x5Ab6DE7b08baF7A5d6Cb475b48E9055685E5C346",
       },
       {
         index: "1",
@@ -74,6 +78,7 @@ const testValues = {
           "0x20779de3e5a9a44f012cedf6f56e78af493fcb441d19cd884471e28457bbf697",
           "0x172864ef2714d9feaf400fe1342b595b61fc740234de3a7cd4e3d4eb8be3fc36",
         ],
+        beneficiary: "0x5664bc69ABeb9CB25c0CAA0C9326C8217E8AF6B4",
       },
       {
         index: "7",
@@ -85,6 +90,7 @@ const testValues = {
           "0x20779de3e5a9a44f012cedf6f56e78af493fcb441d19cd884471e28457bbf697",
           "0x172864ef2714d9feaf400fe1342b595b61fc740234de3a7cd4e3d4eb8be3fc36",
         ],
+        beneficiary: "0xfc8437956EeaCCE97996Ad01af59b828F3F5A808",
       },
     ],
   },

--- a/solidity/test/staker-rewards/rewardsData.js
+++ b/solidity/test/staker-rewards/rewardsData.js
@@ -7,7 +7,7 @@ const testValues = {
       {
         index: "0",
         amount: "85",
-        account: "0x012ed55a0876Ea9e58277197DC14CbA47571CE28",
+        operator: "0x012ed55a0876Ea9e58277197DC14CbA47571CE28",
         proof: [
           "0x1419d8cdecc66122fdd450e7322c82dbd1a183b4abad7ed01637042fcbbb1231",
           "0x79be08e672b91905bbbfa785ba28cf962112aae1bc30911e74e1af3939e7501f",
@@ -22,7 +22,7 @@ const testValues = {
       {
         index: "6",
         amount: "42",
-        account: "0x162F49fE6F365d04Db07F77377699aeFE2E8A2cf",
+        operator: "0x162F49fE6F365d04Db07F77377699aeFE2E8A2cf",
         proof: [
           "0x098f41b175b4374631df722f58f4bc63fca57851682d6dcc911a975f4582f385",
           "0xf4b6ad879c695dbdb0376fca8b9548cc4718bd08e0e657732b3b9df595a71dba",
@@ -37,7 +37,7 @@ const testValues = {
       {
         index: "77",
         amount: "1",
-        account: "0xF3c6F5F265F503f53EAD8aae90FC257A5aa49AC1",
+        operator: "0xF3c6F5F265F503f53EAD8aae90FC257A5aa49AC1",
         proof: [
           "0x081122f7920ab9553b71a84d1f9961256379ed7ff5257c8bd9749155e3dddeff",
           "0xb335096692ef570690f2d858f2d52c268728d60b12a2a856f2691155ccf36377",
@@ -59,7 +59,7 @@ const testValues = {
       {
         index: "0",
         amount: "80",
-        account: "0x05fc93DeFFFe436822100E795F376228470FB514",
+        operator: "0x05fc93DeFFFe436822100E795F376228470FB514",
         proof: [
           "0x54fce5fe1df9254fa00885de1ee9455b85f7dadc4b3192c33e5c3be9bea8d060",
           "0xeddbf7ea36eda7b37bd9314041a68b1c8adc2d5351ee1b373ab5fc464d20b02a",
@@ -71,7 +71,7 @@ const testValues = {
       {
         index: "1",
         amount: "70",
-        account: "0x57E7c6B647C004CFB7A38E08fDDef09Af5Ea55eD",
+        operator: "0x57E7c6B647C004CFB7A38E08fDDef09Af5Ea55eD",
         proof: [
           "0xc5d54b41f2c330a898fa1773bc4e8355b9bcc6e382c055f549b845af3814790c",
           "0x303ed1284f356d779e4a0a48644f5c4a210f7ea3f250d14ad811767cfe059a39",
@@ -83,7 +83,7 @@ const testValues = {
       {
         index: "7",
         amount: "10",
-        account: "0xF3c6F5F265F503f53EAD8aae90FC257A5aa49AC1",
+        operator: "0xF3c6F5F265F503f53EAD8aae90FC257A5aa49AC1",
         proof: [
           "0x92a4eaf5cccec93f36a5e27edf10b095949c5517f6a4896295f18b34652fbf03",
           "0xd7c0e1ce86eac4aec04c6f30dbd9d9215d1d30a640cd92c09cbcf68648711ea0",


### PR DESCRIPTION
Refs: #602

We expect the account passed to the rewards `claim` function to be an operator account.
In such case, rewards should be transferred to the operator's beneficiary address.