### PR TITLE
Moved arguments for versioning in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,5 @@
 FROM golang:1.13.8-alpine3.10 AS gobuild
 
-ARG VERSION
-ARG REVISION
-
 ENV GOPATH=/go \
 	GOBIN=/go/bin \
 	APP_NAME=keep-ecdsa \
@@ -60,6 +57,10 @@ COPY ./ $APP_DIR/
 
 # Configure private repositories for Go dependencies
 ARG GOPRIVATE
+
+# Client Versioning.
+ARG VERSION
+ARG REVISION
 
 RUN GOOS=linux GOPRIVATE=$GOPRIVATE go build -ldflags "-X main.version=$VERSION -X main.revision=$REVISION" -a -o $APP_NAME ./ && \
 	mv $APP_NAME $BIN_PATH


### PR DESCRIPTION
As we expect the arguments to be updating, especially REVISION to be set
to the current commit hash we need to define them closer to the place
they will be used. Currently, if we update a value for REVISION it causes
all subsequent layers to be executed and not fetched from the cache. There's
actually nothing changing besides the commit hash we pass to go build
command, so all the layers can be reused.