### PR TITLE
Return from monitoring loop on maxPubkeyChecksCount

### DIFF
--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -683,6 +683,7 @@ func (n *Node) monitorKeepPublicKeySubmission(
 					keepAddress.String(),
 					maxPubkeyChecksCount,
 				)
+				return
 			}
 
 			logger.Infof(


### PR DESCRIPTION
It may happen that one group member decides not to submit public key to
the chain (their Ethereum node is broken, they do not have enough ETH on
operator account) and the keep gets terminated. To prevent other,
properly working, group members to keep retrying submitting the key
indefinitely, we should exit the monitoring loop once the maximum number
of retries is reached.