### PR TITLE
Replaced ::set-env with env file in npm publishing action config

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -2,12 +2,12 @@ name: NPM
 
 on:
   push:
-    branches:
-      - master
-    paths:
-      - "solidity/contracts/**"
-      - "solidity/package.json"
-      - "solidity/package-lock.json"
+    # branches:
+    #   - master
+    # paths:
+    #   - "solidity/contracts/**"
+    #   - "solidity/package.json"
+    #   - "solidity/package-lock.json"
 
 jobs:
   publish-contracts:

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -29,7 +29,7 @@ jobs:
         working-directory: ./solidity
         run: |
           PACKAGE_VERSION=$(npm version prerelease --preid=pre)
-          echo "::set-env name=PACKAGE_VERSION::$PACKAGE_VERSION"
+          echo "PACKAGE_VERSION=$PACKAGE_VERSION" >> $GITHUB_ENV
       - name: Setup git
         run: |
           git remote set-url origin https://${{ secrets.CI_GITHUB_TOKEN }}@github.com/keep-network/keep-ecdsa.git

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "1.6.0-pre.1",
+  "version": "1.6.0-pre.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "1.6.0-pre.2",
+  "version": "1.6.0-pre.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "1.6.0-pre.0",
+  "version": "1.6.0-pre.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "1.6.0-pre.2",
+  "version": "1.6.0-pre.3",
   "description": "Smart contracts for ECDSA Keep",
   "repository": {
     "type": "git",

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "1.6.0-pre.1",
+  "version": "1.6.0-pre.2",
   "description": "Smart contracts for ECDSA Keep",
   "repository": {
     "type": "git",

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "1.6.0-pre.0",
+  "version": "1.6.0-pre.1",
   "description": "Smart contracts for ECDSA Keep",
   "repository": {
     "type": "git",


### PR DESCRIPTION
GitHub actions stopped supporting `::set-env` to set environment
property and require to store variables in file. We updated the
configuration to reflect it.
See: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/