### PR TITLE
Set ERC20 details in `TestToken` contract

### DIFF
--- a/solidity/contracts/test/TestToken.sol
+++ b/solidity/contracts/test/TestToken.sol
@@ -1,8 +1,12 @@
 pragma solidity 0.5.17;
 
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/ERC20Detailed.sol";
 
-contract TestToken is ERC20 {
+contract TestToken is ERC20, ERC20Detailed {
+
+    constructor() public ERC20Detailed("TEST Token", "TEST", 18) {}
+
     /// @dev             Mints an amount of the token and assigns it to an account.
     ///                  Uses the internal _mint function. Anyone can call
     /// @param _account  The account that will receive the created tokens.

--- a/solidity/contracts/test/TestToken.sol
+++ b/solidity/contracts/test/TestToken.sol
@@ -4,7 +4,6 @@ import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 import "openzeppelin-solidity/contracts/token/ERC20/ERC20Detailed.sol";
 
 contract TestToken is ERC20, ERC20Detailed {
-
     constructor() public ERC20Detailed("TEST Token", "TEST", 18) {}
 
     /// @dev             Mints an amount of the token and assigns it to an account.


### PR DESCRIPTION
We use `TestToken` contract as a mock of LP token in the `LPRewards`
contract, in local/Ropsten deployment. Due to changes from
https://github.com/MetaMask/metamask-extension/pull/10606 if the user
calls `approve` on the `TestToken` the MetaMask shows the loading screen
which never disappears because `TestToken` doesn't implement
`ERC20Detailed`. This commit will prevent MetaMask from freezing.