### PR TITLE
Releases/mainnet/solidity/v1.4.0

### DIFF
--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "1.4.0-pre.0",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -942,9 +942,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "1.5.0-pre.1",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.5.0-pre.1.tgz",
-      "integrity": "sha512-pE+v7kANGyEvLH5YI9yIaqZb/lT1XoEV9zLNQ6fC5vX+93yNvJjPhEYqAYI55f9rdYcOKtTWy7YksBbeceVXEw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.5.0.tgz",
+      "integrity": "sha512-IhJT66HWdoBtQkNn0wSNvnv3gtNpeOd5ypKEioRCQn0/Xj5MyWsU5d14Nen30yil3keAVBBd7/EvfHnR2PqGJw==",
       "requires": {
         "@openzeppelin/upgrades": "^2.7.2",
         "openzeppelin-solidity": "2.4.0"

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "1.4.0",
+  "version": "1.5.0-pre.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -942,9 +942,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.5.0.tgz",
-      "integrity": "sha512-IhJT66HWdoBtQkNn0wSNvnv3gtNpeOd5ypKEioRCQn0/Xj5MyWsU5d14Nen30yil3keAVBBd7/EvfHnR2PqGJw==",
+      "version": "1.6.0-pre.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.6.0-pre.0.tgz",
+      "integrity": "sha512-FeAdtoCta+7gi9wXc6z+Uobfr5G5WXxpCI4Uabh/vDV1l5yEQijosrQrArdj3Y5JsohICbwLFMIH0walsItk4A==",
       "requires": {
         "@openzeppelin/upgrades": "^2.7.2",
         "openzeppelin-solidity": "2.4.0"

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "1.4.0-pre.0",
+  "version": "1.4.0",
   "description": "Smart contracts for ECDSA Keep",
   "repository": {
     "type": "git",
@@ -34,8 +34,8 @@
   },
   "homepage": "https://github.com/keep-network/keep-ecdsa",
   "dependencies": {
-    "@keep-network/keep-core": ">1.5.0-pre <1.5.0-rc",
-    "@keep-network/sortition-pools": ">1.2.0-pre <1.2.0-rc",
+    "@keep-network/keep-core": "1.5.0",
+    "@keep-network/sortition-pools": "1.2.0-pre.3",
     "@openzeppelin/upgrades": "^2.7.2",
     "openzeppelin-solidity": "2.3.0"
   },

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "1.4.0",
+  "version": "1.5.0-pre.0",
   "description": "Smart contracts for ECDSA Keep",
   "repository": {
     "type": "git",
@@ -34,8 +34,8 @@
   },
   "homepage": "https://github.com/keep-network/keep-ecdsa",
   "dependencies": {
-    "@keep-network/keep-core": "1.5.0",
-    "@keep-network/sortition-pools": "1.2.0-pre.3",
+    "@keep-network/keep-core": ">1.6.0-pre <1.6.0-rc",
+    "@keep-network/sortition-pools": ">1.2.0-pre <1.2.0-rc",
     "@openzeppelin/upgrades": "^2.7.2",
     "openzeppelin-solidity": "2.3.0"
   },


### PR DESCRIPTION
Updating version for `solidity/v1.4.0` release. Please see https://github.com/keep-network/keep-ecdsa/milestone/19

848b7c29 is tagged as `solidity/v1.4.0`.