### PR TITLE
solidity/v1.6.0 release

### DIFF
--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "1.6.0-pre.0",
+  "version": "1.6.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -942,9 +942,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "1.7.0-pre.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.7.0-pre.0.tgz",
-      "integrity": "sha512-4t8j1iOykPTPCgR1d83QIKl4kCiU/hLFFYtzz41epmTdUAGwLum142BG0A5dWy/B7f2Zpzj8wLDVXTo4drt8nw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.6.0.tgz",
+      "integrity": "sha512-zVA1rvbaxyQ7riJsTCz90u1ILjhA4wYz6n/+F4ntlo7kMJ7iwYfKcscF9bhvA/wCBKECbqWrk0lL85QkTF+CDA==",
       "requires": {
         "@openzeppelin/upgrades": "^2.7.2",
         "openzeppelin-solidity": "2.4.0"
@@ -958,9 +958,9 @@
       }
     },
     "@keep-network/sortition-pools": {
-      "version": "1.2.0-pre.4",
-      "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-1.2.0-pre.4.tgz",
-      "integrity": "sha512-5zlbOUWCRkWBM55XK0TWt3+Xi4MPkph9JmhxqyNOSNMZD4BOtxuEinVVo+Ldy1NtIJHvqH7o/3O4wep4RPqmrQ==",
+      "version": "1.2.0-pre.3",
+      "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-1.2.0-pre.3.tgz",
+      "integrity": "sha512-MlhhegYQ/bG/vA9IT8Vxgn+ojvluC0YENF+Ic3xJNP6Ir/MEWH6gC7rDeaILzOJdqSVV5/8I53aTbYSRwzHoSg==",
       "requires": {
         "@openzeppelin/contracts": "^2.4.0"
       }

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "1.6.0",
+  "version": "1.7.0-pre.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -942,9 +942,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.6.0.tgz",
-      "integrity": "sha512-zVA1rvbaxyQ7riJsTCz90u1ILjhA4wYz6n/+F4ntlo7kMJ7iwYfKcscF9bhvA/wCBKECbqWrk0lL85QkTF+CDA==",
+      "version": "1.7.0-pre.5",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.7.0-pre.5.tgz",
+      "integrity": "sha512-1G7ls/G2D0nNnXppP8QPuppompk6YCFwveePqcWIYoV+ym/ac4IznoSBv4v4S4/p900pu2ZNrbXfj/VoHLqyrA==",
       "requires": {
         "@openzeppelin/upgrades": "^2.7.2",
         "openzeppelin-solidity": "2.4.0"

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "1.6.0",
+  "version": "1.7.0-pre.0",
   "description": "Smart contracts for ECDSA Keep",
   "repository": {
     "type": "git",
@@ -34,8 +34,8 @@
   },
   "homepage": "https://github.com/keep-network/keep-ecdsa",
   "dependencies": {
-    "@keep-network/keep-core": "1.6.0",
-    "@keep-network/sortition-pools": "1.2.0-pre.3",
+    "@keep-network/keep-core": ">1.7.0-pre <1.7.0-rc",
+    "@keep-network/sortition-pools": ">1.2.0-pre <1.2.0-rc",
     "@openzeppelin/upgrades": "^2.7.2",
     "openzeppelin-solidity": "2.3.0"
   },

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "1.6.0-pre.0",
+  "version": "1.6.0",
   "description": "Smart contracts for ECDSA Keep",
   "repository": {
     "type": "git",
@@ -34,8 +34,8 @@
   },
   "homepage": "https://github.com/keep-network/keep-ecdsa",
   "dependencies": {
-    "@keep-network/keep-core": ">1.7.0-pre <1.7.0-rc",
-    "@keep-network/sortition-pools": ">1.2.0-pre <1.2.0-rc",
+    "@keep-network/keep-core": "1.6.0",
+    "@keep-network/sortition-pools": "1.2.0-pre.3",
     "@openzeppelin/upgrades": "^2.7.2",
     "openzeppelin-solidity": "2.3.0"
   },


### PR DESCRIPTION
Updating versions for Solidity contracts v1.6.0 release.

https://github.com/keep-network/keep-ecdsa/pull/676/commits/1cac69b5f19b76cd953f93f2d788d0b6fa8811f3 is tagged as `solidity/v1.6.0` 

See https://github.com/keep-network/keep-ecdsa/milestone/24?closed=1