### PR TITLE
Cache more on-chain data between firewall checks

### DIFF
--- a/pkg/firewall/firewall_test.go
+++ b/pkg/firewall/firewall_test.go
@@ -643,8 +643,10 @@ func TestIsKeepActiveCaching(t *testing.T) {
 		t.Fatal("keep is not active")
 	}
 
-	// close active keep and see it's been updated properly
+	// close active keep and see it's been updated properly after caching period
+	// elapsed
 	chain.CloseKeep(keep1Address)
+	time.Sleep(cacheLifeTime)
 	isActive, err = policy.isKeepActive(keep1Address)
 	if err != nil {
 		t.Fatal(err)
@@ -802,7 +804,7 @@ func createNewPolicy(
 		nonAuthorizedOperatorsCache: cache.NewTimeCache(cacheLifeTime),
 		activeKeepMembersCache:      cache.NewTimeCache(cacheLifeTime),
 		noActiveKeepMembersCache:    cache.NewTimeCache(cacheLifeTime),
-		keepInfoCache:               newKeepInfoCache(),
+		keepInfoCache:               newKeepInfoCache(cacheLifeTime),
 	}
 }
 


### PR DESCRIPTION
There are ~8 nodes in the network right now which undelegated their stake. Given that they do not have a minimum stake now, we execute an additional check to see if the node is a member of at least one active keep.

All those nodes try to connect to bootstrap at the same time and bootstrap is executing the additional check for all of them at the same time.

This check is expensive and it may happen that it can not complete in less than 30 seconds (concurrency limits, compute unit per second limit on Ethereum client) and libp2p will retry. Libp2p retries firewall check, in this case, every 30 seconds and we may end up stacking firewall checks for the same address - the previous check can still be in progress while a new check for the same address will be executing.

Increasing or completely removing concurrency limit and/or switching to Ethereum client not limiting compute units per second helps but we need to make sure the firewall is as least expensive as possible.

With this change, we add caching to [keep index, keep address] mapping that never changes on the chain. This way, even if two or more firewall checks are executed at the same time, most requests will be served from the cache. It will help serve those requests faster and with fewer calls to Ethereum client.

For the same reason, we add caching to positive isActive check results for a keep. So far, we were only caching negative isActive checks because they never change and information in the cache can last forever. Positive isActive check result can only be time-cached for a certain duration and there is a risk that information in the cache is out of date. Still, given that we already cache the final result of active/non-active keep member check (`activeKeepMembersCache`, `noActiveKeepMembersCache`), caching positive isActive check results for keeps for the same or shorter time will not change the behavior of the firewall but will help with reducing the number of requests to Ethereum client and making the policy check faster.

Last but not least, unit tests for firewall caching have been improved to actually validate how many chain calls are executed and to see if the given piece of information is fetched from the cache.