### PR TITLE
Backport: Cache more on-chain data between firewall checks

### DIFF
--- a/pkg/firewall/firewall.go
+++ b/pkg/firewall/firewall.go
@@ -70,16 +70,18 @@ type stakeOrActiveKeepPolicy struct {
 func (soakp *stakeOrActiveKeepPolicy) Validate(
 	remotePeerPublicKey *ecdsa.PublicKey,
 ) error {
+	remotePeerNetworkPublicKey := coreKey.NetworkPublic(*remotePeerPublicKey)
+	remotePeerAddress := coreKey.NetworkPubKeyToChainAddress(
+		&remotePeerNetworkPublicKey,
+	)
+
+	logger.Debugf("validating firewall rules for [%v]", remotePeerAddress)
+
 	// Validate minimum stake policy. If the remote peer has the minimum stake,
 	// we are fine and we should let to connect.
 	if err := soakp.minimumStakePolicy.Validate(remotePeerPublicKey); err == nil {
 		return nil
 	}
-
-	remotePeerNetworkPublicKey := coreKey.NetworkPublic(*remotePeerPublicKey)
-	remotePeerAddress := coreKey.NetworkPubKeyToChainAddress(
-		&remotePeerNetworkPublicKey,
-	)
 
 	// Check if the remote peer has authorization on the factory.
 	// The authorization cannot be revoked.
@@ -100,6 +102,11 @@ func (soakp *stakeOrActiveKeepPolicy) Validate(
 func (soakp *stakeOrActiveKeepPolicy) validateAuthorization(
 	remotePeerAddress string,
 ) error {
+	logger.Debugf(
+		"validating authorization for [%v]",
+		remotePeerAddress,
+	)
+
 	// Before hitting ETH client, consult the in-memory time cache.
 	// If the caching time for the given entry elapsed or if that entry is
 	// not in the cache, we'll have to consult the chain and execute a call
@@ -122,7 +129,7 @@ func (soakp *stakeOrActiveKeepPolicy) validateAuthorization(
 	)
 	if err != nil {
 		return fmt.Errorf(
-			"could not check authorization for address [%v]: [%v]",
+			"could not validate authorization for address [%v]: [%v]",
 			remotePeerAddress,
 			err,
 		)
@@ -140,6 +147,10 @@ func (soakp *stakeOrActiveKeepPolicy) validateAuthorization(
 func (soakp *stakeOrActiveKeepPolicy) validateActiveKeepMembership(
 	remotePeerAddress string,
 ) error {
+	logger.Debugf(
+		"validating active keep membership for [%v]",
+		remotePeerAddress,
+	)
 
 	// First, check in the in-memory time cache to minimize hits to ETH client.
 	// If the Keep client with the given chain address is in the active members
@@ -247,6 +258,7 @@ func (soakp *stakeOrActiveKeepPolicy) getKeepAtIndex(
 		return soakp.chain.GetKeepWithID(cachedID)
 	}
 
+	logger.Debugf("fetching keep at index [%v] from the chain", index)
 	keep, err := soakp.chain.GetKeepAtIndex(index)
 	if err != nil {
 		return nil, err
@@ -282,6 +294,10 @@ func (soakp *stakeOrActiveKeepPolicy) isKeepActive(
 		return true, nil
 	}
 
+	logger.Debugf(
+		"checking if keep with ID [%v] is active on the chain",
+		keep.ID(),
+	)
 	isActive, err := keep.IsActive()
 	if err != nil {
 		return false, err
@@ -313,6 +329,10 @@ func (soakp *stakeOrActiveKeepPolicy) getKeepMembers(
 		return members, nil
 	}
 
+	logger.Debugf(
+		"getting members of the keep with ID [%v] from the chain",
+		keep.ID(),
+	)
 	memberAddresses, err := keep.GetMembers()
 	if err != nil {
 		return nil, nil


### PR DESCRIPTION
See https://github.com/keep-network/keep-ecdsa/pull/737

There are ~8 nodes in the network right now which undelegated their stake. Given that they do not have a minimum stake now, we execute an additional check to see if the node is a member of at least one active keep.

All those nodes try to connect to bootstrap at the same time and bootstrap is executing the additional check for all of them at the same time.

This check is expensive and it may happen that it can not complete in less than 30 seconds (concurrency limits, compute unit per second limit on Ethereum client) and libp2p will retry. Libp2p retries firewall check, in this case, every 30 seconds and we may end up stacking firewall checks for the same address - the previous check can still be in progress while a new check for the same address will be executing.

Increasing or completely removing concurrency limit and/or switching to Ethereum client not limiting compute units per second helps but we need to make sure the firewall is as least expensive as possible.

With this change, we add caching to [keep index, keep on-chain ID] mapping that never changes on the chain. This way, even if two or more firewall checks are executed at the same time, most requests will be served from the cache. It will help serve those requests faster and with fewer calls to Ethereum client.

For the same reason, we add caching to positive isActive check results for a keep. So far, we were only caching negative isActive checks because they never change and information in the cache can last forever. Positive isActive check result can only be time-cached for a certain duration and there is a risk that information in the cache is out of date. Still, given that we already cache the final result of active/non-active keep member check (activeKeepMembersCache, noActiveKeepMembersCache), caching positive isActive check results for keeps for the same or shorter time will not change the behavior of the firewall but will help with reducing the number of requests to Ethereum client and making the policy check faster.

Last but not least, unit tests for firewall caching have been improved to actually validate how many chain calls are executed and to see if the given piece of information is fetched from the cache.