### PR TITLE
Pull changes in `ContractAddress` method

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,8 +19,8 @@ require (
 	github.com/gogo/protobuf v1.3.1
 	github.com/google/gofuzz v1.1.0
 	github.com/ipfs/go-log v1.0.4
-	github.com/keep-network/keep-common v1.3.1-0.20210226151147-28633644e7e5
-	github.com/keep-network/keep-core v1.3.2-0.20210225151037-3f9f104b3d8b
+	github.com/keep-network/keep-common v1.3.1-0.20210304083053-baf172c68552
+	github.com/keep-network/keep-core v1.3.2-0.20210304083305-d08fdb9170d5
 	github.com/keep-network/tbtc v1.1.1-0.20210303113031-adf361fd085b
 	github.com/pkg/errors v0.9.1
 	github.com/urfave/cli v1.22.1

--- a/go.sum
+++ b/go.sum
@@ -344,12 +344,12 @@ github.com/keep-network/cli v1.20.0 h1:mEufpPsovOVdduTTkk+a2CxS3crIrGFqUsvs58gSi
 github.com/keep-network/cli v1.20.0/go.mod h1:nzsst4JjU+rGE8Q5J839fYxectxWHpLhxKNohQWtQhA=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec h1:2pXAsi4OUUjZKr5ds5UOF2IxXN+jVW0WetVO+czkf+A=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec/go.mod h1:xR8jf3/VJAjh3nWu5tFe8Yxnt2HvWsqZHfGef1P5oDk=
-github.com/keep-network/keep-common v1.3.1-0.20210225144425-98d03fe6e9bd h1:Aoy92eomiXN3J+CesSLaH9z6ckJmnIBGr281XZZ3Vt4=
-github.com/keep-network/keep-common v1.3.1-0.20210225144425-98d03fe6e9bd/go.mod h1:sldQ7H2fdJWFdYUJCe/UsMGlyqtoT+39o7GTvpUVWnI=
 github.com/keep-network/keep-common v1.3.1-0.20210226151147-28633644e7e5 h1:hzkjJv1bgn5nxibcDgAT3mHNsHZjMnYUW2F/wn/AGrs=
 github.com/keep-network/keep-common v1.3.1-0.20210226151147-28633644e7e5/go.mod h1:sldQ7H2fdJWFdYUJCe/UsMGlyqtoT+39o7GTvpUVWnI=
-github.com/keep-network/keep-core v1.3.2-0.20210225151037-3f9f104b3d8b h1:Q2mNJyYpeB/RR/PFbjTTYr1jJvjLhSWQmNUnBZBDUIM=
-github.com/keep-network/keep-core v1.3.2-0.20210225151037-3f9f104b3d8b/go.mod h1:D5MXDiDxYfUMOvNOWJgd+jx0WHU4CTfjPvvTIOn0NA0=
+github.com/keep-network/keep-common v1.3.1-0.20210304083053-baf172c68552 h1:N3FQultvCbxwGoXWlSF4WWQnPOohuPSDwS+ZFpiiqLg=
+github.com/keep-network/keep-common v1.3.1-0.20210304083053-baf172c68552/go.mod h1:eM8DwRcQYzq5TYQSn9iOFXfvnAh2w1xWQmpIoG1cdpo=
+github.com/keep-network/keep-core v1.3.2-0.20210304083305-d08fdb9170d5 h1:o6kfolnjNHr6zDxxKmqgNYytHUv3LZsZ10fZ1LWfV4c=
+github.com/keep-network/keep-core v1.3.2-0.20210304083305-d08fdb9170d5/go.mod h1:wa98Eftg9XT7WKvuPkQQH5z8RIx93ApTVNMVit6non4=
 github.com/keep-network/tbtc v1.1.1-0.20210303113031-adf361fd085b h1:D6FOQK7Q1AUBrXpoo/EKeV06NIClsU9E1+n1BuJUMF4=
 github.com/keep-network/tbtc v1.1.1-0.20210303113031-adf361fd085b/go.mod h1:s2IqWSI3YS++2GIftOe+E3cUBprWK7eHI08TL1wHNwE=
 github.com/keep-network/toml v0.3.0 h1:G+NJwWR/ZiORqeLBsDXDchYoL29PXHdxOPcCueA7ctE=

--- a/pkg/chain/celo/connect.go
+++ b/pkg/chain/celo/connect.go
@@ -123,7 +123,7 @@ func Connect(
 		// but make sure an empty address is in place. A missing TBTCSystem
 		// address should only mean that we fail to start the tBTC app handling,
 		// not that the whole client fails to start.
-		tbtcSystemAddress = &common.Address{}
+		tbtcSystemAddress = common.Address{}
 	}
 
 	bondedECDSAKeepFactoryContractAddress, err := config.ContractAddress(
@@ -134,7 +134,7 @@ func Connect(
 	}
 
 	bondedECDSAKeepFactoryContract, err := contract.NewBondedECDSAKeepFactory(
-		*bondedECDSAKeepFactoryContractAddress,
+		bondedECDSAKeepFactoryContractAddress,
 		accountKey,
 		wrappedClient,
 		nonceManager,
@@ -151,7 +151,7 @@ func Connect(
 		accountKey:                     accountKey,
 		client:                         wrappedClient,
 		bondedECDSAKeepFactoryContract: bondedECDSAKeepFactoryContract,
-		tbtcSystemAddress:              *tbtcSystemAddress,
+		tbtcSystemAddress:              tbtcSystemAddress,
 		blockCounter:                   blockCounter,
 		nonceManager:                   nonceManager,
 		miningWaiter:                   miningWaiter,

--- a/pkg/chain/ethereum/connect.go
+++ b/pkg/chain/ethereum/connect.go
@@ -122,7 +122,7 @@ func Connect(
 		// but make sure an empty address is in place. A missing TBTCSystem
 		// address should only mean that we fail to start the tBTC app handling,
 		// not that the whole client fails to start.
-		tbtcSystemAddress = &common.Address{}
+		tbtcSystemAddress = common.Address{}
 	}
 
 	bondedECDSAKeepFactoryContractAddress, err := config.ContractAddress(
@@ -132,7 +132,7 @@ func Connect(
 		return nil, err
 	}
 	bondedECDSAKeepFactoryContract, err := contract.NewBondedECDSAKeepFactory(
-		*bondedECDSAKeepFactoryContractAddress,
+		bondedECDSAKeepFactoryContractAddress,
 		accountKey,
 		wrappedClient,
 		nonceManager,
@@ -150,7 +150,7 @@ func Connect(
 		client:     wrappedClient,
 
 		bondedECDSAKeepFactoryContract: bondedECDSAKeepFactoryContract,
-		tbtcSystemAddress:              *tbtcSystemAddress,
+		tbtcSystemAddress:              tbtcSystemAddress,
 		blockCounter:                   blockCounter,
 		nonceManager:                   nonceManager,
 		miningWaiter:                   miningWaiter,


### PR DESCRIPTION
Depends on: https://github.com/keep-network/keep-common/pull/70
Depends on: https://github.com/keep-network/keep-core/pull/2360
Depends on: #714 

Updated `keep-common` dependency and adjusted the code to changes made in the `ContractAddress` method exposed by config structs.