### PR TITLE
Deploy LPRewardsTBTCSaddle to local/Ropsten network

### DIFF
--- a/solidity/migrations/2_deploy_contracts.js
+++ b/solidity/migrations/2_deploy_contracts.js
@@ -25,6 +25,7 @@ const FullyBackedSortitionPoolFactory = artifacts.require(
 const LPRewardsTBTCETH = artifacts.require("LPRewardsTBTCETH")
 const LPRewardsKEEPETH = artifacts.require("LPRewardsKEEPETH")
 const LPRewardsKEEPTBTC = artifacts.require("LPRewardsKEEPTBTC")
+const LPRewardsTBTCSaddle = artifacts.require("LPRewardsTBTCSaddle")
 const TestToken = artifacts.require("./test/TestToken")
 const ECDSARewards = artifacts.require("ECDSARewards")
 const ECDSARewardsDistributor = artifacts.require("ECDSARewardsDistributor")
@@ -132,6 +133,13 @@ module.exports = async function (deployer, network) {
     LPRewardsKEEPTBTC,
     KeepTokenAddress,
     WrappedTokenKEEPTBTC.address
+  )
+
+  const WrappedTokenSaddle = await deployer.deploy(TestToken)
+  await deployer.deploy(
+    LPRewardsTBTCSaddle,
+    KeepTokenAddress,
+    WrappedTokenSaddle.address
   )
 
   // ECDSA Rewards

--- a/solidity/scripts/liquidity-rewards-starter.js
+++ b/solidity/scripts/liquidity-rewards-starter.js
@@ -1,6 +1,8 @@
 const LPRewardsTBTCETH = artifacts.require("LPRewardsTBTCETH")
 const LPRewardsKEEPETH = artifacts.require("LPRewardsKEEPETH")
 const LPRewardsKEEPTBTC = artifacts.require("LPRewardsKEEPTBTC")
+const LPRewardsTBTCSaddle = artifacts.require("LPRewardsTBTCSaddle")
+
 const TestToken = artifacts.require("./test/TestToken")
 const KeepToken = artifacts.require(
   "@keep-network/keep-core/build/truffle/KeepToken"
@@ -39,105 +41,72 @@ const mintAndApproveLPReward = async (
   })
 }
 
+const getWrappedTokenContract = async (LPRewardsContract) => {
+  const address = await LPRewardsContract.wrappedToken()
+  return await TestToken.at(address)
+}
+
 module.exports = async function () {
   try {
     const accounts = await web3.eth.getAccounts()
     const lpRewardsOwner = accounts[0]
+
+    const keepToken = await KeepToken.at(KeepTokenAddress)
     const lpRewardsKEEPETH = await LPRewardsKEEPETH.deployed()
     const lpRewardsTBTCETH = await LPRewardsTBTCETH.deployed()
     const lpRewardsKEEPTBTC = await LPRewardsKEEPTBTC.deployed()
-
-    const KEEPETHWrappedTokenAddress = await lpRewardsKEEPETH.wrappedToken()
-    const KEEPETHWrappedTokenContract = await TestToken.at(
-      KEEPETHWrappedTokenAddress
-    )
-
-    const TBTCETHWrappedTokenAddress = await lpRewardsTBTCETH.wrappedToken()
-    const TBTCETHHWrappedTokenContract = await TestToken.at(
-      TBTCETHWrappedTokenAddress
-    )
-
-    const KEEPTBTCWrappedTokenAddress = await lpRewardsKEEPTBTC.wrappedToken()
-    const KEEPTBTCHWrappedTokenContract = await TestToken.at(
-      KEEPTBTCWrappedTokenAddress
-    )
-
-    const keepToken = await KeepToken.at(KeepTokenAddress)
-
+    const lpRewardsTBTCSaddle = await LPRewardsTBTCSaddle.deployed()
     const reward = web3.utils.toWei("1000000")
 
-    await initLPRewardContract(
-      lpRewardsKEEPETH,
-      keepToken,
-      lpRewardsOwner,
-      reward
-    )
-    await initLPRewardContract(
-      lpRewardsTBTCETH,
-      keepToken,
-      lpRewardsOwner,
-      reward
-    )
-    await initLPRewardContract(
-      lpRewardsKEEPTBTC,
-      keepToken,
-      lpRewardsOwner,
-      reward
-    )
+    const LP_REWARDS = {
+      KEEP_ETH: {
+        contract: lpRewardsKEEPETH,
+        wrappedTokenContract: null,
+      },
+      TBTC_ETH: {
+        contract: lpRewardsTBTCETH,
+        wrappedTokenContract: null,
+      },
+      KEEP_TBTC: {
+        contract: lpRewardsKEEPTBTC,
+        wrappedTokenContract: null,
+      },
+      TBTC_SADDLE: {
+        contract: lpRewardsTBTCSaddle,
+        wrappedTokenContract: null,
+      },
+    }
 
-    const staker1 = accounts[8]
-    const staker1WrappedTokenBalance = web3.utils.toWei("300")
+    for (const key of Object.keys(LP_REWARDS)) {
+      LP_REWARDS[key].wrappedTokenContract = await getWrappedTokenContract(
+        LP_REWARDS[key].contract
+      )
 
-    const staker2 = accounts[9]
-    const staker2WrappedTokenBalance = web3.utils.toWei("700")
+      await initLPRewardContract(
+        LP_REWARDS[key].contract,
+        keepToken,
+        lpRewardsOwner,
+        reward
+      )
+    }
 
-    await mintAndApproveLPReward(
-      KEEPETHWrappedTokenContract,
-      lpRewardsKEEPETH.address,
-      staker1,
-      staker1WrappedTokenBalance
-    )
-    await mintAndApproveLPReward(
-      KEEPETHWrappedTokenContract,
-      lpRewardsKEEPETH.address,
-      staker2,
-      staker2WrappedTokenBalance
-    )
+    for (let i = 8; i < 10; i++) {
+      const staker = accounts[i]
+      const amount = web3.utils.toWei(`${i * 100}`)
 
-    await mintAndApproveLPReward(
-      TBTCETHHWrappedTokenContract,
-      lpRewardsTBTCETH.address,
-      staker1,
-      staker1WrappedTokenBalance
-    )
-    await mintAndApproveLPReward(
-      TBTCETHHWrappedTokenContract,
-      lpRewardsTBTCETH.address,
-      staker2,
-      staker2WrappedTokenBalance
-    )
+      for (const values of Object.values(LP_REWARDS)) {
+        const lpRewardsContract = values.contract
 
-    await mintAndApproveLPReward(
-      KEEPTBTCHWrappedTokenContract,
-      lpRewardsKEEPTBTC.address,
-      staker1,
-      staker1WrappedTokenBalance
-    )
-    await mintAndApproveLPReward(
-      KEEPTBTCHWrappedTokenContract,
-      lpRewardsKEEPTBTC.address,
-      staker2,
-      staker2WrappedTokenBalance
-    )
+        await mintAndApproveLPReward(
+          values.wrappedTokenContract,
+          lpRewardsContract.address,
+          staker,
+          amount
+        )
 
-    await lpRewardsKEEPETH.stake(staker1WrappedTokenBalance, { from: staker1 })
-    await lpRewardsKEEPETH.stake(staker2WrappedTokenBalance, { from: staker2 })
-
-    await lpRewardsTBTCETH.stake(staker1WrappedTokenBalance, { from: staker1 })
-    await lpRewardsTBTCETH.stake(staker2WrappedTokenBalance, { from: staker2 })
-
-    await lpRewardsKEEPTBTC.stake(staker1WrappedTokenBalance, { from: staker1 })
-    await lpRewardsKEEPTBTC.stake(staker2WrappedTokenBalance, { from: staker2 })
+        await lpRewardsContract.stake(amount, { from: staker })
+      }
+    }
   } catch (err) {
     console.error(err)
     process.exit(1)

--- a/solidity/scripts/liquidity-rewards-starter.js
+++ b/solidity/scripts/liquidity-rewards-starter.js
@@ -41,8 +41,8 @@ const mintAndApproveLPReward = async (
   })
 }
 
-const getWrappedTokenContract = async (LPRewardsContract) => {
-  const address = await LPRewardsContract.wrappedToken()
+const getWrappedTokenContract = async (lpRewardsContract) => {
+  const address = await lpRewardsContract.wrappedToken()
   return await TestToken.at(address)
 }
 
@@ -50,55 +50,35 @@ module.exports = async function () {
   try {
     const accounts = await web3.eth.getAccounts()
     const lpRewardsOwner = accounts[0]
-
     const keepToken = await KeepToken.at(KeepTokenAddress)
-    const lpRewardsKEEPETH = await LPRewardsKEEPETH.deployed()
-    const lpRewardsTBTCETH = await LPRewardsTBTCETH.deployed()
-    const lpRewardsKEEPTBTC = await LPRewardsKEEPTBTC.deployed()
-    const lpRewardsTBTCSaddle = await LPRewardsTBTCSaddle.deployed()
     const reward = web3.utils.toWei("1000000")
+    const LPRewardsContracts = [
+      LPRewardsKEEPETH,
+      LPRewardsTBTCETH,
+      LPRewardsKEEPTBTC,
+      LPRewardsTBTCSaddle,
+    ]
 
-    const LP_REWARDS = {
-      KEEP_ETH: {
-        contract: lpRewardsKEEPETH,
-        wrappedTokenContract: null,
-      },
-      TBTC_ETH: {
-        contract: lpRewardsTBTCETH,
-        wrappedTokenContract: null,
-      },
-      KEEP_TBTC: {
-        contract: lpRewardsKEEPTBTC,
-        wrappedTokenContract: null,
-      },
-      TBTC_SADDLE: {
-        contract: lpRewardsTBTCSaddle,
-        wrappedTokenContract: null,
-      },
-    }
-
-    for (const key of Object.keys(LP_REWARDS)) {
-      LP_REWARDS[key].wrappedTokenContract = await getWrappedTokenContract(
-        LP_REWARDS[key].contract
-      )
+    for (const LPRewardsContract of LPRewardsContracts) {
+      const lpRewardsContract = await LPRewardsContract.deployed()
 
       await initLPRewardContract(
-        LP_REWARDS[key].contract,
+        lpRewardsContract,
         keepToken,
         lpRewardsOwner,
         reward
       )
-    }
 
-    for (let i = 8; i < 10; i++) {
-      const staker = accounts[i]
-      const amount = web3.utils.toWei(`${i * 100}`)
+      const wrappedTokenContract = await getWrappedTokenContract(
+        lpRewardsContract
+      )
 
-      for (const values of Object.values(LP_REWARDS)) {
-        const lpRewardsContract = values.contract
+      for (let i = 8; i < 10; i++) {
+        const staker = accounts[i]
+        const amount = web3.utils.toWei(`${i * 100}`)
 
         await mintAndApproveLPReward(
-          values.wrappedTokenContract,
+          wrappedTokenContract,
           lpRewardsContract.address,
           staker,
           amount


### PR DESCRIPTION
This PR deploys the `LPRewardsTBTCSaddle` contract to the local/Ropsten network. It also fixes an issue that the KEEP token dashboard doesn't work because imports the `LPRewardsTBTCSaddle` that doesn't exist in the network.