### PR TITLE
Saddle BTC LP rewards

### DIFF
--- a/solidity/contracts/LPRewards.sol
+++ b/solidity/contracts/LPRewards.sol
@@ -248,8 +248,11 @@ contract LPRewardsTBTCSaddle is LPRewards {
 
     // if the pool is gated, disallow tx's that didn't come from msg.sender.
     function stake(uint256 amount) public {
-        // solium-disable-next-line security/no-tx-origin
-        require(!_gated || msg.sender == tx.origin, "Only EOA can stake");
+        require(
+            // solium-disable-next-line security/no-tx-origin
+            !_gated || msg.sender == tx.origin,
+            "Only Externally Owned Account can stake"
+        );
         super.stake(amount);
     }
 

--- a/solidity/contracts/LPRewards.sol
+++ b/solidity/contracts/LPRewards.sol
@@ -249,7 +249,7 @@ contract LPRewardsTBTCSaddle is LPRewards {
     // if the pool is gated, disallow tx's that didn't come from msg.sender.
     function stake(uint256 amount) public {
         // solium-disable-next-line security/no-tx-origin
-        require(!_gated || msg.sender == tx.origin, "EOA only plz");
+        require(!_gated || msg.sender == tx.origin, "Only EOA can stake");
         super.stake(amount);
     }
 

--- a/solidity/contracts/LPRewards.sol
+++ b/solidity/contracts/LPRewards.sol
@@ -239,7 +239,7 @@ contract LPRewardsKEEPTBTC is LPRewards {
 
 /// @title KEEP rewards for the tBTC Saddle liquidity pool.
 contract LPRewardsTBTCSaddle is LPRewards {
-    bool public _gated = true;
+    bool public gated = true;
 
     constructor(KeepToken keepToken, IERC20 tbtcSaddleLPToken)
         public
@@ -250,13 +250,13 @@ contract LPRewardsTBTCSaddle is LPRewards {
     function stake(uint256 amount) public {
         require(
             // solium-disable-next-line security/no-tx-origin
-            !_gated || msg.sender == tx.origin,
+            !gated || msg.sender == tx.origin,
             "Only Externally Owned Account can stake"
         );
         super.stake(amount);
     }
 
-    function setGated(bool gated) public onlyOwner {
-        _gated = gated;
+    function setGated(bool _gated) public onlyOwner {
+        gated = _gated;
     }
 }

--- a/solidity/contracts/LPRewards.sol
+++ b/solidity/contracts/LPRewards.sol
@@ -236,3 +236,24 @@ contract LPRewardsKEEPTBTC is LPRewards {
         LPRewards(keepToken, keepTbtcUniswapPair)
     {}
 }
+
+/// @title KEEP rewards for the tBTC Saddle liquidity pool.
+contract LPRewardsTBTCSaddle is LPRewards {
+    bool public _gated = true;
+
+    constructor(KeepToken keepToken, IERC20 tbtcSaddleLPToken)
+        public
+        LPRewards(keepToken, tbtcSaddleLPToken)
+    {}
+
+    // if the pool is gated, disallow tx's that didn't come from msg.sender.
+    function stake(uint256 amount) public {
+        // solium-disable-next-line security/no-tx-origin
+        require(!_gated || msg.sender == tx.origin, "EOA only plz");
+        super.stake(amount);
+    }
+
+    function setGated(bool gated) public onlyOwner {
+        _gated = gated;
+    }
+}

--- a/solidity/contracts/test/LPRewardsStaker.sol
+++ b/solidity/contracts/test/LPRewardsStaker.sol
@@ -1,0 +1,22 @@
+pragma solidity 0.5.17;
+
+import "../LPRewards.sol";
+
+contract LPRewardsStaker {
+
+    IERC20 public lpToken;
+    LPRewards public lpRewards;
+
+    constructor(
+        IERC20 _lpToken,
+        LPRewards _lpRewards
+    ) public {
+        lpToken = _lpToken;
+        lpRewards = _lpRewards;
+    }
+
+    function stake(uint256 amount) public {
+        lpToken.approve(address(lpRewards), amount);
+        lpRewards.stake(amount);
+    }
+}

--- a/solidity/test/LPRewardsTest.js
+++ b/solidity/test/LPRewardsTest.js
@@ -421,7 +421,7 @@ describe("LPRewardsTBTCSaddle", () => {
   let keepToken
   let lpToken
   let lpRewards
-  let lpRewardsStaker
+  let stakerContract
 
   before(async () => {
     keepToken = await KeepToken.new({from: keepTokenOwner})
@@ -431,7 +431,7 @@ describe("LPRewardsTBTCSaddle", () => {
       lpToken.address,
       {from: lpRewardsOwner}
     )
-    lpRewardsStaker = await LPRewardsStaker.new(
+    stakerContract = await LPRewardsStaker.new(
       lpToken.address,
       lpRewards.address
     )
@@ -497,8 +497,8 @@ describe("LPRewardsTBTCSaddle", () => {
       // ok, no did not revert
 
       // can contract stake?
-      await lpToken.mint(lpRewardsStaker.address, lpTokenAmount)
-      await lpRewardsStaker.stake(lpTokenAmount, {from: stakerEOA})
+      await lpToken.mint(stakerContract.address, lpTokenAmount)
+      await stakerContract.stake(lpTokenAmount, {from: stakerEOA})
       // ok, did not revert
     })
 
@@ -514,9 +514,9 @@ describe("LPRewardsTBTCSaddle", () => {
       // ok, no did not revert
 
       // can contract stake?
-      await lpToken.mint(lpRewardsStaker.address, lpTokenAmount)
+      await lpToken.mint(stakerContract.address, lpTokenAmount)
       await expectRevert(
-        lpRewardsStaker.stake(lpTokenAmount, {from: stakerEOA}),
+        stakerContract.stake(lpTokenAmount, {from: stakerEOA}),
         "Only Externally Owned Account can stake"
       )
     })

--- a/solidity/test/LPRewardsTest.js
+++ b/solidity/test/LPRewardsTest.js
@@ -468,6 +468,14 @@ describe("LPRewardsTBTCSaddle", () => {
         "Ownable: caller is not the owner"
       )
     })
+
+    it("updates gated state", async () => {
+      await lpRewards.setGated(false, {from: lpRewardsOwner})
+      expect(await lpRewards.gated()).to.be.false
+
+      await lpRewards.setGated(true, {from: lpRewardsOwner})
+      expect(await lpRewards.gated()).to.be.true
+    })
   })
 
   describe("stake", () => {

--- a/solidity/test/LPRewardsTest.js
+++ b/solidity/test/LPRewardsTest.js
@@ -485,35 +485,43 @@ describe("LPRewardsTBTCSaddle", () => {
   })
 
   describe("stake", () => {
-    it("allows anyone to stake in a non-gated state", async () => {
+    it("in the non-gated state allows an externally owned account to stake", async () => {
       await lpRewards.setGated(false, {from: lpRewardsOwner})
 
       const lpTokenAmount = web3.utils.toBN(1987).mul(tokenDecimalMultiplier)
 
-      // can EOA stake?
       await lpToken.mint(stakerEOA, lpTokenAmount)
       await lpToken.approve(lpRewards.address, lpTokenAmount, {from: stakerEOA})
       await lpRewards.stake(lpTokenAmount, {from: stakerEOA})
       // ok, no did not revert
+    })
 
-      // can contract stake?
+    it("in the non-gated state allows a contract to stake", async () => {
+      await lpRewards.setGated(false, {from: lpRewardsOwner})
+
+      const lpTokenAmount = web3.utils.toBN(1987).mul(tokenDecimalMultiplier)
+
       await lpToken.mint(stakerContract.address, lpTokenAmount)
       await stakerContract.stake(lpTokenAmount, {from: stakerEOA})
       // ok, did not revert
     })
 
-    it("allows only EOA to stake in a gated state", async () => {
+    it("in the gated state allows an externally owned account to stake", async () => {
       await lpRewards.setGated(true, {from: lpRewardsOwner})
 
       const lpTokenAmount = web3.utils.toBN(1987).mul(tokenDecimalMultiplier)
 
-      // can EOA stake?
       await lpToken.mint(stakerEOA, lpTokenAmount)
       await lpToken.approve(lpRewards.address, lpTokenAmount, {from: stakerEOA})
       await lpRewards.stake(lpTokenAmount, {from: stakerEOA})
       // ok, no did not revert
+    })
 
-      // can contract stake?
+    it("in the gated state does not allow a contract to stake", async () => {
+      await lpRewards.setGated(true, {from: lpRewardsOwner})
+
+      const lpTokenAmount = web3.utils.toBN(1987).mul(tokenDecimalMultiplier)
+
       await lpToken.mint(stakerContract.address, lpTokenAmount)
       await expectRevert(
         stakerContract.stake(lpTokenAmount, {from: stakerEOA}),

--- a/solidity/test/LPRewardsTest.js
+++ b/solidity/test/LPRewardsTest.js
@@ -503,7 +503,7 @@ describe("LPRewardsTBTCSaddle", () => {
       await lpToken.mint(lpRewardsStaker.address, lpTokenAmount)
       await expectRevert(
         lpRewardsStaker.stake(lpTokenAmount, {from: stakerEOA}),
-        "Only EOA can stake"
+        "Only Externally Owned Account can stake"
       )
     })
 

--- a/solidity/test/LPRewardsTest.js
+++ b/solidity/test/LPRewardsTest.js
@@ -456,6 +456,12 @@ describe("LPRewardsTBTCSaddle", () => {
     await restoreSnapshot()
   })
 
+  describe("constructor", () => {
+    it("enables gated state", async () => {
+      expect(await lpRewards.gated()).to.be.true
+    })
+  })
+
   describe("setGated", () => {
     it("can be called by owner", async () => {
       await lpRewards.setGated(false, {from: lpRewardsOwner})


### PR DESCRIPTION
Saddle BTC LP rewards contract.

`LPRewardsTBTCSaddle` is just like `LPRewards` contract except that it adds a notion of a guarded state in which only Externally Owner Accounts can stake tokens.