### PR TITLE
Solidity contracts version 1.5.0 release

### DIFF
--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "1.5.0-pre.0",
+  "version": "1.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -942,9 +942,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "1.6.0-pre.1",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.6.0-pre.1.tgz",
-      "integrity": "sha512-dG8Sc7sjSsPJxmJHz5Fu/xwNYQbPJ1M5sUCZOiw3cKI/p0NKtcJrUzSlC1UERYRocw+uWECcd8O1WfCnu5H2Wg==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.6.0.tgz",
+      "integrity": "sha512-zVA1rvbaxyQ7riJsTCz90u1ILjhA4wYz6n/+F4ntlo7kMJ7iwYfKcscF9bhvA/wCBKECbqWrk0lL85QkTF+CDA==",
       "requires": {
         "@openzeppelin/upgrades": "^2.7.2",
         "openzeppelin-solidity": "2.4.0"

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "1.5.0",
+  "version": "1.6.0-pre.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -942,9 +942,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.6.0.tgz",
-      "integrity": "sha512-zVA1rvbaxyQ7riJsTCz90u1ILjhA4wYz6n/+F4ntlo7kMJ7iwYfKcscF9bhvA/wCBKECbqWrk0lL85QkTF+CDA==",
+      "version": "1.7.0-pre.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.7.0-pre.0.tgz",
+      "integrity": "sha512-4t8j1iOykPTPCgR1d83QIKl4kCiU/hLFFYtzz41epmTdUAGwLum142BG0A5dWy/B7f2Zpzj8wLDVXTo4drt8nw==",
       "requires": {
         "@openzeppelin/upgrades": "^2.7.2",
         "openzeppelin-solidity": "2.4.0"

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "1.5.0-pre.0",
+  "version": "1.5.0",
   "description": "Smart contracts for ECDSA Keep",
   "repository": {
     "type": "git",
@@ -34,8 +34,8 @@
   },
   "homepage": "https://github.com/keep-network/keep-ecdsa",
   "dependencies": {
-    "@keep-network/keep-core": ">1.6.0-pre <1.6.0-rc",
-    "@keep-network/sortition-pools": ">1.2.0-pre <1.2.0-rc",
+    "@keep-network/keep-core": "1.6.0",
+    "@keep-network/sortition-pools": "1.2.0-pre.3",
     "@openzeppelin/upgrades": "^2.7.2",
     "openzeppelin-solidity": "2.3.0"
   },

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "1.5.0",
+  "version": "1.6.0-pre.0",
   "description": "Smart contracts for ECDSA Keep",
   "repository": {
     "type": "git",
@@ -34,8 +34,8 @@
   },
   "homepage": "https://github.com/keep-network/keep-ecdsa",
   "dependencies": {
-    "@keep-network/keep-core": "1.6.0",
-    "@keep-network/sortition-pools": "1.2.0-pre.3",
+    "@keep-network/keep-core": ">1.7.0-pre <1.7.0-rc",
+    "@keep-network/sortition-pools": ">1.2.0-pre <1.2.0-rc",
     "@openzeppelin/upgrades": "^2.7.2",
     "openzeppelin-solidity": "2.3.0"
   },


### PR DESCRIPTION
This PR contains release of solidity contracts version `solidity/v1.5.0` for milestone https://github.com/keep-network/keep-ecdsa/milestone/23?closed=1.

dafa5ed4a19cc6333dcf76e1fa8892ff777f1247 commit was tagged with solidity/v1.5.0.