### PR TITLE
Automatically Broadcast BTC Recovery Address

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -18,10 +18,10 @@ import (
 	eth "github.com/keep-network/keep-ecdsa/pkg/chain"
 	"github.com/keep-network/keep-ecdsa/pkg/client/event"
 	"github.com/keep-network/keep-ecdsa/pkg/ecdsa/tss"
+	"github.com/keep-network/keep-ecdsa/pkg/ecdsa/tss/params"
 	"github.com/keep-network/keep-ecdsa/pkg/node"
 	"github.com/keep-network/keep-ecdsa/pkg/registry"
 	"github.com/keep-network/keep-ecdsa/pkg/utils"
-	"github.com/keep-network/keep-ecdsa/pkg/ecdsa/tss/params"
 )
 
 var logger = log.Logger("keep-ecdsa")
@@ -173,13 +173,13 @@ func Initialize(
 				ctx,
 				ethereumChain,
 				networkProvider,
-				keepAddress,
-				operatorPublicKey,
 				clientConfig,
 				tssNode,
+				operatorPublicKey,
 				keepsRegistry,
-				subscriptionOnSignatureRequested,
 				eventDeduplicator,
+				keepAddress,
+				subscriptionOnSignatureRequested,
 			)
 
 		}(keepAddress)
@@ -505,17 +505,18 @@ func generateKeyForKeep(
 		subscriptionOnSignatureRequested,
 		eventDeduplicator,
 	)
+
 	go monitorKeepTerminatedEvent(
 		ctx,
 		ethereumChain,
 		networkProvider,
-		keepAddress,
-		operatorPublicKey,
 		clientConfig,
 		tssNode,
+		operatorPublicKey,
 		keepsRegistry,
-		subscriptionOnSignatureRequested,
 		eventDeduplicator,
+		keepAddress,
+		subscriptionOnSignatureRequested,
 	)
 }
 
@@ -874,13 +875,13 @@ func monitorKeepTerminatedEvent(
 	ctx context.Context,
 	ethereumChain eth.Handle,
 	networkProvider net.Provider,
-	keepAddress common.Address,
-	operatorPublicKey *operator.PublicKey,
 	clientConfig *Config,
 	tssNode *node.Node,
+	operatorPublicKey *operator.PublicKey,
 	keepsRegistry *registry.Keeps,
-	subscriptionOnSignatureRequested subscription.EventSubscription,
 	eventDeduplicator *event.Deduplicator,
+	keepAddress common.Address,
+	subscriptionOnSignatureRequested subscription.EventSubscription,
 ) {
 	keepTerminated := make(chan *eth.KeepTerminatedEvent)
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -18,7 +18,6 @@ import (
 	eth "github.com/keep-network/keep-ecdsa/pkg/chain"
 	"github.com/keep-network/keep-ecdsa/pkg/client/event"
 	"github.com/keep-network/keep-ecdsa/pkg/ecdsa/tss"
-	"github.com/keep-network/keep-ecdsa/pkg/ecdsa/tss/params"
 	"github.com/keep-network/keep-ecdsa/pkg/node"
 	"github.com/keep-network/keep-ecdsa/pkg/registry"
 	"github.com/keep-network/keep-ecdsa/pkg/utils"
@@ -938,8 +937,6 @@ func monitorKeepTerminatedEvent(
 					members,
 				)
 
-				preParamsBox := params.NewBox(nil)
-
 				tss.BroadcastRecoveryAddress(
 					ctx,
 					keepAddress.Hex(),
@@ -948,7 +945,6 @@ func monitorKeepTerminatedEvent(
 					uint(len(memberIDs)-1),
 					networkProvider,
 					ethereumChain.Signing().PublicKeyToAddress,
-					preParamsBox,
 				)
 
 				keepsRegistry.UnregisterKeep(keepAddress)

--- a/pkg/ecdsa/tss/gen/pb/message.pb.go
+++ b/pkg/ecdsa/tss/gen/pb/message.pb.go
@@ -6,13 +6,12 @@ package pb
 import (
 	bytes "bytes"
 	fmt "fmt"
+	proto "github.com/gogo/protobuf/proto"
 	io "io"
 	math "math"
 	math_bits "math/bits"
 	reflect "reflect"
 	strings "strings"
-
-	proto "github.com/gogo/protobuf/proto"
 )
 
 // Reference imports to suppress errors if they are not otherwise used.
@@ -179,31 +178,86 @@ func (m *AnnounceMessage) GetSenderID() []byte {
 	return nil
 }
 
+type LiquidationRecoveryMessage struct {
+	SenderID           []byte `protobuf:"bytes,1,opt,name=senderID,proto3" json:"senderID,omitempty"`
+	BtcRecoveryAddress string `protobuf:"bytes,2,opt,name=btcRecoveryAddress,proto3" json:"btcRecoveryAddress,omitempty"`
+}
+
+func (m *LiquidationRecoveryMessage) Reset()      { *m = LiquidationRecoveryMessage{} }
+func (*LiquidationRecoveryMessage) ProtoMessage() {}
+func (*LiquidationRecoveryMessage) Descriptor() ([]byte, []int) {
+	return fileDescriptor_8447775385e7eb85, []int{3}
+}
+func (m *LiquidationRecoveryMessage) XXX_Unmarshal(b []byte) error {
+	return m.Unmarshal(b)
+}
+func (m *LiquidationRecoveryMessage) XXX_Marshal(b []byte, deterministic bool) ([]byte, error) {
+	if deterministic {
+		return xxx_messageInfo_LiquidationRecoveryMessage.Marshal(b, m, deterministic)
+	} else {
+		b = b[:cap(b)]
+		n, err := m.MarshalToSizedBuffer(b)
+		if err != nil {
+			return nil, err
+		}
+		return b[:n], nil
+	}
+}
+func (m *LiquidationRecoveryMessage) XXX_Merge(src proto.Message) {
+	xxx_messageInfo_LiquidationRecoveryMessage.Merge(m, src)
+}
+func (m *LiquidationRecoveryMessage) XXX_Size() int {
+	return m.Size()
+}
+func (m *LiquidationRecoveryMessage) XXX_DiscardUnknown() {
+	xxx_messageInfo_LiquidationRecoveryMessage.DiscardUnknown(m)
+}
+
+var xxx_messageInfo_LiquidationRecoveryMessage proto.InternalMessageInfo
+
+func (m *LiquidationRecoveryMessage) GetSenderID() []byte {
+	if m != nil {
+		return m.SenderID
+	}
+	return nil
+}
+
+func (m *LiquidationRecoveryMessage) GetBtcRecoveryAddress() string {
+	if m != nil {
+		return m.BtcRecoveryAddress
+	}
+	return ""
+}
+
 func init() {
 	proto.RegisterType((*TSSProtocolMessage)(nil), "tss.TSSProtocolMessage")
 	proto.RegisterType((*ReadyMessage)(nil), "tss.ReadyMessage")
 	proto.RegisterType((*AnnounceMessage)(nil), "tss.AnnounceMessage")
+	proto.RegisterType((*LiquidationRecoveryMessage)(nil), "tss.LiquidationRecoveryMessage")
 }
 
 func init() { proto.RegisterFile("pb/message.proto", fileDescriptor_8447775385e7eb85) }
 
 var fileDescriptor_8447775385e7eb85 = []byte{
-	// 240 bytes of a gzipped FileDescriptorProto
-	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0xe2, 0x12, 0x28, 0x48, 0xd2, 0xcf,
-	0x4d, 0x2d, 0x2e, 0x4e, 0x4c, 0x4f, 0xd5, 0x2b, 0x28, 0xca, 0x2f, 0xc9, 0x17, 0x62, 0x2e, 0x29,
-	0x2e, 0x56, 0xea, 0x62, 0xe4, 0x12, 0x0a, 0x09, 0x0e, 0x0e, 0x00, 0x89, 0x24, 0xe7, 0xe7, 0xf8,
-	0x42, 0x54, 0x08, 0x49, 0x71, 0x71, 0x14, 0xa7, 0xe6, 0xa5, 0xa4, 0x16, 0x79, 0xba, 0x48, 0x30,
-	0x2a, 0x30, 0x6a, 0xf0, 0x04, 0xc1, 0xf9, 0x42, 0x12, 0x5c, 0xec, 0x05, 0x89, 0x95, 0x39, 0xf9,
-	0x89, 0x29, 0x12, 0x4c, 0x60, 0x29, 0x18, 0x57, 0x48, 0x81, 0x8b, 0x3b, 0xb3, 0xd8, 0xa9, 0x28,
-	0x3f, 0x31, 0x25, 0x39, 0xb1, 0xb8, 0x44, 0x82, 0x59, 0x81, 0x51, 0x83, 0x23, 0x08, 0x59, 0x48,
-	0x48, 0x86, 0x8b, 0xb3, 0x38, 0xb5, 0xb8, 0x38, 0x33, 0x3f, 0xcf, 0xd3, 0x45, 0x82, 0x45, 0x81,
-	0x51, 0x83, 0x33, 0x08, 0x21, 0xa0, 0xa4, 0xc5, 0xc5, 0x13, 0x94, 0x9a, 0x98, 0x52, 0x49, 0x84,
-	0x2b, 0x94, 0x74, 0xb9, 0xf8, 0x1d, 0xf3, 0xf2, 0xf2, 0x4b, 0xf3, 0x92, 0x53, 0x89, 0x50, 0xee,
-	0x64, 0x71, 0xe1, 0xa1, 0x1c, 0xc3, 0x8d, 0x87, 0x72, 0x0c, 0x1f, 0x1e, 0xca, 0x31, 0x36, 0x3c,
-	0x92, 0x63, 0x5c, 0xf1, 0x48, 0x8e, 0xf1, 0xc4, 0x23, 0x39, 0xc6, 0x0b, 0x8f, 0xe4, 0x18, 0x1f,
-	0x3c, 0x92, 0x63, 0x7c, 0xf1, 0x48, 0x8e, 0xe1, 0xc3, 0x23, 0x39, 0xc6, 0x09, 0x8f, 0xe5, 0x18,
-	0x2e, 0x3c, 0x96, 0x63, 0xb8, 0xf1, 0x58, 0x8e, 0x21, 0x8a, 0xa9, 0x20, 0x29, 0x89, 0x0d, 0x1c,
-	0x5a, 0xc6, 0x80, 0x00, 0x00, 0x00, 0xff, 0xff, 0x80, 0x6d, 0xec, 0x07, 0x41, 0x01, 0x00, 0x00,
+	// 284 bytes of a gzipped FileDescriptorProto
+	0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02, 0xff, 0x8c, 0x91, 0x31, 0x4b, 0x03, 0x41,
+	0x10, 0x85, 0x77, 0x12, 0xd1, 0x64, 0x0d, 0x28, 0x5b, 0x1d, 0x41, 0x86, 0x23, 0x55, 0x10, 0x8c,
+	0x85, 0x8d, 0x6d, 0x42, 0x9a, 0x80, 0x82, 0x6c, 0xac, 0xec, 0xf6, 0x6e, 0x17, 0x3d, 0x88, 0xbb,
+	0xe7, 0xcd, 0x45, 0x48, 0x67, 0x6d, 0xe5, 0xcf, 0xf0, 0xa7, 0x58, 0x5e, 0x99, 0xd2, 0xdb, 0x6b,
+	0x2c, 0xf3, 0x13, 0xc4, 0x93, 0xa8, 0x85, 0xc5, 0x95, 0xef, 0x7b, 0x6f, 0x98, 0x19, 0x1e, 0x3f,
+	0x4c, 0xa3, 0xd3, 0x7b, 0x43, 0xa4, 0x6e, 0xcd, 0x28, 0xcd, 0x5c, 0xee, 0x44, 0x3b, 0x27, 0x1a,
+	0x3c, 0x03, 0x17, 0xd7, 0xf3, 0xf9, 0xd5, 0x17, 0x89, 0xdd, 0xe2, 0xf2, 0x3b, 0x21, 0xfa, 0xbc,
+	0x43, 0xc6, 0x6a, 0x93, 0xcd, 0xa6, 0x01, 0x84, 0x30, 0xec, 0xc9, 0x1f, 0x2d, 0x02, 0xbe, 0x97,
+	0xaa, 0xd5, 0xc2, 0x29, 0x1d, 0xb4, 0x6a, 0x6b, 0x2b, 0x45, 0xc8, 0xf7, 0x13, 0x9a, 0x64, 0x4e,
+	0xe9, 0x58, 0x51, 0x1e, 0xb4, 0x43, 0x18, 0x76, 0xe4, 0x5f, 0x24, 0x8e, 0x78, 0x97, 0x0c, 0x51,
+	0xe2, 0xec, 0x6c, 0x1a, 0xec, 0x84, 0x30, 0xec, 0xca, 0x5f, 0x30, 0x38, 0xe6, 0x3d, 0x69, 0x94,
+	0x5e, 0x35, 0xb8, 0x62, 0x70, 0xc2, 0x0f, 0xc6, 0xd6, 0xba, 0xa5, 0x8d, 0x4d, 0x93, 0xf8, 0x1d,
+	0xef, 0x5f, 0x24, 0x0f, 0xcb, 0x44, 0xab, 0x3c, 0x71, 0x56, 0x9a, 0xd8, 0x3d, 0x9a, 0xac, 0xc9,
+	0x22, 0x31, 0xe2, 0x22, 0xca, 0xe3, 0xed, 0xc4, 0x58, 0xeb, 0xcc, 0x10, 0xd5, 0x9f, 0x77, 0xe5,
+	0x3f, 0xce, 0xe4, 0xbc, 0x28, 0x91, 0xad, 0x4b, 0x64, 0x9b, 0x12, 0xe1, 0xc9, 0x23, 0xbc, 0x7a,
+	0x84, 0x37, 0x8f, 0x50, 0x78, 0x84, 0x77, 0x8f, 0xf0, 0xe1, 0x91, 0x6d, 0x3c, 0xc2, 0x4b, 0x85,
+	0xac, 0xa8, 0x90, 0xad, 0x2b, 0x64, 0x37, 0xad, 0x34, 0x8a, 0x76, 0xeb, 0x5e, 0xce, 0x3e, 0x03,
+	0x00, 0x00, 0xff, 0xff, 0xd3, 0xc9, 0xfe, 0x9b, 0xab, 0x01, 0x00, 0x00,
 }
 
 func (this *TSSProtocolMessage) Equal(that interface{}) bool {
@@ -287,6 +341,33 @@ func (this *AnnounceMessage) Equal(that interface{}) bool {
 	}
 	return true
 }
+func (this *LiquidationRecoveryMessage) Equal(that interface{}) bool {
+	if that == nil {
+		return this == nil
+	}
+
+	that1, ok := that.(*LiquidationRecoveryMessage)
+	if !ok {
+		that2, ok := that.(LiquidationRecoveryMessage)
+		if ok {
+			that1 = &that2
+		} else {
+			return false
+		}
+	}
+	if that1 == nil {
+		return this == nil
+	} else if this == nil {
+		return false
+	}
+	if !bytes.Equal(this.SenderID, that1.SenderID) {
+		return false
+	}
+	if this.BtcRecoveryAddress != that1.BtcRecoveryAddress {
+		return false
+	}
+	return true
+}
 func (this *TSSProtocolMessage) GoString() string {
 	if this == nil {
 		return "nil"
@@ -317,6 +398,17 @@ func (this *AnnounceMessage) GoString() string {
 	s := make([]string, 0, 5)
 	s = append(s, "&pb.AnnounceMessage{")
 	s = append(s, "SenderID: "+fmt.Sprintf("%#v", this.SenderID)+",\n")
+	s = append(s, "}")
+	return strings.Join(s, "")
+}
+func (this *LiquidationRecoveryMessage) GoString() string {
+	if this == nil {
+		return "nil"
+	}
+	s := make([]string, 0, 6)
+	s = append(s, "&pb.LiquidationRecoveryMessage{")
+	s = append(s, "SenderID: "+fmt.Sprintf("%#v", this.SenderID)+",\n")
+	s = append(s, "BtcRecoveryAddress: "+fmt.Sprintf("%#v", this.BtcRecoveryAddress)+",\n")
 	s = append(s, "}")
 	return strings.Join(s, "")
 }
@@ -442,6 +534,43 @@ func (m *AnnounceMessage) MarshalToSizedBuffer(dAtA []byte) (int, error) {
 	return len(dAtA) - i, nil
 }
 
+func (m *LiquidationRecoveryMessage) Marshal() (dAtA []byte, err error) {
+	size := m.Size()
+	dAtA = make([]byte, size)
+	n, err := m.MarshalToSizedBuffer(dAtA[:size])
+	if err != nil {
+		return nil, err
+	}
+	return dAtA[:n], nil
+}
+
+func (m *LiquidationRecoveryMessage) MarshalTo(dAtA []byte) (int, error) {
+	size := m.Size()
+	return m.MarshalToSizedBuffer(dAtA[:size])
+}
+
+func (m *LiquidationRecoveryMessage) MarshalToSizedBuffer(dAtA []byte) (int, error) {
+	i := len(dAtA)
+	_ = i
+	var l int
+	_ = l
+	if len(m.BtcRecoveryAddress) > 0 {
+		i -= len(m.BtcRecoveryAddress)
+		copy(dAtA[i:], m.BtcRecoveryAddress)
+		i = encodeVarintMessage(dAtA, i, uint64(len(m.BtcRecoveryAddress)))
+		i--
+		dAtA[i] = 0x12
+	}
+	if len(m.SenderID) > 0 {
+		i -= len(m.SenderID)
+		copy(dAtA[i:], m.SenderID)
+		i = encodeVarintMessage(dAtA, i, uint64(len(m.SenderID)))
+		i--
+		dAtA[i] = 0xa
+	}
+	return len(dAtA) - i, nil
+}
+
 func encodeVarintMessage(dAtA []byte, offset int, v uint64) int {
 	offset -= sovMessage(v)
 	base := offset
@@ -503,6 +632,23 @@ func (m *AnnounceMessage) Size() (n int) {
 	return n
 }
 
+func (m *LiquidationRecoveryMessage) Size() (n int) {
+	if m == nil {
+		return 0
+	}
+	var l int
+	_ = l
+	l = len(m.SenderID)
+	if l > 0 {
+		n += 1 + l + sovMessage(uint64(l))
+	}
+	l = len(m.BtcRecoveryAddress)
+	if l > 0 {
+		n += 1 + l + sovMessage(uint64(l))
+	}
+	return n
+}
+
 func sovMessage(x uint64) (n int) {
 	return (math_bits.Len64(x|1) + 6) / 7
 }
@@ -538,6 +684,17 @@ func (this *AnnounceMessage) String() string {
 	}
 	s := strings.Join([]string{`&AnnounceMessage{`,
 		`SenderID:` + fmt.Sprintf("%v", this.SenderID) + `,`,
+		`}`,
+	}, "")
+	return s
+}
+func (this *LiquidationRecoveryMessage) String() string {
+	if this == nil {
+		return "nil"
+	}
+	s := strings.Join([]string{`&LiquidationRecoveryMessage{`,
+		`SenderID:` + fmt.Sprintf("%v", this.SenderID) + `,`,
+		`BtcRecoveryAddress:` + fmt.Sprintf("%v", this.BtcRecoveryAddress) + `,`,
 		`}`,
 	}, "")
 	return s
@@ -705,10 +862,7 @@ func (m *TSSProtocolMessage) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthMessage
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthMessage
 			}
 			if (iNdEx + skippy) > l {
@@ -792,10 +946,7 @@ func (m *ReadyMessage) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
-				return ErrInvalidLengthMessage
-			}
-			if (iNdEx + skippy) < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthMessage
 			}
 			if (iNdEx + skippy) > l {
@@ -879,10 +1030,123 @@ func (m *AnnounceMessage) Unmarshal(dAtA []byte) error {
 			if err != nil {
 				return err
 			}
-			if skippy < 0 {
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthMessage
 			}
-			if (iNdEx + skippy) < 0 {
+			if (iNdEx + skippy) > l {
+				return io.ErrUnexpectedEOF
+			}
+			iNdEx += skippy
+		}
+	}
+
+	if iNdEx > l {
+		return io.ErrUnexpectedEOF
+	}
+	return nil
+}
+func (m *LiquidationRecoveryMessage) Unmarshal(dAtA []byte) error {
+	l := len(dAtA)
+	iNdEx := 0
+	for iNdEx < l {
+		preIndex := iNdEx
+		var wire uint64
+		for shift := uint(0); ; shift += 7 {
+			if shift >= 64 {
+				return ErrIntOverflowMessage
+			}
+			if iNdEx >= l {
+				return io.ErrUnexpectedEOF
+			}
+			b := dAtA[iNdEx]
+			iNdEx++
+			wire |= uint64(b&0x7F) << shift
+			if b < 0x80 {
+				break
+			}
+		}
+		fieldNum := int32(wire >> 3)
+		wireType := int(wire & 0x7)
+		if wireType == 4 {
+			return fmt.Errorf("proto: LiquidationRecoveryMessage: wiretype end group for non-group")
+		}
+		if fieldNum <= 0 {
+			return fmt.Errorf("proto: LiquidationRecoveryMessage: illegal tag %d (wire type %d)", fieldNum, wire)
+		}
+		switch fieldNum {
+		case 1:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field SenderID", wireType)
+			}
+			var byteLen int
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMessage
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				byteLen |= int(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			if byteLen < 0 {
+				return ErrInvalidLengthMessage
+			}
+			postIndex := iNdEx + byteLen
+			if postIndex < 0 {
+				return ErrInvalidLengthMessage
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.SenderID = append(m.SenderID[:0], dAtA[iNdEx:postIndex]...)
+			if m.SenderID == nil {
+				m.SenderID = []byte{}
+			}
+			iNdEx = postIndex
+		case 2:
+			if wireType != 2 {
+				return fmt.Errorf("proto: wrong wireType = %d for field BtcRecoveryAddress", wireType)
+			}
+			var stringLen uint64
+			for shift := uint(0); ; shift += 7 {
+				if shift >= 64 {
+					return ErrIntOverflowMessage
+				}
+				if iNdEx >= l {
+					return io.ErrUnexpectedEOF
+				}
+				b := dAtA[iNdEx]
+				iNdEx++
+				stringLen |= uint64(b&0x7F) << shift
+				if b < 0x80 {
+					break
+				}
+			}
+			intStringLen := int(stringLen)
+			if intStringLen < 0 {
+				return ErrInvalidLengthMessage
+			}
+			postIndex := iNdEx + intStringLen
+			if postIndex < 0 {
+				return ErrInvalidLengthMessage
+			}
+			if postIndex > l {
+				return io.ErrUnexpectedEOF
+			}
+			m.BtcRecoveryAddress = string(dAtA[iNdEx:postIndex])
+			iNdEx = postIndex
+		default:
+			iNdEx = preIndex
+			skippy, err := skipMessage(dAtA[iNdEx:])
+			if err != nil {
+				return err
+			}
+			if (skippy < 0) || (iNdEx+skippy) < 0 {
 				return ErrInvalidLengthMessage
 			}
 			if (iNdEx + skippy) > l {

--- a/pkg/ecdsa/tss/gen/pb/message.proto
+++ b/pkg/ecdsa/tss/gen/pb/message.proto
@@ -17,3 +17,8 @@ message ReadyMessage {
 message AnnounceMessage {
   bytes senderID = 1;
 }
+
+message LiquidationRecoveryMessage {
+	bytes senderID = 1;
+	string btcRecoveryAddress = 2;
+}

--- a/pkg/ecdsa/tss/marshaling.go
+++ b/pkg/ecdsa/tss/marshaling.go
@@ -272,3 +272,25 @@ func (m *AnnounceMessage) Unmarshal(bytes []byte) error {
 
 	return nil
 }
+
+
+// Marshal converts this message to a byte array suitable for network communication.
+func (m *LiquidationRecoveryMessage) Marshal() ([]byte, error) {
+	return (&pb.LiquidationRecoveryMessage{
+		SenderID: m.SenderID,
+		BtcRecoveryAddress: m.BtcRecoveryAddress,
+	}).Marshal()
+}
+
+// Unmarshal converts a byte array produced by Marshal to a message.
+func (m *LiquidationRecoveryMessage) Unmarshal(bytes []byte) error {
+	pbMsg := &pb.LiquidationRecoveryMessage{}
+	if err := pbMsg.Unmarshal(bytes); err != nil {
+		return err
+	}
+
+	m.SenderID = pbMsg.SenderID
+	m.BtcRecoveryAddress = pbMsg.BtcRecoveryAddress
+
+	return nil
+}

--- a/pkg/ecdsa/tss/marshaling_test.go
+++ b/pkg/ecdsa/tss/marshaling_test.go
@@ -176,3 +176,37 @@ func TestFuzzAnnounceMessageRoundtrip(t *testing.T) {
 func TestFuzzAnnounceMessageUnmarshaler(t *testing.T) {
 	pbutils.FuzzUnmarshaler(&AnnounceMessage{})
 }
+
+func TestLiquidationRecoveryMessageRoundtrip(t *testing.T) {
+	for i := 0; i < 10; i++ {
+		var message LiquidationRecoveryMessage
+
+		f := fuzz.New().NilChance(0.1).NumElements(0, 512)
+		f.Fuzz(&message)
+
+		_ = pbutils.RoundTrip(&message, &ReadyMessage{})
+	}
+}
+
+func TestLiquidationRecoveryMessageMarshalling(t *testing.T) {
+	msg := &LiquidationRecoveryMessage{
+		SenderID: MemberID([]byte("member-1")),
+	}
+
+	unmarshaled := &LiquidationRecoveryMessage{}
+
+	if err := pbutils.RoundTrip(msg, unmarshaled); err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(msg, unmarshaled) {
+		t.Fatalf(
+			"unexpected content of unmarshaled message\nexpected: [%+v]\nactual:   [%+v]\n",
+			msg,
+			unmarshaled,
+		)
+	}
+}
+
+func TestFuzzLiquidationRecoveryMessageUnmarshaler(t *testing.T) {
+	pbutils.FuzzUnmarshaler(&LiquidationRecoveryMessage{})
+}

--- a/pkg/ecdsa/tss/marshaling_test.go
+++ b/pkg/ecdsa/tss/marshaling_test.go
@@ -2,9 +2,10 @@ package tss
 
 import (
 	"fmt"
-	fuzz "github.com/google/gofuzz"
 	"reflect"
 	"testing"
+
+	fuzz "github.com/google/gofuzz"
 
 	"github.com/keep-network/keep-ecdsa/internal/testdata"
 	"github.com/keep-network/keep-ecdsa/pkg/utils/pbutils"
@@ -177,7 +178,7 @@ func TestFuzzAnnounceMessageUnmarshaler(t *testing.T) {
 	pbutils.FuzzUnmarshaler(&AnnounceMessage{})
 }
 
-func TestLiquidationRecoveryMessageRoundtrip(t *testing.T) {
+func TestFuzzLiquidationRecoveryMessageRoundtrip(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		var message LiquidationRecoveryMessage
 
@@ -190,7 +191,8 @@ func TestLiquidationRecoveryMessageRoundtrip(t *testing.T) {
 
 func TestLiquidationRecoveryMessageMarshalling(t *testing.T) {
 	msg := &LiquidationRecoveryMessage{
-		SenderID: MemberID([]byte("member-1")),
+		SenderID:           MemberID([]byte("member-1")),
+		BtcRecoveryAddress: "bcrt1qgvlmm6pe4epm7j3mjwkvdf2ymymu8tes04t6cr",
 	}
 
 	unmarshaled := &LiquidationRecoveryMessage{}

--- a/pkg/ecdsa/tss/message.go
+++ b/pkg/ecdsa/tss/message.go
@@ -39,6 +39,15 @@ func (m *AnnounceMessage) Type() string {
 	return "ecdsa/announce_message"
 }
 
+type LiquidationRecoveryMessage struct {
+	SenderID MemberID
+	BtcRecoveryAddress string
+}
+
+func (m * LiquidationRecoveryMessage) Type() string {
+	return "ecdsa/liquidation_recovery_message"
+}
+
 func RegisterUnmarshalers(broadcastChannel net.BroadcastChannel) {
 	broadcastChannel.SetUnmarshaler(func() net.TaggedUnmarshaler {
 		return &AnnounceMessage{}
@@ -50,5 +59,9 @@ func RegisterUnmarshalers(broadcastChannel net.BroadcastChannel) {
 
 	broadcastChannel.SetUnmarshaler(func() net.TaggedUnmarshaler {
 		return &TSSProtocolMessage{}
+	})
+
+	broadcastChannel.SetUnmarshaler(func() net.TaggedUnmarshaler {
+		return &LiquidationRecoveryMessage{}
 	})
 }

--- a/pkg/ecdsa/tss/protocol_recovery.go
+++ b/pkg/ecdsa/tss/protocol_recovery.go
@@ -1,0 +1,147 @@
+package tss
+
+import (
+	"context"
+	cecdsa "crypto/ecdsa"
+	"fmt"
+	"time"
+
+	"github.com/keep-network/keep-core/pkg/net"
+)
+
+// BroadcastRecoveryAddress broadcasts and receives the BTC recovery addresses
+// of each client so that each client can retrieve the underlying bitcoin in
+// the case that a keep is terminated.
+func broadcastRecoveryAddress(
+	parentCtx context.Context,
+	groupID string,
+	memberID MemberID,
+	groupMemberIDs []MemberID,
+	dishonestThreshold uint,
+	networkProvider net.Provider,
+	pubKeyToAddressFn func(cecdsa.PublicKey) []byte,
+) error {
+	const protocolReadyTimeout = 2 * time.Minute
+
+	group := &groupInfo{
+		groupID:            groupID,
+		memberID:           memberID,
+		groupMemberIDs:     groupMemberIDs,
+		dishonestThreshold: int(dishonestThreshold),
+	}
+
+	netBridge, _ := newNetworkBridge(group, networkProvider)
+	broadcastChannel, _ := netBridge.getBroadcastChannel()
+	ctx, cancel := context.WithTimeout(parentCtx, protocolReadyTimeout)
+	defer cancel()
+
+	msgInChan := make(chan *LiquidationRecoveryMessage, len(group.groupMemberIDs))
+	handleLiquidationRecoveryMessage := func(netMsg net.Message) {
+		switch msg := netMsg.Payload().(type) {
+		case *LiquidationRecoveryMessage:
+			msgInChan <- msg
+		}
+	}
+	broadcastChannel.Recv(ctx, handleLiquidationRecoveryMessage)
+
+	memberBTCAddresses := make(map[string]string)
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case msg := <-msgInChan:
+				for _, memberID := range group.groupMemberIDs {
+					if msg.SenderID.Equal(memberID) {
+						memberAddress, err := memberIDToAddress(
+							memberID,
+							pubKeyToAddressFn,
+						)
+						if err != nil {
+							logger.Errorf(
+								"could not convert member ID to address for "+
+									"a member of keep [%s]: [%v]",
+								group.groupID,
+								err,
+							)
+							break
+						}
+						memberBTCAddresses[memberAddress] = msg.BtcRecoveryAddress
+
+						logger.Infof(
+							"member [%s] from keep [%s] announced supplied btc address [%s] for liquidation recovery",
+							memberAddress,
+							group.groupID,
+							msg.BtcRecoveryAddress,
+						)
+
+						break
+					}
+				}
+
+				if len(memberBTCAddresses) == len(group.groupMemberIDs) {
+					cancel()
+				}
+			}
+		}
+	}()
+
+	go func() {
+		sendMessage := func() {
+			if err := broadcastChannel.Send(ctx,
+				&LiquidationRecoveryMessage{SenderID: group.memberID, BtcRecoveryAddress: "abc123"},
+			); err != nil {
+				logger.Errorf("failed to send btc recovery address: [%v]", err)
+			}
+		}
+
+		// Send the message first time. It will be periodically retransmitted
+		// by the broadcast channel for the entire lifetime of the context.
+		sendMessage()
+
+		<-ctx.Done()
+		// Send the message once again as the member received messages
+		// from all peer members but not all peer members could receive
+		// the message from the member as some peer member could join
+		// the protocol after the member sent the last message.
+		sendMessage()
+		return
+	}()
+
+	<-ctx.Done()
+
+	switch ctx.Err() {
+	case context.DeadlineExceeded:
+		for _, memberID := range group.groupMemberIDs {
+			memberAddress, err := memberIDToAddress(memberID, pubKeyToAddressFn)
+			if err != nil {
+				logger.Errorf(
+					"could not convert member ID to address for a member of "+
+						"keep [%s]: [%v]",
+					group.groupID,
+					err,
+				)
+				continue
+			}
+			if _, present := memberBTCAddresses[memberAddress]; !present {
+				logger.Errorf(
+					"member [%s] has not supplied a btc recovery address for keep [%s]; "+
+						"check if keep client for that operator is active and "+
+						"connected",
+					memberAddress,
+					group.groupID,
+				)
+			}
+		}
+		return fmt.Errorf(
+			"waiting for btc recovery addresses timed out after: [%v]", protocolReadyTimeout,
+		)
+	case context.Canceled:
+		logger.Infof("successfully gathered all btc addresses")
+
+		return nil
+	default:
+		return fmt.Errorf("unexpected context error: [%v]", ctx.Err())
+	}
+}

--- a/pkg/ecdsa/tss/tss.go
+++ b/pkg/ecdsa/tss/tss.go
@@ -184,127 +184,13 @@ func BroadcastRecoveryAddress(
 	networkProvider net.Provider,
 	pubKeyToAddressFn func(cecdsa.PublicKey) []byte,
 ) error {
-	const protocolReadyTimeout = 2 * time.Minute
-
-	group := &groupInfo{
-		groupID:            groupID,
-		memberID:           memberID,
-		groupMemberIDs:     groupMemberIDs,
-		dishonestThreshold: int(dishonestThreshold),
-	}
-
-	netBridge, _ := newNetworkBridge(group, networkProvider)
-	broadcastChannel, _ := netBridge.getBroadcastChannel()
-	ctx, cancel := context.WithTimeout(parentCtx, protocolReadyTimeout)
-	defer cancel()
-
-	msgInChan := make(chan *LiquidationRecoveryMessage, len(group.groupMemberIDs))
-	handleLiquidationRecoveryMessage := func(netMsg net.Message) {
-		switch msg := netMsg.Payload().(type) {
-		case *LiquidationRecoveryMessage:
-			msgInChan <- msg
-		}
-	}
-	broadcastChannel.Recv(ctx, handleLiquidationRecoveryMessage)
-
-	memberBTCAddresses := make(map[string]string)
-
-	go func() {
-		for {
-			select {
-			case <-ctx.Done():
-				return
-			case msg := <-msgInChan:
-				for _, memberID := range group.groupMemberIDs {
-					if msg.SenderID.Equal(memberID) {
-						memberAddress, err := memberIDToAddress(
-							memberID,
-							pubKeyToAddressFn,
-						)
-						if err != nil {
-							logger.Errorf(
-								"could not convert member ID to address for "+
-									"a member of keep [%s]: [%v]",
-								group.groupID,
-								err,
-							)
-							break
-						}
-						memberBTCAddresses[memberAddress] = msg.BtcRecoveryAddress
-
-						logger.Infof(
-							"member [%s] from keep [%s] announced supplied btc address [%s] for liquidation recovery",
-							memberAddress,
-							group.groupID,
-							msg.BtcRecoveryAddress,
-						)
-
-						break
-					}
-				}
-
-				if len(memberBTCAddresses) == len(group.groupMemberIDs) {
-					cancel()
-				}
-			}
-		}
-	}()
-
-	go func() {
-		sendMessage := func() {
-			if err := broadcastChannel.Send(ctx,
-				&LiquidationRecoveryMessage{SenderID: group.memberID, BtcRecoveryAddress: "abc123"},
-			); err != nil {
-				logger.Errorf("failed to send btc recovery address: [%v]", err)
-			}
-		}
-
-		// Send the message first time. It will be periodically retransmitted
-		// by the broadcast channel for the entire lifetime of the context.
-		sendMessage()
-
-		<-ctx.Done()
-		// Send the message once again as the member received messages
-		// from all peer members but not all peer members could receive
-		// the message from the member as some peer member could join
-		// the protocol after the member sent the last message.
-		sendMessage()
-		return
-	}()
-
-	<-ctx.Done()
-
-	switch ctx.Err() {
-	case context.DeadlineExceeded:
-		for _, memberID := range group.groupMemberIDs {
-			memberAddress, err := memberIDToAddress(memberID, pubKeyToAddressFn)
-			if err != nil {
-				logger.Errorf(
-					"could not convert member ID to address for a member of "+
-						"keep [%s]: [%v]",
-					group.groupID,
-					err,
-				)
-				continue
-			}
-			if _, present := memberBTCAddresses[memberAddress]; !present {
-				logger.Errorf(
-					"member [%s] has not supplied a btc recovery address for keep [%s]; "+
-						"check if keep client for that operator is active and "+
-						"connected",
-					memberAddress,
-					group.groupID,
-				)
-			}
-		}
-		return fmt.Errorf(
-			"waiting for btc recovery addresses timed out after: [%v]", protocolReadyTimeout,
-		)
-	case context.Canceled:
-		logger.Infof("successfully gathered all btc addresses")
-
-		return nil
-	default:
-		return fmt.Errorf("unexpected context error: [%v]", ctx.Err())
-	}
+	return broadcastRecoveryAddress(
+		parentCtx,
+		groupID,
+		memberID,
+		groupMemberIDs,
+		dishonestThreshold,
+		networkProvider,
+		pubKeyToAddressFn,
+	)
 }

--- a/pkg/ecdsa/tss/tss.go
+++ b/pkg/ecdsa/tss/tss.go
@@ -19,8 +19,10 @@ import (
 )
 
 const (
+	// KeyGenerationProtocolTimeout is the amount of time before we give up on key generation
 	KeyGenerationProtocolTimeout = 8 * time.Minute
-	SigningProtocolTimeout       = 10 * time.Minute
+	// SigningProtocolTimeout is the amount of time before we give up on the signing protocol
+	SigningProtocolTimeout = 10 * time.Minute
 )
 
 var logger = log.Logger("keep-tss")
@@ -170,6 +172,9 @@ func (s *ThresholdSigner) CalculateSignature(
 	return signature, err
 }
 
+// BroadcastRecoveryAddress broadcasts and receives the BTC recovery addresses
+// of each client so that each client can retrieve the underlying bitcoin in
+// the case that a keep is terminated.
 func BroadcastRecoveryAddress(
 	parentCtx context.Context,
 	groupID string,
@@ -178,7 +183,6 @@ func BroadcastRecoveryAddress(
 	dishonestThreshold uint,
 	networkProvider net.Provider,
 	pubKeyToAddressFn func(cecdsa.PublicKey) []byte,
-	paramsBox *params.Box,
 ) error {
 	const protocolReadyTimeout = 2 * time.Minute
 
@@ -303,5 +307,4 @@ func BroadcastRecoveryAddress(
 	default:
 		return fmt.Errorf("unexpected context error: [%v]", ctx.Err())
 	}
-	return nil
 }

--- a/pkg/ecdsa/tss/tss.go
+++ b/pkg/ecdsa/tss/tss.go
@@ -169,3 +169,139 @@ func (s *ThresholdSigner) CalculateSignature(
 
 	return signature, err
 }
+
+func BroadcastRecoveryAddress(
+	parentCtx context.Context,
+	groupID string,
+	memberID MemberID,
+	groupMemberIDs []MemberID,
+	dishonestThreshold uint,
+	networkProvider net.Provider,
+	pubKeyToAddressFn func(cecdsa.PublicKey) []byte,
+	paramsBox *params.Box,
+) error {
+	const protocolReadyTimeout = 2 * time.Minute
+
+	group := &groupInfo{
+		groupID:            groupID,
+		memberID:           memberID,
+		groupMemberIDs:     groupMemberIDs,
+		dishonestThreshold: int(dishonestThreshold),
+	}
+
+	netBridge, _ := newNetworkBridge(group, networkProvider)
+	broadcastChannel, _ := netBridge.getBroadcastChannel()
+	ctx, cancel := context.WithTimeout(parentCtx, protocolReadyTimeout)
+	defer cancel()
+
+	msgInChan := make(chan *LiquidationRecoveryMessage, len(group.groupMemberIDs))
+	handleLiquidationRecoveryMessage := func(netMsg net.Message) {
+		switch msg := netMsg.Payload().(type) {
+		case *LiquidationRecoveryMessage:
+			msgInChan <- msg
+		}
+	}
+	broadcastChannel.Recv(ctx, handleLiquidationRecoveryMessage)
+
+	memberBTCAddresses := make(map[string]string)
+
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case msg := <-msgInChan:
+				for _, memberID := range group.groupMemberIDs {
+					if msg.SenderID.Equal(memberID) {
+						memberAddress, err := memberIDToAddress(
+							memberID,
+							pubKeyToAddressFn,
+						)
+						if err != nil {
+							logger.Errorf(
+								"could not convert member ID to address for "+
+									"a member of keep [%s]: [%v]",
+								group.groupID,
+								err,
+							)
+							break
+						}
+						memberBTCAddresses[memberAddress] = msg.BtcRecoveryAddress
+
+						logger.Infof(
+							"member [%s] from keep [%s] announced supplied btc address [%s] for liquidation recovery",
+							memberAddress,
+							group.groupID,
+							msg.BtcRecoveryAddress,
+						)
+
+						break
+					}
+				}
+
+				if len(memberBTCAddresses) == len(group.groupMemberIDs) {
+					cancel()
+				}
+			}
+		}
+	}()
+
+	go func() {
+		sendMessage := func() {
+			if err := broadcastChannel.Send(ctx,
+				&LiquidationRecoveryMessage{SenderID: group.memberID, BtcRecoveryAddress: "abc123"},
+			); err != nil {
+				logger.Errorf("failed to send btc recovery address: [%v]", err)
+			}
+		}
+
+		// Send the message first time. It will be periodically retransmitted
+		// by the broadcast channel for the entire lifetime of the context.
+		sendMessage()
+
+		<-ctx.Done()
+		// Send the message once again as the member received messages
+		// from all peer members but not all peer members could receive
+		// the message from the member as some peer member could join
+		// the protocol after the member sent the last message.
+		sendMessage()
+		return
+	}()
+
+	<-ctx.Done()
+
+	switch ctx.Err() {
+	case context.DeadlineExceeded:
+		for _, memberID := range group.groupMemberIDs {
+			memberAddress, err := memberIDToAddress(memberID, pubKeyToAddressFn)
+			if err != nil {
+				logger.Errorf(
+					"could not convert member ID to address for a member of "+
+						"keep [%s]: [%v]",
+					group.groupID,
+					err,
+				)
+				continue
+			}
+			if _, present := memberBTCAddresses[memberAddress]; !present {
+				logger.Errorf(
+					"member [%s] has not supplied a btc recovery address for keep [%s]; "+
+						"check if keep client for that operator is active and "+
+						"connected",
+					memberAddress,
+					group.groupID,
+				)
+			}
+		}
+		return fmt.Errorf(
+			"waiting for btc recovery addresses timed out after: [%v]", protocolReadyTimeout,
+		)
+	case context.Canceled:
+		logger.Infof("successfully gathered all btc addresses")
+
+		return nil
+	default:
+		return fmt.Errorf("unexpected context error: [%v]", ctx.Err())
+	}
+	return nil
+}


### PR DESCRIPTION
This PR marks the beginning of Liquidation Recovery Saga!

relevant threads: https://www.flowdock.com/app/cardforcoin/tech/threads/IME_6wBhIH6rYl2qUC_t0rQYggl https://www.flowdock.com/app/cardforcoin/tech/threads/yfCgVoCZf3BOyDm7_w3Q6kL9QXL

The aim of this PR is demonstrate a mechanism that broadcasts a BTC address to each other client in a signing group in the case of a `Terminated` event. The code draws heavily from `ready_protocol`, and I expect that the code in `tss.go` will find a new home elsewhere. The changes in `client.go` are all about exposing the data up the call-stack to `monitorKeepTerminatedEvent`.

#### To Test

Set up a whole local environment (geth, bitcoin, core, 3x ecdsa), then create a deposit (either through the dApp or through new my personal fav, 

```
$ bin/tbtc.js --rpc ws://127.0.0.1:8546 deposit new 10000000
```

Then, crash the collateralization to under 110% by running a script like:
```
const ETHBTCPriceFeedMock = artifacts.require("ETHBTCPriceFeedMock")

async function run() {
  try {
    const ethBtcPriceFeedMock = await ETHBTCPriceFeedMock.deployed()
    await ethBtcPriceFeedMock.setValue("03428571428602040")

    process.exit(0)
  } catch (ex) {
    console.error(ex)
    throw ex
  }
}

module.exports = run
```
in the `tbtc/solidity/scripts` directory via `$ truffle exec <script-name>`

After which, you can check the collateralization by running
```
$ bin/tbtc.js --rpc ws://127.0.0.1:8546 deposit list --vending-machine
```
and seeing an output like:
```
0x55B9684bF537FBCd50B9551195b7b4bC66d29f6c	ACTIVE	100000000	24
0xaBBd372A8891E39372b5b8DcC28B1065Dc052C9f	LIQUIDATION_IN_PROGRESS	10000000	0
```

Grab the address of one of of the `ACTIVE` deposits (in my case, that would be `0x55B9684bF537FBCd50B9551195b7b4bC66d29f6c`), and then liquidate it via:
```
$ bin/tbtc.js --rpc ws://127.0.0.1:8546 deposit 0x55B9684bF537FBCd50B9551195b7b4bC66d29f6c liquidate
```

Then watch your keep-ecdsa logs for messages that look like:
```
2021-02-11T17:02:50.006-0500    INFO    keep-tss    member [0x28bcfad75ee4c87b9089ba4c03a79b8148104da4] from keep [0xb2805515d0B9A58D8fE7D38eD71C97AF9393658F] announced supplied btc address [abc123] for liquidation recovery
2021-02-11T17:02:50.007-0500    INFO    keep-tss    member [0xb7021acafecf289fa345ecc95ecab18077530841] from keep [0xb2805515d0B9A58D8fE7D38eD71C97AF9393658F] announced supplied btc address [abc123] for liquidation recovery
2021-02-11T17:02:50.007-0500    INFO    keep-tss    member [0x65849fc91f8289b401e9d8f6d306b814b7f055c3] from keep [0xb2805515d0B9A58D8fE7D38eD71C97AF9393658F] announced supplied btc address [abc123] for liquidation recovery
```