### PR TITLE
Backport: Increased default max gas price to 1000 Gwei

### DIFF
--- a/configs/config.toml.SAMPLE
+++ b/configs/config.toml.SAMPLE
@@ -19,7 +19,7 @@
 	# performed.A value can be provided in `wei`, `Gwei` or `ether`, e.g.
 	# `800.5 Gwei`.
 	#
-	# MaxGasPrice = "500 Gwei" # 500 Gwei (default value)
+	# MaxGasPrice = "1000 Gwei" # 1000 Gwei (default value)
 	#
   # Uncomment to enable Ethereum node rate limiting. Both properties can be
   # used together or separately.

--- a/pkg/chain/ethereum/connect.go
+++ b/pkg/chain/ethereum/connect.go
@@ -41,7 +41,7 @@ var (
 	// gas price can not be higher than the max gas price value. If the maximum
 	// allowed gas price is reached, no further resubmission attempts are
 	// performed. This value can be overwritten in the configuration file.
-	DefaultMaxGasPrice = big.NewInt(500000000000) // 500 Gwei
+	DefaultMaxGasPrice = big.NewInt(1000000000000) // 1000 Gwei
 )
 
 // ethereumChain is an implementation of ethereum blockchain interface.


### PR DESCRIPTION
On 2021-02-23 we observed the average gas price on mainnet went up to 
625 Gwei. Some operators were required to update their config files
as the default value of 500 Gwei was no longer enough.

Given that we observe high gas prices quite frequently, this change bumps
up the default max gas price to 1000 Gwei.

It does not mean it is the price every transaction will be submitted
with. This is the _maximum_ the client can bump up the gas price to if
the transaction was not mined in the specific time frame. Gas price bumps
happen incrementally over time as long as the transaction sits in the mempool
or until the max allowed gas price is reached.