### PR TITLE
Updated docs pointing to ropsten contracts

### DIFF
--- a/docs/run-keep-ecdsa.adoc
+++ b/docs/run-keep-ecdsa.adoc
@@ -457,13 +457,13 @@ Contract addresses needed to boot a Keep ECDSA client:
 |
 
 |BondedECDSAKeepFactory
-|`0x9EcCf03dFBDa6A5E50d7aBA14e0c60c2F6c575E6`
+|`0x26dBc9eF92a062c41FB07513313D14Fd54B630e5`
 
 |Sanctioned Applications
-|`0xc3f96306eDabACEa249D2D22Ec65697f38c6Da69` (tBTC's system contract)
+|`0xA41ffe9d9BAD45aD884e5100E6e201854912373E` (tBTC's system contract)
 
 |tBTC Sortition pool (for <<Authorizations,authorization>>)
-|`0x20F1f14a42135d3944fEd1AeD2bE13b01c152054`
+|`0xBE0994212CBFd7A22bCA9F73F253AB15e767053b`
 |===
 
 

--- a/infrastructure/kube/keep-test/keep-ecdsa-0-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-ecdsa-0-statefulset.yaml
@@ -109,7 +109,7 @@ spec:
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
             - name: SANCTIONED_APPLICATIONS
-              value: '0x14dC06F762E7f4a756825c1A1dA569b3180153cB' # Shall we extract this property to a configmap?
+              value: '0xA41ffe9d9BAD45aD884e5100E6e201854912373E' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-test/keep-ecdsa-1-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-ecdsa-1-statefulset.yaml
@@ -109,7 +109,7 @@ spec:
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
             - name: SANCTIONED_APPLICATIONS
-              value: '0x576ad5Ced9D0030D2F26E2F08BD2E92de9fcD858' # Shall we extract this property to a configmap?
+              value: '0xA41ffe9d9BAD45aD884e5100E6e201854912373E' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-test/keep-ecdsa-1-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-ecdsa-1-statefulset.yaml
@@ -77,12 +77,12 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: eth-network-ropsten
-                  key: rpc-url
+                  key: keep-ecdsa-rpc-url
             - name: ETH_WS_URL
               valueFrom:
                 secretKeyRef:
                   name: eth-network-ropsten
-                  key: ws-url
+                  key: keep-ecdsa-ws-url
             - name: ETH_NETWORK_ID
               valueFrom:
                 configMapKeyRef:

--- a/infrastructure/kube/keep-test/keep-ecdsa-2-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-ecdsa-2-statefulset.yaml
@@ -110,7 +110,7 @@ spec:
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
             - name: SANCTIONED_APPLICATIONS
-              value: '0xc3f96306eDabACEa249D2D22Ec65697f38c6Da69' # Shall we extract this property to a configmap?
+              value: '0xA41ffe9d9BAD45aD884e5100E6e201854912373E' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-test/keep-ecdsa-3-statefulset.yaml
+++ b/infrastructure/kube/keep-test/keep-ecdsa-3-statefulset.yaml
@@ -110,7 +110,7 @@ spec:
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
             - name: SANCTIONED_APPLICATIONS
-              value: '0xc3f96306eDabACEa249D2D22Ec65697f38c6Da69' # Shall we extract this property to a configmap?
+              value: '0xA41ffe9d9BAD45aD884e5100E6e201854912373E' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config


### PR DESCRIPTION
Updated contracts addresses in test environment documentation. The
contracts were migrated in `@keep-network/keep-ecdsa@1.5.1-rc.1` and are
currently backed by nodes running in keep-test environment.

Circle CI job: https://app.circleci.com/pipelines/github/keep-network/keep-ecdsa/3184/workflows/3f823f9b-5a20-4d05-8bcb-dbf7034f59e6