### PR TITLE
Removal of unnecessary solidity/dashboard exclusion

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -9,7 +9,6 @@ on:
       - "rfc-18/**"
     paths:
       - "solidity/**"
-      - "!solidity/dashboard/**"
       - ".github/workflows/contracts.yml"
   pull_request:
     branches:
@@ -17,7 +16,6 @@ on:
       - "rfc-18/**"
     paths:
       - "solidity/**"
-      - "!solidity/dashboard/**"
       - ".github/workflows/contracts.yml"
 
 jobs:


### PR DESCRIPTION
Path `solidity/dashboard/**` was configured as a excluded path in the
conditions for triggering of workflows. This configuration was obsolete,
as there is no 'solidity/dashboard/` in keep-ecdsa project.