### PR TITLE
Staker rewards: Pass blocks as script input

### DIFF
--- a/staker-rewards/README.adoc
+++ b/staker-rewards/README.adoc
@@ -91,7 +91,7 @@ you can run `nvm use 14.3.0`.
 
 To verify operator rewards and display summary in a table, run:
 ```
-./rewards-merkle-generator.sh -v -w <eth_host> -s <start_timestamp> -e <end_timestamp> -r <reward_allocation>
+./rewards-merkle-generator.sh -v -w <eth_host> -s <start_timestamp> -e <end_timestamp> -x <start_block> -y <end_block> -r <reward_allocation>
 ```
 
 This command runs all calculations against mainnet data and displays operator 
@@ -102,7 +102,7 @@ to a beneficiary.
 To calculate operator rewards and calculate merkle tree, drop option `-v`, and run:
 
 ```
-./rewards-merkle-generator.sh -w <eth_host> -s <start_timestamp> -e <end_timestamp> -r <reward_allocation>
+./rewards-merkle-generator.sh -w <eth_host> -s <start_timestamp> -e <end_timestamp> -x <start_block> -y <end_block> -r <reward_allocation>
 ```
 
 Merkle tree output will be written to `distributor/output-merkle-objects.json`.

--- a/staker-rewards/README.adoc
+++ b/staker-rewards/README.adoc
@@ -91,7 +91,13 @@ you can run `nvm use 14.3.0`.
 
 To verify operator rewards and display summary in a table, run:
 ```
-./rewards-merkle-generator.sh -v -w <eth_host> -s <start_timestamp> -e <end_timestamp> -x <start_block> -y <end_block> -r <reward_allocation>
+./rewards-merkle-generator.sh --verify \
+    --eth-host <eth_host> \
+    --start-timestamp <start_timestamp> \
+    --end-timestamp <end_timestamp> \
+    --start-block <start_block> \
+    --end-block <end_block> \
+    --allocation <reward_allocation>
 ```
 
 This command runs all calculations against mainnet data and displays operator 
@@ -99,10 +105,16 @@ rewards in a human-friendly way in a table with numbers rounded to two decimal
 places. Rewards are allocated per operator but upon claiming they are transferred
 to a beneficiary.
 
-To calculate operator rewards and calculate merkle tree, drop option `-v`, and run:
+To calculate operator rewards and calculate merkle tree, drop option `--verify`, and run:
 
 ```
-./rewards-merkle-generator.sh -w <eth_host> -s <start_timestamp> -e <end_timestamp> -x <start_block> -y <end_block> -r <reward_allocation>
+./rewards-merkle-generator.sh \
+    --eth-host <eth_host> \
+    --start-timestamp <start_timestamp> \
+    --end-timestamp <end_timestamp> \
+    --start-block <start_block> \
+    --end-block <end_block> \
+    --allocation <reward_allocation>
 ```
 
 Merkle tree output will be written to `distributor/output-merkle-objects.json`.
@@ -111,5 +123,9 @@ The script will output information used to calculate rewards for each operator i
 text format that can be easily imported to a spreadsheet for inspection but is harder to verify
 just by looking at the output. 
 
-To enable additional operator authorization checks against Tenderly
-API, please use `-u <tenderly_url> -t <tenderly_token>` for running the script.
+To enable additional operator authorization checks against Tenderly API, please use:
+```
+--tenderly-url <tenderly_url>
+--tenderly-token <tenderly_token>
+```
+flags for running the script.

--- a/staker-rewards/README.adoc
+++ b/staker-rewards/README.adoc
@@ -129,3 +129,12 @@ To enable additional operator authorization checks against Tenderly API, please 
 --tenderly-token <tenderly_token>
 ```
 flags for running the script.
+
+=== Determining block number for a timestamp
+
+In order to determine the block number for an arbitrary timestamp, run:
+```
+./block-by-date.sh --eth-host <eth_host> --timestamp <timestamp>
+```
+The corresponding block number will be returned. We recommend to double-check
+the result on http://etherscan.io[Etherscan].

--- a/staker-rewards/block-by-date.js
+++ b/staker-rewards/block-by-date.js
@@ -2,8 +2,6 @@ import clc from "cli-color"
 import BlockByDate from "ethereum-block-by-date"
 import Context from "./lib/context.js"
 
-// Usage: ETH_HOSTNAME=<eth_host> node --experimental-json-modules \
-// block-by-date.js <timestamp>
 async function run() {
   const ethHostname = process.env.ETH_HOSTNAME
   const timestamp = process.argv[2]

--- a/staker-rewards/block-by-date.js
+++ b/staker-rewards/block-by-date.js
@@ -1,0 +1,31 @@
+import clc from "cli-color"
+import BlockByDate from "ethereum-block-by-date"
+import Context from "./lib/context.js"
+
+// Usage: ETH_HOSTNAME=<eth_host> node --experimental-json-modules \
+// block-by-date.js <timestamp>
+async function run() {
+  const ethHostname = process.env.ETH_HOSTNAME
+  const timestamp = process.argv[2]
+
+  if (!ethHostname) {
+    console.error(clc.red("Please provide ETH_HOSTNAME value"))
+    return
+  }
+
+  const { web3 } = await Context.initialize(ethHostname)
+  const blockByDate = new BlockByDate(web3)
+  return (await blockByDate.getDate(timestamp * 1000)).block
+}
+
+run()
+  .then((result) => {
+    console.log(clc.green(`Block ${result}`))
+
+    process.exit(0)
+  })
+  .catch((error) => {
+    console.trace(clc.red("Script errored out with error: "), error)
+
+    process.exit(1)
+  })

--- a/staker-rewards/block-by-date.sh
+++ b/staker-rewards/block-by-date.sh
@@ -1,0 +1,72 @@
+#!/bin/bash
+
+set -e
+
+LOG_START='\n\e[1;36m' # new line + bold + color
+LOG_END='\n\e[0m' # new line + reset color
+
+WORKDIR=$PWD
+
+NODE_CURRENT_VER="$(node --version)"
+NODE_REQUIRED_VER="v14.3.0"
+
+if [ "$(printf '%s\n' "$NODE_REQUIRED_VER" "$NODE_CURRENT_VER" | sort -V | head -n1)" != "$NODE_REQUIRED_VER" ]; 
+then
+      echo "Required node version must be at least ${NODE_REQUIRED_VER}" 
+      exit 1
+fi
+
+help()
+{
+   echo ""
+   echo "Usage: $0 --eth-host <eth_host> --timestamp <timestamp>"
+   echo -e "\t--eth-host Websocket endpoint of the Ethereum node"
+   echo -e "\t--timestamp Timestamp of the searched block"
+   exit 1 # Exit script after printing help
+}
+
+if [ "$1" == "-help" ]; then
+  help
+fi
+
+printf "${LOG_START}Processing input parameters...${LOG_END}"
+
+# Transform long options to short ones
+for arg in "$@"; do
+  shift
+  case "$arg" in
+    "--eth-host")  set -- "$@" "-h" ;;
+    "--timestamp") set -- "$@" "-t" ;;
+    *)             set -- "$@" "$arg"
+  esac
+done
+
+# Parse short options
+OPTIND=1
+while getopts "h:t:" opt
+do
+   case "$opt" in
+      h ) eth_host="$OPTARG" ;;
+      t ) timestamp="$OPTARG" ;;
+      ? ) help ;; # Print help in case parameter is non-existent
+   esac
+done
+shift $(expr $OPTIND - 1) # remove options from positional parameters
+
+#Print help in case required parameters are empty
+if [ -z "$eth_host" ] || [ -z "$timestamp" ]
+then
+   echo "Some or all of the required parameters are empty";
+   help
+fi
+
+printf "${LOG_START}Installing dependencies for staker-rewards...${LOG_END}"
+
+cd "$WORKDIR"
+npm i
+
+printf "${LOG_START}Looking for block...${LOG_END}"
+
+ETH_HOSTNAME="$eth_host" node --experimental-json-modules block-by-date.js "$timestamp"
+
+printf "${LOG_START}Script finished successfully${LOG_END}"

--- a/staker-rewards/rewards-merkle-generator.sh
+++ b/staker-rewards/rewards-merkle-generator.sh
@@ -22,7 +22,7 @@ fi
 help()
 {
    echo ""
-   echo "Usage: $0 -v -w <eth_host> -s <start_interval> -e <end_interval> -r <rewards> -u <tenderly_url> -t <tenderly_token>"
+   echo "Usage: $0 -v -w <eth_host> -s <start_interval> -e <end_interval> -x <start_block> -y <end_block> -r <rewards> -u <tenderly_url> -t <tenderly_token>"
    echo -e "\t-v Optional verify flag just to display the results without generation of a merkle tree"
    echo -e "\t-w Websocket endpoint of the Ethereum node"
    echo -e "\t-s Start of the interval passed as UNIX timestamp"
@@ -39,13 +39,15 @@ fi
 
 printf "${LOG_START}Processing input parameters...${LOG_END}"
 
-while getopts "vw:s:e:r:u:t:" opt
+while getopts "vw:s:e:x:y:r:u:t:" opt
 do
    case "$opt" in
       v ) verify=true ;;
       w ) eth_host="$OPTARG" ;;
       s ) start="$OPTARG" ;;
       e ) end="$OPTARG" ;;
+      x ) start_block="$OPTARG" ;;
+      y ) end_block="$OPTARG" ;;
       r ) rewards="$OPTARG" ;;
       u ) tenderly_url="$OPTARG" ;;
       t ) tenderly_token="$OPTARG" ;;
@@ -54,7 +56,7 @@ do
 done
 
 #Print help in case required parameters are empty
-if [ -z "$eth_host" ] || [ -z "$start" ] || [ -z "$end" ] || [ -z "$rewards" ]
+if [ -z "$eth_host" ] || [ -z "$start" ] || [ -z "$end" ] || [ -z "$start_block" ] || [ -z "$end_block" ] || [ -z "$rewards" ]
 then
    echo "Some or all of the required parameters are empty";
    help
@@ -85,7 +87,7 @@ ETH_HOSTNAME="$eth_host" \
 TENDERLY_PROJECT_URL="$tenderly_url" \
 TENDERLY_ACCESS_TOKEN="$tenderly_token" \
 REWARDS_PATH="$WORKDIR/$STAKER_REWARD" \
-node --experimental-json-modules rewards.js "$start" "$end" "$rewards"
+node --experimental-json-modules rewards.js "$start" "$end" "$start_block" "$end_block" "$rewards"
 
 printf "${LOG_START}Generating merkle output object...${LOG_END}"
 

--- a/staker-rewards/rewards-merkle-generator.sh
+++ b/staker-rewards/rewards-merkle-generator.sh
@@ -22,14 +22,25 @@ fi
 help()
 {
    echo ""
-   echo "Usage: $0 -v -w <eth_host> -s <start_interval> -e <end_interval> -x <start_block> -y <end_block> -r <rewards> -u <tenderly_url> -t <tenderly_token>"
-   echo -e "\t-v Optional verify flag just to display the results without generation of a merkle tree"
-   echo -e "\t-w Websocket endpoint of the Ethereum node"
-   echo -e "\t-s Start of the interval passed as UNIX timestamp"
-   echo -e "\t-e End of the interval passed as UNIX timestamp"
-   echo -e "\t-r Total KEEP rewards distributed within the given interval passed as 18-decimals number"
-   echo -e "\t-u Optional Tenderly API project URL"
-   echo -e "\t-t Optional access token for Tenderly API used to fetch transactions from the chain"
+   echo "Usage: $0"\
+        "--verify"\
+        "--eth-host <eth_host>"\
+        "--start-timestamp <start_timestamp>"\
+        "--end-timestamp <end_timestamp>"\
+        "--start-block <start_block>"\
+        "--end-block <end_block>"\
+        "--allocation <allocation>"\
+        "--tenderly-url <tenderly_url>"\
+        "--tenderly-token <tenderly_token>"
+   echo -e "\t--verify Optional verify flag just to display the results without generation of a merkle tree"
+   echo -e "\t--eth-host Websocket endpoint of the Ethereum node"
+   echo -e "\t--start-timestamp Start of the interval passed as UNIX timestamp"
+   echo -e "\t--end-timestamp End of the interval passed as UNIX timestamp"
+   echo -e "\t--start-block Start block of the interval"
+   echo -e "\t--end-block End block of the interval"
+   echo -e "\t--allocation Total KEEP rewards distributed within the given interval passed as 18-decimals number"
+   echo -e "\t--tenderly-url Optional Tenderly API project URL"
+   echo -e "\t--tenderly-token Optional access token for Tenderly API used to fetch transactions from the chain"
    exit 1 # Exit script after printing help
 }
 
@@ -39,21 +50,41 @@ fi
 
 printf "${LOG_START}Processing input parameters...${LOG_END}"
 
-while getopts "vw:s:e:x:y:r:u:t:" opt
+# Transform long options to short ones
+for arg in "$@"; do
+  shift
+  case "$arg" in
+    "--verify")          set -- "$@" "-v" ;;
+    "--eth-host")        set -- "$@" "-h" ;;
+    "--start-timestamp") set -- "$@" "-s" ;;
+    "--end-timestamp")   set -- "$@" "-e" ;;
+    "--start-block")     set -- "$@" "-x" ;;
+    "--end-block")       set -- "$@" "-y" ;;
+    "--allocation")      set -- "$@" "-a" ;;
+    "--tenderly-url")    set -- "$@" "-u" ;;
+    "--tenderly-token")  set -- "$@" "-t" ;;
+    *)                   set -- "$@" "$arg"
+  esac
+done
+
+# Parse short options
+OPTIND=1
+while getopts "vh:s:e:x:y:a:u:t:" opt
 do
    case "$opt" in
       v ) verify=true ;;
-      w ) eth_host="$OPTARG" ;;
+      h ) eth_host="$OPTARG" ;;
       s ) start="$OPTARG" ;;
       e ) end="$OPTARG" ;;
       x ) start_block="$OPTARG" ;;
       y ) end_block="$OPTARG" ;;
-      r ) rewards="$OPTARG" ;;
+      a ) rewards="$OPTARG" ;;
       u ) tenderly_url="$OPTARG" ;;
       t ) tenderly_token="$OPTARG" ;;
       ? ) help ;; # Print help in case parameter is non-existent
    esac
 done
+shift $(expr $OPTIND - 1) # remove options from positional parameters
 
 #Print help in case required parameters are empty
 if [ -z "$eth_host" ] || [ -z "$start" ] || [ -z "$end" ] || [ -z "$start_block" ] || [ -z "$end_block" ] || [ -z "$rewards" ]


### PR DESCRIPTION
Refs: #646

This pull request removes usage of the `ethereum-block-by-date` used to determine interval blocks basing on interval timestamps. Instead of that, it introduces the possibility to pass blocks as the script input, using `-x` and `-y` flags. The main motivation behind this change was inaccurate results returned by the library for timestamps relatively close to the script invocation timestamp. Providing interval timestamps as script input should give repeatable results and make sure no blocks are omitted or overlapping between intervals However, we leave the possibility to use the `ethereum-block-by-date` by introducing a separate `block-by-date.js` utility script.