### PR TITLE
Move migration and publishing of contracts (Ethereum) to GH Actions

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,6 +143,8 @@ jobs:
           root: /tmp/keep-ecdsa
           paths:
             - docker-images
+  # GitHub Actions equivalent of this job (.github/workflows/contracts.yml) 
+  # has been created as part of work on RFC-18
   migrate_contracts:
     executor: docker-node-gcloud
     steps:
@@ -171,6 +173,8 @@ jobs:
           root: /tmp/keep-ecdsa
           paths:
             - contracts
+  # GitHub Actions equivalent of this job (.github/workflows/contracts.yml) 
+  # has been created as part of work on RFC-18
   publish_npm_package:
     executor: docker-node
     steps:
@@ -263,6 +267,8 @@ jobs:
           registry-url: $GCR_REGISTRY_URL
           image: initcontainer-provision-keep-ecdsa
           tag: latest
+  # GitHub Actions equivalent of this job (.github/workflows/contracts.yml) 
+  # has been created as part of work on RFC-18
   publish_contract_data:
     executor: gcp-cli/default
     steps:

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -92,8 +92,7 @@ jobs:
         || github.ref == 'refs/heads/master')
         && (github.event_name == 'push'
         || github.event_name == 'workflow_dispatch')
-    # TODO: Implement similiar for keep-dev (should execute for rfc-18... & master branch)
-    environment: keep-test # currently keep-test requires manual aproval of job
+    environment: keep-test # keep-test requires a manual aproval
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -141,7 +140,7 @@ jobs:
           TRUFFLE_NETWORK: ${{ secrets.KEEP_TEST_ETH_TRUFFLE_NETWORK }}
           ETH_HOSTNAME: ${{ secrets.KEEP_TEST_ETH_HOSTNAME }}
           CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY: ${{ secrets.KEEP_TEST_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
-        run: npx truffle migrate --reset --network $TRUFFLE_NETWORK # writes artifacts to /home/runner/work/keep-ecdsa/keep-ecdsa/solidity/build/contracts
+        run: npx truffle migrate --reset --network $TRUFFLE_NETWORK
 
       - name: Push contracts to Tenderly
         # TODO: once below action gets tagged replace `@main` with `@v1`
@@ -177,16 +176,6 @@ jobs:
         run: |
           echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }} > .npmrc
           npm publish --access=public --dry-run
-
-      # TODO: consider swithing to below action, after tweaking
-      # (requires some changes, as below config throws an error)
-      # - name: Publish to npm
-      #   uses: JS-DevTools/npm-publish@v1
-      #   with:
-      #     package: ./solidity/package.json
-      #     token: ${{ secrets.NPM_TOKEN }}
-      #     access: public
-      #     dry-run: true # TODO: to be removed once testing of workflow is done
   
   migrate-and-publish-celo:
     needs: [build-and-test, lint]

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -18,6 +18,7 @@ on:
     paths:
       - "solidity/**"
       - ".github/workflows/contracts.yml"
+  workflow_dispatch:
 
 jobs:
   build-and-test:
@@ -83,6 +84,110 @@ jobs:
       - name: Lint
         run: npm run lint
 
+  migrate-and-publish-ethereum:
+    needs: [build-and-test, lint]
+    # TODO: Remove 'rfc-18/' condition once migration to GH Actions is done
+    if: |
+      (startsWith(github.ref, 'refs/heads/rfc-18/')
+        || github.ref == 'refs/heads/master')
+        && (github.event_name == 'push'
+        || github.event_name == 'workflow_dispatch')
+    # TODO: Implement similiar for keep-dev (should execute for rfc-18... & master branch)
+    environment: keep-test # currently keep-test requires manual aproval of job
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12.x]
+    defaults:
+      run:
+        working-directory: ./solidity
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Cache node modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-solidity-node-modules
+        with:
+          path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Install dependencies
+        run: npm ci
+      
+      - uses: google-github-actions/setup-gcloud@v0.2.0
+        with:
+          project_id: ${{ secrets.GOOGLE_PROJECT_ID }}
+          service_account_key: ${{ secrets.KEEP_TEST_GCR_JSON_KEY }}
+
+      - name: Fetch external contracts artifacts
+        env:
+          CONTRACT_DATA_BUCKET: ${{ secrets.KEEP_TEST_CONTRACT_DATA_BUCKET }}
+          CONTRACT_DATA_BUCKET_DIR: keep-core
+          ETH_NETWORK_ID: ${{ secrets.KEEP_TEST_ETH_NETWORK_ID }} # currently ='3' (ropsten)
+        run: ./scripts/ci-provision-external-contracts.sh
+
+      - name: Migrate contracts
+        env:
+          TRUFFLE_NETWORK: ${{ secrets.KEEP_TEST_ETH_TRUFFLE_NETWORK }}
+          ETH_HOSTNAME: ${{ secrets.KEEP_TEST_ETH_HOSTNAME }}
+          CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY: ${{ secrets.KEEP_TEST_ETH_CONTRACT_OWNER_PRIVATE_KEY }}
+        run: npx truffle migrate --reset --network $TRUFFLE_NETWORK # writes artifacts to /home/runner/work/keep-ecdsa/keep-ecdsa/solidity/build/contracts
+
+      - name: Push contracts to Tenderly
+        # TODO: once below action gets tagged replace `@main` with `@v1`
+        uses: keep-network/tenderly-push-action@main
+        continue-on-error: true
+        with:
+          working-directory: ./solidity
+          tenderly-token: ${{ secrets.TENDERLY_TOKEN }}
+          tenderly-project: thesis/keep-test
+          eth-network-id: ${{ secrets.KEEP_TEST_ETH_NETWORK_ID }} # currently ='3' (ropsten)
+          github-project-name: keep-ecdsa
+          # version-tag: # TODO: resolve npm package version
+
+      - name: Upload contract data
+        env:
+          CONTRACT_DATA_BUCKET: ${{ secrets.KEEP_TEST_CONTRACT_DATA_BUCKET }}
+        run: |
+          cd build/contracts
+          gsutil -m cp * gs://"$CONTRACT_DATA_BUCKET"/keep-ecdsa
+
+      - name: Copy artifacts
+        run: |
+          mkdir -p artifacts
+          cp -r build/contracts/* artifacts/
+
+      - name: Bump up package version
+        uses: keep-network/npm-version-bump@v1
+        with:
+          workDir: ./solidity
+
+      - name: Publish to npm
+        # TODO: --dry-run to be removed once testing of workflow is done
+        run: |
+          echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }} > .npmrc
+          npm publish --access=public --dry-run
+
+      # TODO: consider swithing to below action, after tweaking
+      # (requires some changes, as below config throws an error)
+      # - name: Publish to npm
+      #   uses: JS-DevTools/npm-publish@v1
+      #   with:
+      #     package: ./solidity/package.json
+      #     token: ${{ secrets.NPM_TOKEN }}
+      #     access: public
+      #     dry-run: true # TODO: to be removed once testing of workflow is done
+  
   migrate-and-publish-celo:
     needs: [build-and-test, lint]
     if: |

--- a/solidity/tenderly.yaml
+++ b/solidity/tenderly.yaml
@@ -1,2 +1,7 @@
 account_id: d9a948cf-8667-43df-acb0-ce194f6dda7a
-project_slug: thesis/keep
+projects:
+  thesis/keep:
+    networks:
+    - "1" # mainnet
+  thesis/keep-test:
+    - "3" # ropsten 


### PR DESCRIPTION
As described in RFC-18, there is a need for a refactorization of Keep
and tBTC release processes in order to reduce human involvement and to 
make the processes faster and less error prone. A part of this task is
migration from CircleCI jobs to GitHub Actions. This PR enhances
the workflow for building and testing Solidity with a job performing
contracts migration on Ethereum chain.
The job does following:
- fetches the contracts artifacts uploaded to Google Storage bucket by
  Solidity workflow in`keep-core`
- migrates contracts
- pushes them to Tenderly
- uploads contract data to Google Storage bucket (`keep-ecdsa`)
- bumps up version of npm package containing contract artifacts and
  uploads the package to npm registry

The `migrate-and-publish-ethereum` job is configured to execute only if
workflow is started by a push or workflow_dispatch event on master or
`rfc-18/*` branch. The `rfc-18/*` condition will need to be removed
once whole `build-test-migrate-publish-keep-test` CircleCI process gets
migrated to GH Actions.
Additionally, as we may not always want to migrate and publish
contracts on every push (or workflow_dispatch) on master, the job was
configured to require manual approval in GitHub GUI. This is done by
configuration of environment protection rules on keep-test and using
`environment: keep-test` config in the workflow.