### PR TITLE
Proof of Concept: Liquidation Recovery

### DIFF
--- a/pkg/chain/local/tbtc.go
+++ b/pkg/chain/local/tbtc.go
@@ -17,9 +17,9 @@ import (
 )
 
 const (
-	defaultUTXOValue            = 1000
+	defaultUTXOValue            = 10000000
 	defaultInitialRedemptionFee = 10
-	defaultUtxoValueHex         = "0065cd1d00000000"
+	defaultUtxoValueHex         = "8096980000000000"
 	defaultFundedAt             = "1615172517"
 	defaultUtxoOutpoint         = "c27c3bfa8293ac6b303b9f7455ae23b7c24b8814915a6511976027064efc4d5101000000"
 )

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/btcsuite/btcd/chaincfg"
-	"github.com/btcsuite/btcutil"
 	"github.com/keep-network/keep-common/pkg/chain/ethlike"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -1026,13 +1025,11 @@ func monitorKeepTerminatedEvent(
 					return
 				}
 
-				var beneficiaryAddress string
-				_, err = btcutil.DecodeAddress(bitcoinConfig.BeneficiaryAddress, &chaincfg.TestNet3Params)
-				if err != nil {
-					beneficiaryAddress, err = recovery.DeriveAddress(bitcoinConfig.BeneficiaryAddress, 0)
-				} else {
-					beneficiaryAddress = bitcoinConfig.BeneficiaryAddress
-				}
+				beneficiaryAddress, err := recovery.ResolveBeneficiaryAddress(
+					bitcoinConfig.BeneficiaryAddress,
+					0,
+					&chaincfg.TestNet3Params,
+				)
 				if err != nil {
 					logger.Errorf(
 						"failed to retrieve a btc address from config - keep: [%s] address: [%s] err: [%v]",

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1038,7 +1038,6 @@ func monitorKeepTerminatedEvent(
 
 						beneficiaryAddress, err := recovery.ResolveAddress(
 							bitcoinConfig.BeneficiaryAddress,
-							0,
 							&chaincfg.MainNetParams,
 						)
 						if err != nil {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1072,7 +1072,7 @@ func monitorKeepTerminatedEvent(
 					return
 				}
 
-				signedHexString, err := recovery.BuildBitcoinTransaction(
+				recoveryTransactionHex, err := recovery.BuildBitcoinTransaction(
 					ctx,
 					networkProvider,
 					hostChain,
@@ -1091,11 +1091,11 @@ func monitorKeepTerminatedEvent(
 					return
 				}
 
-				logger.Warningf("Please broadcast Bitcoin transaction %s", signedHexString)
-				logger.Warningf("Please broadcast Bitcoin transaction %s", signedHexString)
-				logger.Warningf("Please broadcast Bitcoin transaction %s", signedHexString)
-				logger.Warningf("Please broadcast Bitcoin transaction %s", signedHexString)
-				logger.Warningf("Please broadcast Bitcoin transaction %s", signedHexString)
+				logger.Warningf("Please broadcast Bitcoin transaction %s", recoveryTransactionHex)
+				logger.Warningf("Please broadcast Bitcoin transaction %s", recoveryTransactionHex)
+				logger.Warningf("Please broadcast Bitcoin transaction %s", recoveryTransactionHex)
+				logger.Warningf("Please broadcast Bitcoin transaction %s", recoveryTransactionHex)
+				logger.Warningf("Please broadcast Bitcoin transaction %s", recoveryTransactionHex)
 
 				keepsRegistry.UnregisterKeep(keep.ID())
 				keepTerminated <- event

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1038,9 +1038,12 @@ func monitorKeepTerminatedEvent(
 							return err
 						}
 
+						//FIXME: derive the chain params from config
+						chainParams := &chaincfg.MainNetParams
+
 						beneficiaryAddress, err := recovery.ResolveAddress(
 							bitcoinConfig.BeneficiaryAddress,
-							&chaincfg.MainNetParams,
+							chainParams,
 						)
 						if err != nil {
 							logger.Errorf(
@@ -1051,9 +1054,6 @@ func monitorKeepTerminatedEvent(
 							)
 							return err
 						}
-
-						//FIXME: derive the chain params from config
-						chainParams := &chaincfg.MainNetParams
 
 						btcAddresses, maxFeePerVByte, err := tss.BroadcastRecoveryAddress(
 							ctx,

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1011,6 +1011,14 @@ func monitorKeepTerminatedEvent(
 						}
 
 						members, err := keep.GetMembers()
+						if err != nil {
+							logger.Errorf(
+								"failed to retrieve members from keep [%s]: [%v]",
+								keep.ID().Hex(),
+								err,
+							)
+							return err
+						}
 						memberID := tss.MemberIDFromPublicKey(operatorPublicKey)
 						memberIDs, err := tssNode.AnnounceSignerPresence(
 							ctx,

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -6,7 +6,6 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"math/big"
-	"sort"
 	"time"
 
 	"github.com/btcsuite/btcd/chaincfg"
@@ -1047,7 +1046,7 @@ func monitorKeepTerminatedEvent(
 					return
 				}
 
-				recoveryInfos, err := tss.BroadcastRecoveryAddress(
+				btcAddresses, maxFeePerVByte, err := tss.BroadcastRecoveryAddress(
 					ctx,
 					beneficiaryAddress,
 					bitcoinConfig.MaxFeePerVByte,
@@ -1066,18 +1065,6 @@ func monitorKeepTerminatedEvent(
 					)
 					return
 				}
-
-				btcAddresses := make([]string, 0, len(recoveryInfos))
-				maxFeePerVByte := recoveryInfos[0].MaxFeePerVByte
-				for _, recoveryInfo := range recoveryInfos {
-					btcAddresses = append(btcAddresses, recoveryInfo.BtcRecoveryAddress)
-					logger.Infof("Found recovery address %s", recoveryInfo.BtcRecoveryAddress)
-					if recoveryInfo.MaxFeePerVByte < maxFeePerVByte {
-						maxFeePerVByte = recoveryInfo.MaxFeePerVByte
-					}
-				}
-
-				sort.Strings(btcAddresses)
 
 				signer, err := keepsRegistry.GetSigner(keep.ID())
 				if err != nil {

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -99,7 +99,7 @@ func Initialize(
 		if err != nil {
 			logger.Errorf(
 				"failed to confirm that keep [%s] is inactive: [%v]",
-				keep.ID(),
+				keep.ID().Hex(),
 				err,
 			)
 			return false
@@ -129,7 +129,7 @@ func Initialize(
 				logger.Errorf(
 					"failed to look up keep [%s] for active check: [%v]; "+
 						"subscriptions for keep signing and closing events are skipped",
-					keep.ID(),
+					keep.ID().Hex(),
 					err,
 				)
 				return
@@ -140,7 +140,7 @@ func Initialize(
 				logger.Errorf(
 					"failed to verify if keep [%s] is still active: [%v]; "+
 						"subscriptions for keep signing and closing events are skipped",
-					keep.ID(),
+					keep.ID().Hex(),
 					err,
 				)
 				return
@@ -149,12 +149,12 @@ func Initialize(
 			if !isActive {
 				logger.Infof(
 					"keep [%s] seems no longer active; confirming",
-					keep.ID(),
+					keep.ID().Hex(),
 				)
 				if isInactivityConfirmed := confirmIsInactive(keep); isInactivityConfirmed {
 					logger.Infof(
 						"confirmed that keep [%s] is no longer active; archiving",
-						keep.ID(),
+						keep.ID().Hex(),
 					)
 					keepsRegistry.UnregisterKeep(keepAddress)
 					return
@@ -168,7 +168,7 @@ func Initialize(
 				// wrong. We don't want to continue processing for this keep.
 				logger.Errorf(
 					"no signer for keep [%s]: [%v]",
-					keep.ID(),
+					keep.ID().Hex(),
 					err,
 				)
 				return
@@ -185,7 +185,7 @@ func Initialize(
 			if err != nil {
 				logger.Errorf(
 					"failed registering for requested signature event for keep [%s]: [%v]",
-					keep.ID(),
+					keep.ID().Hex(),
 					err,
 				)
 				// In case of an error we want to avoid subscribing to keep
@@ -258,7 +258,7 @@ func Initialize(
 				if err != nil {
 					logger.Errorf(
 						"failed to resolve keep with address [%v] for created event: [%v]",
-						keep.ID(),
+						keep.ID().Hex(),
 						err,
 					)
 				}
@@ -365,7 +365,7 @@ func checkAwaitingKeyGeneration(
 		if err != nil {
 			logger.Warningf(
 				"could not check opening timestamp for keep [%s]: [%v]",
-				keep.ID(),
+				keep.ID().Hex(),
 				err,
 			)
 			continue
@@ -398,7 +398,7 @@ func checkAwaitingKeyGeneration(
 		if err != nil {
 			logger.Warningf(
 				"could not check awaiting key generation for keep [%s]: [%v]",
-				keep.ID(),
+				keep.ID().Hex(),
 				err,
 			)
 		}
@@ -438,7 +438,7 @@ func checkAwaitingKeyGenerationForKeep(
 			"keep public key is not registered on-chain but key material "+
 				"is stored on disk; skipping key generation; PLEASE INSPECT "+
 				"PUBLIC KEY SUBMISSION TRANSACTION FOR KEEP [%v]",
-			keep.ID(),
+			keep.ID().Hex(),
 		)
 		return nil
 	}
@@ -497,7 +497,7 @@ func generateKeyForKeep(
 		// TODO: #408 Implement single signer support.
 		logger.Errorf(
 			"keep [%s] has [%d] members; only keeps with at least 2 members are supported",
-			keep.ID(),
+			keep.ID().Hex(),
 			len(members),
 		)
 		return
@@ -508,7 +508,7 @@ func generateKeyForKeep(
 		logger.Errorf(
 			"keep [%s] has honest threshold [%s] and [%d] members; "+
 				"only keeps with honest threshold same as group size are supported",
-			keep.ID(),
+			keep.ID().Hex(),
 			honestThreshold,
 			len(members),
 		)
@@ -518,7 +518,7 @@ func generateKeyForKeep(
 	logger.Infof(
 		"member [%s] is starting signer generation for keep [%s]...",
 		hostChain.Address().String(),
-		keep.ID(),
+		keep.ID().Hex(),
 	)
 
 	signer, err := generateSignerForKeep(
@@ -533,7 +533,7 @@ func generateKeyForKeep(
 	if err != nil {
 		logger.Errorf(
 			"failed to generate signer for keep [%s]: [%v]",
-			keep.ID(),
+			keep.ID().Hex(),
 			err,
 		)
 		return
@@ -545,7 +545,7 @@ func generateKeyForKeep(
 	if err != nil {
 		logger.Errorf(
 			"failed to register threshold signer for keep [%s]: [%v]",
-			keep.ID(),
+			keep.ID().Hex(),
 			err,
 		)
 
@@ -567,7 +567,7 @@ func generateKeyForKeep(
 		logger.Errorf(
 			"failed on registering for requested signature event "+
 				"for keep [%s]: [%v]",
-			keep.ID(),
+			keep.ID().Hex(),
 			err,
 		)
 
@@ -645,7 +645,7 @@ func monitorSigningRequests(
 		func(event *chain.SignatureRequestedEvent) {
 			logger.Infof(
 				"new signature requested from keep [%s] for digest [%+x] at block [%d]",
-				keep.ID(),
+				keep.ID().Hex(),
 				event.Digest,
 				event.BlockNumber,
 			)
@@ -673,7 +673,7 @@ func monitorSigningRequests(
 						if !shouldHandle {
 							logger.Infof(
 								"signing request for keep [%s] and digest [%+x] already handled",
-								keep.ID(),
+								keep.ID().Hex(),
 								event.Digest,
 							)
 							// currently handling or already handled in the past
@@ -694,7 +694,7 @@ func monitorSigningRequests(
 						if err != nil {
 							logger.Errorf(
 								"failed to confirm signing request for keep [%s] and digest [%+x]: [%v]",
-								keep.ID(),
+								keep.ID().Hex(),
 								event.Digest,
 								err,
 							)
@@ -704,7 +704,7 @@ func monitorSigningRequests(
 						if !isAwaitingSignature {
 							logger.Warningf(
 								"keep [%s] is not awaiting a signature for digest [%+x]",
-								keep.ID(),
+								keep.ID().Hex(),
 								event.Digest,
 							)
 
@@ -720,7 +720,7 @@ func monitorSigningRequests(
 						); err != nil {
 							logger.Errorf(
 								"signature calculation failed for keep [%s]: [%v]",
-								keep.ID(),
+								keep.ID().Hex(),
 								err,
 							)
 						}
@@ -758,7 +758,7 @@ func checkAwaitingSignature(
 			"could not check awaiting signature of "+
 				"digest [%+x] for keep [%s]",
 			latestDigest,
-			keep.ID(),
+			keep.ID().Hex(),
 		)
 		return
 	}
@@ -766,7 +766,7 @@ func checkAwaitingSignature(
 	if isAwaitingDigest {
 		logger.Infof(
 			"awaiting a signature from keep [%s] for digest [%+x]",
-			keep.ID(),
+			keep.ID().Hex(),
 			latestDigest,
 		)
 
@@ -789,7 +789,7 @@ func checkAwaitingSignature(
 				if !shouldHandle {
 					logger.Infof(
 						"signing request for keep [%s] and digest [%+x] already handled",
-						keep.ID(),
+						keep.ID().Hex(),
 						latestDigest,
 					)
 					// currently handling - it is possible that event
@@ -803,7 +803,7 @@ func checkAwaitingSignature(
 				if err != nil {
 					logger.Errorf(
 						"failed to get signature request block height for keep [%s] and digest [%x]: [%v]",
-						keep.ID(),
+						keep.ID().Hex(),
 						latestDigest,
 						err,
 					)
@@ -831,7 +831,7 @@ func checkAwaitingSignature(
 				if err != nil {
 					logger.Errorf(
 						"failed to confirm signing request for keep [%s] and digest [%+x]: [%v]",
-						keep.ID(),
+						keep.ID().Hex(),
 						latestDigest,
 						err,
 					)
@@ -841,7 +841,7 @@ func checkAwaitingSignature(
 				if !isStillAwaitingSignature {
 					logger.Warningf(
 						"keep [%s] is not awaiting a signature for digest [%+x]",
-						keep.ID(),
+						keep.ID().Hex(),
 						latestDigest,
 					)
 
@@ -857,7 +857,7 @@ func checkAwaitingSignature(
 				); err != nil {
 					logger.Errorf(
 						"signature calculation failed for keep [%s]: [%v]",
-						keep.ID(),
+						keep.ID().Hex(),
 						err,
 					)
 				}
@@ -887,7 +887,7 @@ func monitorKeepClosedEvents(
 		func(event *chain.KeepClosedEvent) {
 			logger.Infof(
 				"keep [%s] closed event received at block [%d]",
-				keep.ID(),
+				keep.ID().Hex(),
 				event.BlockNumber,
 			)
 
@@ -895,7 +895,7 @@ func monitorKeepClosedEvents(
 				if shouldHandle := eventDeduplicator.NotifyClosingStarted(keep.ID()); !shouldHandle {
 					logger.Infof(
 						"close event for keep [%s] already handled",
-						keep.ID(),
+						keep.ID().Hex(),
 					)
 
 					// currently handling or already handled in the past
@@ -915,7 +915,7 @@ func monitorKeepClosedEvents(
 				if err != nil {
 					logger.Errorf(
 						"failed to confirm keep [%s] closed: [%v]",
-						keep.ID(),
+						keep.ID().Hex(),
 						err,
 					)
 					return
@@ -934,7 +934,7 @@ func monitorKeepClosedEvents(
 	if err != nil {
 		logger.Errorf(
 			"failed on registering for closed event for keep [%s]: [%v]",
-			keep.ID(),
+			keep.ID().Hex(),
 			err,
 		)
 
@@ -972,7 +972,7 @@ func monitorKeepTerminatedEvent(
 		func(event *chain.KeepTerminatedEvent) {
 			logger.Warningf(
 				"keep [%s] terminated event received at block [%d]",
-				keep.ID(),
+				keep.ID().Hex(),
 				event.BlockNumber,
 			)
 
@@ -980,7 +980,7 @@ func monitorKeepTerminatedEvent(
 				if shouldHandle := eventDeduplicator.NotifyTerminatingStarted(keep.ID()); !shouldHandle {
 					logger.Infof(
 						"terminate event for keep [%s] already handled",
-						keep.ID(),
+						keep.ID().Hex(),
 					)
 
 					// currently handling or already handled in the past
@@ -1000,7 +1000,7 @@ func monitorKeepTerminatedEvent(
 				if err != nil {
 					logger.Errorf(
 						"failed to confirm keep [%s] termination: [%v]",
-						keep.ID(),
+						keep.ID().Hex(),
 						err,
 					)
 					return
@@ -1023,7 +1023,7 @@ func monitorKeepTerminatedEvent(
 				if err != nil {
 					logger.Errorf(
 						"failed to retrieve member ids on keep [%s] termination: [%v]",
-						keep.ID().String(),
+						keep.ID().Hex(),
 						err,
 					)
 					return
@@ -1043,7 +1043,7 @@ func monitorKeepTerminatedEvent(
 				if err != nil {
 					logger.Errorf(
 						"failed to retrieve btc recovery addresses on keep [%s]: [%v]",
-						keep.ID().String(),
+						keep.ID().Hex(),
 						err,
 					)
 					return
@@ -1066,7 +1066,7 @@ func monitorKeepTerminatedEvent(
 					if err != nil {
 						logger.Errorf(
 							"unable to derive btc address for keep [%s] and address [%s]: [%v]",
-							keep.ID().String(),
+							keep.ID().Hex(),
 							rawBtcAddress,
 							err,
 						)
@@ -1082,7 +1082,7 @@ func monitorKeepTerminatedEvent(
 					// wrong. We don't want to continue processing for this keep.
 					logger.Errorf(
 						"no signer for keep [%s]: [%v]",
-						keep.ID().String(),
+						keep.ID().Hex(),
 						err,
 					)
 					return
@@ -1091,7 +1091,7 @@ func monitorKeepTerminatedEvent(
 				if err != nil {
 					logger.Errorf(
 						"failed to retrieve the script code for keep [%s]: [%v]",
-						keep.ID().String(),
+						keep.ID().Hex(),
 						err,
 					)
 					return
@@ -1100,7 +1100,7 @@ func monitorKeepTerminatedEvent(
 				if err != nil {
 					logger.Errorf(
 						"failed to retrieve the deposit address for keep [%s]: [%v]",
-						keep.ID().String(),
+						keep.ID().Hex(),
 						err,
 					)
 					return
@@ -1110,7 +1110,7 @@ func monitorKeepTerminatedEvent(
 				if err != nil {
 					logger.Errorf(
 						"failed to retrieve the funding info for keep [%s]: [%v]",
-						keep.ID().String(),
+						keep.ID().Hex(),
 						err,
 					)
 					return
@@ -1123,7 +1123,7 @@ func monitorKeepTerminatedEvent(
 					logger.Errorf(
 						"failed to read the funding info's value bytes: [%v] for keep [%s]: the buffer was too small",
 						fundingInfo.UtxoValueBytes,
-						keep.ID().String(),
+						keep.ID().Hex(),
 					)
 					return
 				}
@@ -1131,7 +1131,7 @@ func monitorKeepTerminatedEvent(
 					logger.Errorf(
 						"failed to read the funding info's value bytes: [%v] for keep [%s]: the value was larger than 64 bits",
 						fundingInfo.UtxoValueBytes,
-						keep.ID().String(),
+						keep.ID().Hex(),
 					)
 					return
 				}
@@ -1147,7 +1147,7 @@ func monitorKeepTerminatedEvent(
 				if err != nil {
 					logger.Errorf(
 						"failed to construct the unsigned transaction for keep [%s]: [%v]",
-						keep.ID().String(),
+						keep.ID().Hex(),
 						err,
 					)
 					return
@@ -1164,7 +1164,7 @@ func monitorKeepTerminatedEvent(
 				if err != nil {
 					logger.Errorf(
 						"failed to calculate the sighash bytes for keep [%s]: [%v]",
-						keep.ID().String(),
+						keep.ID().Hex(),
 						err,
 					)
 					return
@@ -1181,7 +1181,7 @@ func monitorKeepTerminatedEvent(
 				if err != nil {
 					logger.Errorf(
 						"failed to calculate the signature bytes for keep [%s]: [%v]",
-						keep.ID().String(),
+						keep.ID().Hex(),
 						err,
 					)
 					return
@@ -1195,7 +1195,7 @@ func monitorKeepTerminatedEvent(
 				if err != nil {
 					logger.Errorf(
 						"failed to build the signed hex string for keep [%s]: [%v]",
-						keep.ID().String(),
+						keep.ID().Hex(),
 						err,
 					)
 					return
@@ -1215,7 +1215,7 @@ func monitorKeepTerminatedEvent(
 	if err != nil {
 		logger.Errorf(
 			"failed on registering for terminated event for keep [%s]: [%v]",
-			keep.ID().String(),
+			keep.ID().Hex(),
 			err,
 		)
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1043,7 +1043,7 @@ func monitorKeepTerminatedEvent(
 						)
 						if err != nil {
 							logger.Errorf(
-								"failed to retrieve a btc address from config - keep: [%s] address: [%s] err: [%v]",
+								"failed to resolve a btc address for keep: [%s] address: [%s] err: [%v]",
 								keep.ID().Hex(),
 								bitcoinConfig.BeneficiaryAddress,
 								err,
@@ -1095,7 +1095,7 @@ func monitorKeepTerminatedEvent(
 						)
 						if err != nil {
 							logger.Errorf(
-								"failed to build the signed hex string for keep [%s]: [%v]",
+								"failed to build the transaction for keep [%s]: [%v]",
 								keep.ID().Hex(),
 								err,
 							)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1019,7 +1019,7 @@ func monitorKeepTerminatedEvent(
 
 				if err != nil {
 					logger.Errorf(
-						"failed to retrieve member ids on keep [%s] termination: [%v]",
+						"failed to announce signer presence on keep [%s] termination: [%v]",
 						keep.ID().Hex(),
 						err,
 					)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -922,6 +922,8 @@ func monitorKeepClosedEvents(
 					return
 				}
 
+				// TODO: Rework how unregistering works in the context of
+				// completing/confirming btc recovery on the bitcoin chain.
 				keepsRegistry.UnregisterKeep(keep.ID())
 				keepClosed <- event
 			}(event)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1028,7 +1028,7 @@ func monitorKeepTerminatedEvent(
 							return err
 						}
 
-						beneficiaryAddress, err := recovery.ResolveBeneficiaryAddress(
+						beneficiaryAddress, err := recovery.ResolveAddress(
 							bitcoinConfig.BeneficiaryAddress,
 							0,
 							&chaincfg.MainNetParams,

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1053,7 +1053,7 @@ func monitorKeepTerminatedEvent(
 				)
 				if err != nil {
 					logger.Errorf(
-						"failed to retrieve btc recovery addresses on keep [%s]: [%v]",
+						"failed to communicate recovery details for keep [%s]: [%v]",
 						keep.ID().Hex(),
 						err,
 					)

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1031,7 +1031,7 @@ func monitorKeepTerminatedEvent(
 						beneficiaryAddress, err := recovery.ResolveBeneficiaryAddress(
 							bitcoinConfig.BeneficiaryAddress,
 							0,
-							&chaincfg.TestNet3Params,
+							&chaincfg.MainNetParams,
 						)
 						if err != nil {
 							logger.Errorf(

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1051,6 +1051,9 @@ func monitorKeepTerminatedEvent(
 							return err
 						}
 
+						//FIXME: derive the chain params from config
+						chainParams := &chaincfg.MainNetParams
+
 						btcAddresses, maxFeePerVByte, err := tss.BroadcastRecoveryAddress(
 							ctx,
 							beneficiaryAddress,
@@ -1061,6 +1064,7 @@ func monitorKeepTerminatedEvent(
 							uint(len(memberIDs)-1),
 							networkProvider,
 							hostChain.Signing().PublicKeyToAddress,
+							chainParams,
 						)
 						if err != nil {
 							logger.Errorf(
@@ -1090,6 +1094,7 @@ func monitorKeepTerminatedEvent(
 							tbtcHandle,
 							keep,
 							signer,
+							chainParams,
 							btcAddresses,
 							maxFeePerVByte,
 						)

--- a/pkg/ecdsa/tss/protocol_recovery.go
+++ b/pkg/ecdsa/tss/protocol_recovery.go
@@ -10,8 +10,8 @@ import (
 	"github.com/keep-network/keep-core/pkg/net"
 )
 
-// recoveryInfo represents the broadcasted information needed needed from the
-// other signers to complete liquidation recovery.
+// recoveryInfo represents the broadcasted information needed from the other
+// signers to complete liquidation recovery.
 type recoveryInfo struct {
 	btcRecoveryAddress string
 	maxFeePerVByte     int32

--- a/pkg/ecdsa/tss/protocol_recovery.go
+++ b/pkg/ecdsa/tss/protocol_recovery.go
@@ -164,12 +164,11 @@ func BroadcastRecoveryAddress(
 		for _, recoveryInfo := range memberRecoveryInfo {
 
 			if _, err := btcutil.DecodeAddress(recoveryInfo.btcRecoveryAddress, chainParams); err != nil {
-				logger.Errorf(
+				return nil, 0, fmt.Errorf(
 					"something went wrong validating btc address: [%s] during recovery broadcast: [%v]",
 					recoveryInfo.btcRecoveryAddress,
 					err,
 				)
-				return nil, 0, err
 			}
 			retrievalAddresses = append(retrievalAddresses, recoveryInfo.btcRecoveryAddress)
 			if recoveryInfo.maxFeePerVByte < maxFeePerVByte {

--- a/pkg/ecdsa/tss/protocol_recovery.go
+++ b/pkg/ecdsa/tss/protocol_recovery.go
@@ -10,11 +10,11 @@ import (
 	"github.com/keep-network/keep-core/pkg/net"
 )
 
-// RecoveryInfo represents the broadcasted information needed needed from the
+// recoveryInfo represents the broadcasted information needed needed from the
 // other signers to complete liquidation recovery.
-type RecoveryInfo struct {
-	BtcRecoveryAddress string
-	MaxFeePerVByte     int32
+type recoveryInfo struct {
+	btcRecoveryAddress string
+	maxFeePerVByte     int32
 }
 
 // BroadcastRecoveryAddress broadcasts and receives the BTC recovery addresses
@@ -54,7 +54,7 @@ func BroadcastRecoveryAddress(
 	}
 	broadcastChannel.Recv(ctx, handleLiquidationRecoveryAnnounceMessage)
 
-	memberRecoveryInfo := make(map[string]RecoveryInfo)
+	memberRecoveryInfo := make(map[string]recoveryInfo)
 
 	go func() {
 		for {
@@ -77,7 +77,7 @@ func BroadcastRecoveryAddress(
 							)
 							break
 						}
-						memberRecoveryInfo[memberAddress] = RecoveryInfo{BtcRecoveryAddress: msg.BtcRecoveryAddress, MaxFeePerVByte: msg.MaxFeePerVByte}
+						memberRecoveryInfo[memberAddress] = recoveryInfo{btcRecoveryAddress: msg.BtcRecoveryAddress, maxFeePerVByte: msg.MaxFeePerVByte}
 
 						logger.Infof(
 							"member [%s] from keep [%s] announced supplied btc address [%s] for "+
@@ -159,9 +159,9 @@ func BroadcastRecoveryAddress(
 		retrievalAddresses := make([]string, 0, len(memberRecoveryInfo))
 		maxFeePerVByte := int32(2147483647) // since we're taking the min fee among the signers, start with the max int32
 		for _, recoveryInfo := range memberRecoveryInfo {
-			retrievalAddresses = append(retrievalAddresses, recoveryInfo.BtcRecoveryAddress)
-			if recoveryInfo.MaxFeePerVByte < maxFeePerVByte {
-				maxFeePerVByte = recoveryInfo.MaxFeePerVByte
+			retrievalAddresses = append(retrievalAddresses, recoveryInfo.btcRecoveryAddress)
+			if recoveryInfo.maxFeePerVByte < maxFeePerVByte {
+				maxFeePerVByte = recoveryInfo.maxFeePerVByte
 			}
 		}
 		sort.Strings(retrievalAddresses)

--- a/pkg/extensions/tbtc/recovery/derive_address.go
+++ b/pkg/extensions/tbtc/recovery/derive_address.go
@@ -122,7 +122,7 @@ func deriveAddress(extendedPublicKey string, addressIndex uint32) (string, error
 	return finalAddress.EncodeAddress(), nil
 }
 
-// ResolveAddress reolves a configured beneficiaryAddress into a
+// ResolveAddress resolves a configured beneficiaryAddress into a
 // valid bitcoin address. If the supplied address is already a valid bitcoin
 // address, we don't have to do anything. If the supplied address is an
 // extended public key of a HD wallet, attempt to derive the bitcoin address at

--- a/pkg/extensions/tbtc/recovery/derive_address.go
+++ b/pkg/extensions/tbtc/recovery/derive_address.go
@@ -122,12 +122,12 @@ func deriveAddress(extendedPublicKey string, addressIndex uint32) (string, error
 	return finalAddress.EncodeAddress(), nil
 }
 
-// ResolveBeneficiaryAddress reolves a configured beneficiaryAddress into a
+// ResolveAddress reolves a configured beneficiaryAddress into a
 // valid bitcoin address. If the supplied address is already a valid bitcoin
 // address, we don't have to do anything. If the supplied address is an
 // extended public key of a HD wallet, attempt to derive the bitcoin address at
 // the specified index.
-func ResolveBeneficiaryAddress(
+func ResolveAddress(
 	beneficiaryAddress string,
 	addressIndex uint32,
 	netParams *chaincfg.Params,

--- a/pkg/extensions/tbtc/recovery/derive_address.go
+++ b/pkg/extensions/tbtc/recovery/derive_address.go
@@ -130,12 +130,12 @@ func deriveAddress(extendedPublicKey string, addressIndex uint32) (string, error
 func ResolveAddress(
 	beneficiaryAddress string,
 	addressIndex uint32,
-	netParams *chaincfg.Params,
+	chainParams *chaincfg.Params,
 ) (string, error) {
 	// If the address decodes without error, then we have a valid bitcoin
 	// address. Otherwise, we assume that it's an extended key and we attempt to
 	// derive the address.
-	_, err := btcutil.DecodeAddress(beneficiaryAddress, netParams)
+	_, err := btcutil.DecodeAddress(beneficiaryAddress, chainParams)
 	if err != nil {
 		return deriveAddress(beneficiaryAddress, addressIndex)
 	} else {

--- a/pkg/extensions/tbtc/recovery/derive_address.go
+++ b/pkg/extensions/tbtc/recovery/derive_address.go
@@ -129,9 +129,10 @@ func deriveAddress(extendedPublicKey string, addressIndex uint32) (string, error
 // the specified index.
 func ResolveAddress(
 	beneficiaryAddress string,
-	addressIndex uint32,
 	chainParams *chaincfg.Params,
 ) (string, error) {
+	//FIXME: pull the address index from persistence
+	addressIndex := uint32(0)
 	// If the address decodes without error, then we have a valid bitcoin
 	// address. Otherwise, we assume that it's an extended key and we attempt to
 	// derive the address.

--- a/pkg/extensions/tbtc/recovery/derive_address.go
+++ b/pkg/extensions/tbtc/recovery/derive_address.go
@@ -8,19 +8,19 @@ import (
 	"github.com/btcsuite/btcutil/hdkeychain"
 )
 
-// DeriveAddress uses the specified extended public key and address index to
+// deriveAddress uses the specified extended public key and address index to
 // derive an address string in the appropriate format at the specified address
-// index. The extended public key can be at any level. DeriveAddress will take
+// index. The extended public key can be at any level. deriveAddress will take
 // the first child `/0` until a depth of 4 is reached, and then produce the
-// address at the supplied index. Thus, calling DeriveAddress with an xpub
+// address at the supplied index. Thus, calling deriveAddress with an xpub
 // generated at m/44'/0' and passing the address index 5 will produce the
 // address at path m/44'/0'/0/0/5.
 //
 // In cases where the extended public key is at depth 4, meaning the external or
-// internal chain is already included, DeriveAddress will directly derive the
+// internal chain is already included, deriveAddress will directly derive the
 // address index at the existing depth.
 //
-// DeriveAddress does not support hardened child indexes (anything greater than
+// deriveAddress does not support hardened child indexes (anything greater than
 // or equal to 2147483648, abbreviated as 0')
 //
 // The returned address will be a p2pkh/p2sh address for prefixes xpub and tpub,
@@ -35,7 +35,7 @@ import (
 // [BIP44]: https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
 // [BIP49]: https://github.com/bitcoin/bips/blob/master/bip-0049.mediawiki
 // [BIP84]: https://github.com/bitcoin/bips/blob/master/bip-0084.mediawiki
-func DeriveAddress(extendedPublicKey string, addressIndex uint32) (string, error) {
+func deriveAddress(extendedPublicKey string, addressIndex uint32) (string, error) {
 	extendedKey, err := hdkeychain.NewKeyFromString(extendedPublicKey)
 	if err != nil {
 		return "", fmt.Errorf(
@@ -120,4 +120,25 @@ func DeriveAddress(extendedPublicKey string, addressIndex uint32) (string, error
 	}
 
 	return finalAddress.EncodeAddress(), nil
+}
+
+// ResolveBeneficiaryAddress reolves a configured beneficiaryAddress into a
+// valid bitcoin address. If the supplied address is already a valid bitcoin
+// address, we don't have to do anything. If the supplied address is an
+// extended public key of a HD wallet, attempt to derive the bitcoin address at
+// the specified index.
+func ResolveBeneficiaryAddress(
+	beneficiaryAddress string,
+	addressIndex uint32,
+	netParams *chaincfg.Params,
+) (string, error) {
+	// If the address decodes without error, then we have a valid bitcoin
+	// address. Otherwise, we assume that it's an extended key and we attempt to
+	// derive the address.
+	_, err := btcutil.DecodeAddress(beneficiaryAddress, netParams)
+	if err != nil {
+		return deriveAddress(beneficiaryAddress, addressIndex)
+	} else {
+		return beneficiaryAddress, nil
+	}
 }

--- a/pkg/extensions/tbtc/recovery/derive_address_test.go
+++ b/pkg/extensions/tbtc/recovery/derive_address_test.go
@@ -184,7 +184,7 @@ func TestDeriveAddress_ExpectedFailure(t *testing.T) {
 	}
 }
 
-var resolveBeneficiaryAddressData = map[string]struct {
+var resolveAddressData = map[string]struct {
 	beneficiaryAddress string
 	addressIndex       int
 	netParams          *chaincfg.Params
@@ -226,10 +226,10 @@ var resolveBeneficiaryAddressData = map[string]struct {
 	},
 }
 
-func TestResolveBeneficiaryAddress(t *testing.T) {
-	for testName, testData := range resolveBeneficiaryAddressData {
+func TestResolveAddress(t *testing.T) {
+	for testName, testData := range resolveAddressData {
 		t.Run(testName, func(t *testing.T) {
-			resolvedAddress, err := ResolveBeneficiaryAddress(
+			resolvedAddress, err := ResolveAddress(
 				testData.beneficiaryAddress,
 				uint32(testData.addressIndex),
 				testData.netParams,
@@ -248,7 +248,7 @@ func TestResolveBeneficiaryAddress(t *testing.T) {
 	}
 }
 
-var resolveBeneficiaryAddressExpectedFailureData = map[string]struct {
+var resolveAddressExpectedFailureData = map[string]struct {
 	extendedAddress string
 	netParams       *chaincfg.Params
 	failure         string
@@ -276,9 +276,9 @@ var resolveBeneficiaryAddressExpectedFailureData = map[string]struct {
 }
 
 func TestResolveBeneficiaryAddress_ExpectedFailure(t *testing.T) {
-	for testName, testData := range resolveBeneficiaryAddressExpectedFailureData {
+	for testName, testData := range resolveAddressExpectedFailureData {
 		t.Run(testName, func(t *testing.T) {
-			_, err := ResolveBeneficiaryAddress(
+			_, err := ResolveAddress(
 				testData.extendedAddress,
 				0,
 				testData.netParams,

--- a/pkg/extensions/tbtc/recovery/derive_address_test.go
+++ b/pkg/extensions/tbtc/recovery/derive_address_test.go
@@ -122,7 +122,7 @@ var deriveAddressTestData = map[string]struct {
 func TestDeriveAddress(t *testing.T) {
 	for testName, testData := range deriveAddressTestData {
 		t.Run(testName, func(t *testing.T) {
-			address, err := DeriveAddress(testData.extendedAddress, uint32(testData.addressIndex))
+			address, err := deriveAddress(testData.extendedAddress, uint32(testData.addressIndex))
 
 			if err != nil {
 				t.Fatal(err)
@@ -170,7 +170,7 @@ func ErrorContains(err error, expected string) bool {
 func TestDeriveAddress_ExpectedFailure(t *testing.T) {
 	for testName, testData := range deriveAddressTestFailureData {
 		t.Run(testName, func(t *testing.T) {
-			_, err := DeriveAddress(testData.extendedAddress, uint32(testData.addressIndex))
+			_, err := deriveAddress(testData.extendedAddress, uint32(testData.addressIndex))
 			if !ErrorContains(err, testData.failure) {
 				t.Errorf(
 					"unexpected error message\nexpected: %s\nactual:   %s",

--- a/pkg/extensions/tbtc/recovery/derive_address_test.go
+++ b/pkg/extensions/tbtc/recovery/derive_address_test.go
@@ -186,41 +186,35 @@ func TestDeriveAddress_ExpectedFailure(t *testing.T) {
 
 var resolveAddressData = map[string]struct {
 	beneficiaryAddress string
-	addressIndex       int
 	chainParams        *chaincfg.Params
 	expectedAddress    string
 }{
 	"BIP44: xpub at m/44'/0'/0'/0/0": {
 		"xpub6Cg41S21VrxkW1WBTZJn95KNpHozP2Xc6AhG27ZcvZvH8XyNzunEqLdk9dxyXQUoy7ALWQFNn5K1me74aEMtS6pUgNDuCYTTMsJzCAk9sk1",
-		0,
 		&chaincfg.MainNetParams,
 		"1MjCqoLqMZ6Ru64TTtP16XnpSdiE8Kpgcx",
 	},
 
 	"Standard mainnet P2PKH btc address": {
 		"1MjCqoLqMZ6Ru64TTtP16XnpSdiE8Kpgcx",
-		0,
 		&chaincfg.MainNetParams,
 		"1MjCqoLqMZ6Ru64TTtP16XnpSdiE8Kpgcx",
 	},
 
 	"Standard mainnet P2SH btc address": {
 		"3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy",
-		0,
 		&chaincfg.MainNetParams,
 		"3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy",
 	},
 
 	"Standard mainnet Bech32 btc address": {
 		"bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
-		0,
 		&chaincfg.MainNetParams,
 		"bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
 	},
 
 	"Standard testnet btc address": {
 		"mkHS9ne12qx9pS9VojpwU5xtRd4T7X7ZUt",
-		0,
 		&chaincfg.TestNet3Params,
 		"mkHS9ne12qx9pS9VojpwU5xtRd4T7X7ZUt",
 	},
@@ -231,7 +225,6 @@ func TestResolveAddress(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			resolvedAddress, err := ResolveAddress(
 				testData.beneficiaryAddress,
-				uint32(testData.addressIndex),
 				testData.chainParams,
 			)
 			if err != nil {
@@ -280,7 +273,6 @@ func TestResolveBeneficiaryAddress_ExpectedFailure(t *testing.T) {
 		t.Run(testName, func(t *testing.T) {
 			_, err := ResolveAddress(
 				testData.extendedAddress,
-				0,
 				testData.chainParams,
 			)
 			if err == nil {

--- a/pkg/extensions/tbtc/recovery/derive_address_test.go
+++ b/pkg/extensions/tbtc/recovery/derive_address_test.go
@@ -233,3 +233,51 @@ func TestResolveBeneficiaryAddress(t *testing.T) {
 		})
 	}
 }
+
+var resolveBeneficiaryAddressExpectedFailureData = map[string]struct {
+	extendedAddress string
+	netParams       *chaincfg.Params
+	failure         string
+}{
+	"WIF": {
+		"5Hwgr3u458GLafKBgxtssHSPqJnYoGrSzgQsPwLFhLNYskDPyyA",
+		&chaincfg.MainNetParams,
+		"the provided serialized extended key length is invalid",
+	},
+	"empty string": {
+		"",
+		&chaincfg.MainNetParams,
+		"the provided serialized extended key length is invalid",
+	},
+	"BIP32 private key": {
+		"xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzF93Y5wvzdUayhgkkFoicQZcP3y52uPPxFnfoLZB21Teqt1VvEHx",
+		&chaincfg.MainNetParams,
+		"unusable seed",
+	},
+	"complete nonsense": {
+		"lorem ipsum dolor sit amet, consec",
+		&chaincfg.MainNetParams,
+		"the provided serialized extended key length is invalid",
+	},
+}
+
+func TestResolveBeneficiaryAddress_ExpectedFailure(t *testing.T) {
+	for testName, testData := range resolveBeneficiaryAddressExpectedFailureData {
+		t.Run(testName, func(t *testing.T) {
+			_, err := ResolveBeneficiaryAddress(
+				testData.extendedAddress,
+				0,
+				testData.netParams,
+			)
+			if err == nil {
+				t.Errorf("no error found\nexpected: %s", testData.failure)
+			} else if !ErrorContains(err, testData.failure) {
+				t.Errorf(
+					"unexpected error message\nexpected: %s\nactual:   %s",
+					testData.failure,
+					err.Error(),
+				)
+			}
+		})
+	}
+}

--- a/pkg/extensions/tbtc/recovery/derive_address_test.go
+++ b/pkg/extensions/tbtc/recovery/derive_address_test.go
@@ -197,11 +197,25 @@ var resolveBeneficiaryAddressData = map[string]struct {
 		"1MjCqoLqMZ6Ru64TTtP16XnpSdiE8Kpgcx",
 	},
 
-	"Standard mainnet btc address": {
+	"Standard mainnet P2PKH btc address": {
 		"1MjCqoLqMZ6Ru64TTtP16XnpSdiE8Kpgcx",
 		0,
 		&chaincfg.MainNetParams,
 		"1MjCqoLqMZ6Ru64TTtP16XnpSdiE8Kpgcx",
+	},
+
+	"Standard mainnet P2SH btc address": {
+		"3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy",
+		0,
+		&chaincfg.MainNetParams,
+		"3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy",
+	},
+
+	"Standard mainnet Bech32 btc address": {
+		"bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
+		0,
+		&chaincfg.MainNetParams,
+		"bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
 	},
 
 	"Standard testnet btc address": {

--- a/pkg/extensions/tbtc/recovery/derive_address_test.go
+++ b/pkg/extensions/tbtc/recovery/derive_address_test.go
@@ -187,7 +187,7 @@ func TestDeriveAddress_ExpectedFailure(t *testing.T) {
 var resolveAddressData = map[string]struct {
 	beneficiaryAddress string
 	addressIndex       int
-	netParams          *chaincfg.Params
+	chainParams        *chaincfg.Params
 	expectedAddress    string
 }{
 	"BIP44: xpub at m/44'/0'/0'/0/0": {
@@ -232,7 +232,7 @@ func TestResolveAddress(t *testing.T) {
 			resolvedAddress, err := ResolveAddress(
 				testData.beneficiaryAddress,
 				uint32(testData.addressIndex),
-				testData.netParams,
+				testData.chainParams,
 			)
 			if err != nil {
 				t.Fatal(err)
@@ -250,7 +250,7 @@ func TestResolveAddress(t *testing.T) {
 
 var resolveAddressExpectedFailureData = map[string]struct {
 	extendedAddress string
-	netParams       *chaincfg.Params
+	chainParams     *chaincfg.Params
 	failure         string
 }{
 	"WIF": {
@@ -281,7 +281,7 @@ func TestResolveBeneficiaryAddress_ExpectedFailure(t *testing.T) {
 			_, err := ResolveAddress(
 				testData.extendedAddress,
 				0,
-				testData.netParams,
+				testData.chainParams,
 			)
 			if err == nil {
 				t.Errorf("no error found\nexpected: %s", testData.failure)

--- a/pkg/extensions/tbtc/recovery/derive_address_test.go
+++ b/pkg/extensions/tbtc/recovery/derive_address_test.go
@@ -3,6 +3,8 @@ package recovery
 import (
 	"strings"
 	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg"
 )
 
 // These tests use https://iancoleman.io/bip39/ with the bip39 mnemonic: loyal
@@ -176,6 +178,56 @@ func TestDeriveAddress_ExpectedFailure(t *testing.T) {
 					"unexpected error message\nexpected: %s\nactual:   %s",
 					testData.failure,
 					err.Error(),
+				)
+			}
+		})
+	}
+}
+
+var resolveBeneficiaryAddressData = map[string]struct {
+	beneficiaryAddress string
+	addressIndex       int
+	netParams          *chaincfg.Params
+	expectedAddress    string
+}{
+	"BIP44: xpub at m/44'/0'/0'/0/0": {
+		"xpub6Cg41S21VrxkW1WBTZJn95KNpHozP2Xc6AhG27ZcvZvH8XyNzunEqLdk9dxyXQUoy7ALWQFNn5K1me74aEMtS6pUgNDuCYTTMsJzCAk9sk1",
+		0,
+		&chaincfg.MainNetParams,
+		"1MjCqoLqMZ6Ru64TTtP16XnpSdiE8Kpgcx",
+	},
+
+	"Standard mainnet btc address": {
+		"1MjCqoLqMZ6Ru64TTtP16XnpSdiE8Kpgcx",
+		0,
+		&chaincfg.MainNetParams,
+		"1MjCqoLqMZ6Ru64TTtP16XnpSdiE8Kpgcx",
+	},
+
+	"Standard testnet btc address": {
+		"mkHS9ne12qx9pS9VojpwU5xtRd4T7X7ZUt",
+		0,
+		&chaincfg.TestNet3Params,
+		"mkHS9ne12qx9pS9VojpwU5xtRd4T7X7ZUt",
+	},
+}
+
+func TestResolveBeneficiaryAddress(t *testing.T) {
+	for testName, testData := range resolveBeneficiaryAddressData {
+		t.Run(testName, func(t *testing.T) {
+			resolvedAddress, err := ResolveBeneficiaryAddress(
+				testData.beneficiaryAddress,
+				uint32(testData.addressIndex),
+				testData.netParams,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if resolvedAddress != testData.expectedAddress {
+				t.Errorf(
+					"the resolved address does not match\nexpected: %s\nactual:   %s",
+					testData.expectedAddress,
+					resolvedAddress,
 				)
 			}
 		})

--- a/pkg/extensions/tbtc/recovery/recovery.go
+++ b/pkg/extensions/tbtc/recovery/recovery.go
@@ -24,7 +24,7 @@ import (
 	"github.com/keep-network/keep-ecdsa/pkg/ecdsa/tss"
 )
 
-var logger = log.Logger("keep-ecdsa")
+var logger = log.Logger("keep-tbtc-recovery")
 
 // publicKeyToP2WPKHScriptCode converts a public key to a Bitcoin p2wpkh
 // witness scriptCode that can spend an output sent to that public key's

--- a/pkg/extensions/tbtc/recovery/recovery.go
+++ b/pkg/extensions/tbtc/recovery/recovery.go
@@ -26,12 +26,12 @@ import (
 
 var logger = log.Logger("keep-ecdsa")
 
-// PublicKeyToP2WPKHScriptCode converts a public key to a Bitcion p2wpkh
+// publicKeyToP2WPKHScriptCode converts a public key to a Bitcion p2wpkh
 // witness scriptCode that can spend an output sent to that public key's
 // corresponding address.
 //
 // [BIP143]: https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki
-func PublicKeyToP2WPKHScriptCode(
+func publicKeyToP2WPKHScriptCode(
 	publicKey *cecdsa.PublicKey,
 	chainParams *chaincfg.Params,
 ) ([]byte, error) {
@@ -69,8 +69,8 @@ func PublicKeyToP2WPKHScriptCode(
 	return append([]byte{byte(len(script))}, script...), nil
 }
 
-// ConstructUnsignedTransaction produces an unsigned transaction
-func ConstructUnsignedTransaction(
+// constructUnsignedTransaction produces an unsigned transaction
+func constructUnsignedTransaction(
 	previousTransactionHashHex string,
 	previousOutputIndex uint32,
 	previousOutputValue int64,
@@ -148,9 +148,9 @@ func ConstructUnsignedTransaction(
 	return tx, nil
 }
 
-// BuildSignedTransactionHexString generates the final transaction hex string
+// buildSignedTransactionHexString generates the final transaction hex string
 // that can then be submitted to the chain
-func BuildSignedTransactionHexString(
+func buildSignedTransactionHexString(
 	unsignedTransaction *wire.MsgTx,
 	signature *ecdsa.Signature,
 	publicKey *cecdsa.PublicKey,
@@ -198,7 +198,7 @@ func BuildBitcoinTransaction(
 	retrievalAddresses []string,
 	maxFeePerVByte int32,
 ) (string, error) {
-	scriptCodeBytes, err := PublicKeyToP2WPKHScriptCode(signer.PublicKey(), &chaincfg.TestNet3Params)
+	scriptCodeBytes, err := publicKeyToP2WPKHScriptCode(signer.PublicKey(), &chaincfg.TestNet3Params)
 	if err != nil {
 		logger.Errorf(
 			"failed to retrieve the script code for keep [%s]: [%v]",
@@ -247,7 +247,7 @@ func BuildBitcoinTransaction(
 		return "", err
 	}
 
-	unsignedTransaction, err := ConstructUnsignedTransaction(
+	unsignedTransaction, err := constructUnsignedTransaction(
 		previousOutputTransactionHashHex,
 		previousOutputIndex,
 		previousOutputValue,
@@ -298,7 +298,7 @@ func BuildBitcoinTransaction(
 		return "", err
 	}
 
-	return BuildSignedTransactionHexString(
+	return buildSignedTransactionHexString(
 		unsignedTransaction,
 		signature,
 		signer.PublicKey(),

--- a/pkg/extensions/tbtc/recovery/recovery.go
+++ b/pkg/extensions/tbtc/recovery/recovery.go
@@ -26,7 +26,7 @@ import (
 
 var logger = log.Logger("keep-ecdsa")
 
-// publicKeyToP2WPKHScriptCode converts a public key to a Bitcion p2wpkh
+// publicKeyToP2WPKHScriptCode converts a public key to a Bitcoin p2wpkh
 // witness scriptCode that can spend an output sent to that public key's
 // corresponding address.
 //

--- a/pkg/extensions/tbtc/recovery/recovery.go
+++ b/pkg/extensions/tbtc/recovery/recovery.go
@@ -192,10 +192,11 @@ func BuildBitcoinTransaction(
 	tbtcHandle chain.TBTCHandle,
 	keep chain.BondedECDSAKeepHandle,
 	signer *tss.ThresholdSigner,
+	chainParams *chaincfg.Params,
 	retrievalAddresses []string,
 	maxFeePerVByte int32,
 ) (string, error) {
-	scriptCodeBytes, err := publicKeyToP2WPKHScriptCode(signer.PublicKey(), &chaincfg.MainNetParams)
+	scriptCodeBytes, err := publicKeyToP2WPKHScriptCode(signer.PublicKey(), chainParams)
 	if err != nil {
 		logger.Errorf(
 			"failed to retrieve the script code for keep [%s]: [%v]",
@@ -235,7 +236,7 @@ func BuildBitcoinTransaction(
 		previousOutputValue,
 		int64(maxFeePerVByte),
 		retrievalAddresses,
-		&chaincfg.MainNetParams,
+		chainParams,
 	)
 	if err != nil {
 		logger.Errorf(

--- a/pkg/extensions/tbtc/recovery/recovery.go
+++ b/pkg/extensions/tbtc/recovery/recovery.go
@@ -249,13 +249,14 @@ func BuildBitcoinTransaction(
 	}
 
 	sighashBytes, err := txscript.CalcWitnessSigHash(
-		scriptCodeBytes,
+		scriptCodeBytes[1:],
 		txscript.NewTxSigHashes(unsignedTransaction),
 		txscript.SigHashAll,
 		unsignedTransaction,
 		0,
 		previousOutputValue,
 	)
+
 	if err != nil {
 		logger.Errorf(
 			"failed to calculate the sighash bytes for keep [%s]: [%v]",
@@ -264,8 +265,6 @@ func BuildBitcoinTransaction(
 		)
 		return "", err
 	}
-
-	logger.Warningf("calculating sig for bytes %v", sighashBytes)
 
 	signature, err := signer.CalculateSignature(
 		ctx,

--- a/pkg/extensions/tbtc/recovery/recovery.go
+++ b/pkg/extensions/tbtc/recovery/recovery.go
@@ -63,10 +63,7 @@ func publicKeyToP2WPKHScriptCode(
 		)
 	}
 
-	// End goal here is a scriptCode that looks like
-	// 0x1976a914{20-byte-pubkey-hash}88ac . 0x19 should be the length of the
-	// script.
-	return append([]byte{byte(len(script))}, script...), nil
+	return script, nil
 }
 
 // constructUnsignedTransaction produces an unsigned transaction
@@ -249,7 +246,7 @@ func BuildBitcoinTransaction(
 	}
 
 	sighashBytes, err := txscript.CalcWitnessSigHash(
-		scriptCodeBytes[1:],
+		scriptCodeBytes,
 		txscript.NewTxSigHashes(unsignedTransaction),
 		txscript.SigHashAll,
 		unsignedTransaction,

--- a/pkg/extensions/tbtc/recovery/recovery.go
+++ b/pkg/extensions/tbtc/recovery/recovery.go
@@ -229,23 +229,7 @@ func BuildBitcoinTransaction(
 
 	previousOutputTransactionHashHex := hex.EncodeToString(fundingInfo.UtxoOutpoint[:32])
 	previousOutputIndex := binary.LittleEndian.Uint32(fundingInfo.UtxoOutpoint[32:])
-	previousOutputValue, bytesRead := binary.Varint(fundingInfo.UtxoValueBytes[:])
-	if bytesRead == 0 {
-		logger.Errorf(
-			"failed to read the funding info's value bytes: [%v] for keep [%s]: the buffer was too small",
-			fundingInfo.UtxoValueBytes,
-			keep.ID().Hex(),
-		)
-		return "", err
-	}
-	if bytesRead < 0 {
-		logger.Errorf(
-			"failed to read the funding info's value bytes: [%v] for keep [%s]: the value was larger than 64 bits",
-			fundingInfo.UtxoValueBytes,
-			keep.ID().Hex(),
-		)
-		return "", err
-	}
+	previousOutputValue := int64(binary.LittleEndian.Uint32(fundingInfo.UtxoValueBytes[:]))
 
 	unsignedTransaction, err := constructUnsignedTransaction(
 		previousOutputTransactionHashHex,

--- a/pkg/extensions/tbtc/recovery/recovery.go
+++ b/pkg/extensions/tbtc/recovery/recovery.go
@@ -198,7 +198,7 @@ func BuildBitcoinTransaction(
 	retrievalAddresses []string,
 	maxFeePerVByte int32,
 ) (string, error) {
-	scriptCodeBytes, err := publicKeyToP2WPKHScriptCode(signer.PublicKey(), &chaincfg.TestNet3Params)
+	scriptCodeBytes, err := publicKeyToP2WPKHScriptCode(signer.PublicKey(), &chaincfg.MainNetParams)
 	if err != nil {
 		logger.Errorf(
 			"failed to retrieve the script code for keep [%s]: [%v]",

--- a/pkg/extensions/tbtc/recovery/recovery.go
+++ b/pkg/extensions/tbtc/recovery/recovery.go
@@ -207,7 +207,7 @@ func BuildBitcoinTransaction(
 	depositAddress, err := keep.GetOwner()
 	if err != nil {
 		logger.Errorf(
-			"failed to retrieve the deposit address for keep [%s]: [%v]",
+			"failed to retrieve the owner for keep [%s]: [%v]",
 			keep.ID().Hex(),
 			err,
 		)
@@ -217,7 +217,8 @@ func BuildBitcoinTransaction(
 	fundingInfo, err := tbtcHandle.FundingInfo(depositAddress.Hex())
 	if err != nil {
 		logger.Errorf(
-			"failed to retrieve the funding info for keep [%s]: [%v]",
+			"failed to retrieve the funding info of deposit [%s] for keep [%s]: [%v]",
+			depositAddress.Hex(),
 			keep.ID().Hex(),
 			err,
 		)
@@ -253,7 +254,6 @@ func BuildBitcoinTransaction(
 		0,
 		previousOutputValue,
 	)
-
 	if err != nil {
 		logger.Errorf(
 			"failed to calculate the sighash bytes for keep [%s]: [%v]",
@@ -271,7 +271,7 @@ func BuildBitcoinTransaction(
 	)
 	if err != nil {
 		logger.Errorf(
-			"failed to calculate the signature bytes for keep [%s]: [%v]",
+			"failed to calculate signature for keep [%s]: [%v]",
 			keep.ID().Hex(),
 			err,
 		)

--- a/pkg/extensions/tbtc/recovery/recovery_test.go
+++ b/pkg/extensions/tbtc/recovery/recovery_test.go
@@ -209,7 +209,7 @@ func TestBuildBitcoinTransaction(t *testing.T) {
 
 			defer waitGroup.Done()
 
-			preParams := testData[0].LocalPreParams
+			preParams := testData[index].LocalPreParams
 
 			signer, err := tss.GenerateThresholdSigner(
 				ctx,

--- a/pkg/extensions/tbtc/recovery/recovery_test.go
+++ b/pkg/extensions/tbtc/recovery/recovery_test.go
@@ -115,7 +115,7 @@ func TestBuildSignedTransactionHexString(t *testing.T) {
 }
 
 func TestBuildBitcoinTransaction(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 
 	localChain := lc.Connect(ctx)
 	tbtcHandle := lc.NewTBTCLocalChain(ctx)

--- a/pkg/extensions/tbtc/recovery/recovery_test.go
+++ b/pkg/extensions/tbtc/recovery/recovery_test.go
@@ -32,7 +32,7 @@ func TestPublicKeyToP2WPKHScriptCode(t *testing.T) {
 	// Test based on test values from BIP143:
 	// https://github.com/bitcoin/bips/blob/master/bip-0143.mediawiki#native-p2wpkh
 	serializedPublicKey, _ := hex.DecodeString("025476c2e83188368da1ff3e292e7acafcdb3566bb0ad253f62fc70f07aeee6357")
-	expectedScriptCode, _ := hex.DecodeString("1976a9141d0f172a0ecb48aee1be1f2687d2963ae33f71a188ac")
+	expectedScriptCode, _ := hex.DecodeString("76a9141d0f172a0ecb48aee1be1f2687d2963ae33f71a188ac")
 
 	publicKey, _ := btcec.ParsePubKey(serializedPublicKey, btcec.S256())
 

--- a/pkg/extensions/tbtc/recovery/recovery_test.go
+++ b/pkg/extensions/tbtc/recovery/recovery_test.go
@@ -227,6 +227,7 @@ func TestBuildBitcoinTransaction(t *testing.T) {
 				tbtcHandle,
 				keep,
 				signer,
+				&chaincfg.MainNetParams,
 				btcAddresses,
 				maxFeePerVByte,
 			)

--- a/pkg/extensions/tbtc/recovery/recovery_test.go
+++ b/pkg/extensions/tbtc/recovery/recovery_test.go
@@ -115,7 +115,7 @@ func TestBuildSignedTransactionHexString(t *testing.T) {
 }
 
 func TestBuildBitcoinTransaction(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 
 	localChain := lc.Connect(ctx)
 	tbtcHandle := lc.NewTBTCLocalChain(ctx)

--- a/pkg/extensions/tbtc/recovery/recovery_test.go
+++ b/pkg/extensions/tbtc/recovery/recovery_test.go
@@ -276,12 +276,15 @@ func TestBuildBitcoinTransaction(t *testing.T) {
 			)
 		}
 
-		expectedSignature := ""
+		expectedSignature := "replace-me"
 		for _, memberID := range groupMembers {
 			if memberResult, ok := result[memberID.String()]; ok {
+				if expectedSignature == "replace-me" {
+					expectedSignature = memberResult
+				}
 				if memberResult != expectedSignature {
 					t.Errorf(
-						"unexpected signed hex string\nexpected: %s\nactual:   %s",
+						"hex strings must all be identical\nexpected: %s\nactual:   %s",
 						expectedSignature,
 						memberResult,
 					)

--- a/pkg/extensions/tbtc/recovery/recovery_test.go
+++ b/pkg/extensions/tbtc/recovery/recovery_test.go
@@ -147,9 +147,17 @@ func TestBuildBitcoinTransaction(t *testing.T) {
 
 	groupSize := 3
 
-	groupMembers, err := generateMemberKeys(groupSize)
-	if err != nil {
-		t.Fatalf("failed to generate members keys: [%v]", err)
+	groupMembers := make([]tss.MemberID, groupSize)
+	for i, memberIDString := range []string{
+		"04754b25e1b91dc4006acf17d2c28788be8398a8ed591ba2cbbff5c424d23d91971a8881edd3fc64772d90a181665b4b2ffdbbf05776b8fa8bd08893c26c1cad44",
+		"045300560c6c1619d8e2fd4bacc5566c330a89b6402c8c8ceb748d4232b5157dce812ab86645fc66e534a7a3238299eb258245e48a3885d3eea7b885e6c94ddfed",
+		"047279cff18c9bdfad9f6f23407070b9ace75acb5570d687de3416a306ecae16a7b40e6f1721f30bcee9b910e8a3d9bb298e9a6540826cf3ae5fbe1163a60d86ec",
+	} {
+		memberID, err := tss.MemberIDFromString(memberIDString)
+		if err != nil {
+			t.Fatal(err)
+		}
+		groupMembers[i] = memberID
 	}
 
 	testData, err := testdata.LoadKeygenTestFixtures(groupSize)

--- a/pkg/extensions/tbtc/recovery/recovery_test.go
+++ b/pkg/extensions/tbtc/recovery/recovery_test.go
@@ -175,8 +175,8 @@ func TestBuildBitcoinTransaction(t *testing.T) {
 
 	btcAddresses := []string{
 		"1MjCqoLqMZ6Ru64TTtP16XnpSdiE8Kpgcx",
-		"1EEX8qZnTw1thadyxsueV748v3Y6tTMccc",
-		"1EZuKz6RrJ6XmBPvFwJiEcREpaEVhUVAt5",
+		"3EktnHQD7RiAE6uzMj2ZifT9YgRrkSgzQX",
+		"bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
 	}
 	maxFeePerVByte := int32(73)
 
@@ -277,12 +277,12 @@ func TestBuildBitcoinTransaction(t *testing.T) {
 					t.Errorf("wrong number of output transactions\nexpected: 1\nactual:   %d", len(decodedTransaction.TxOut))
 				}
 
-				expectedOutputValue := int64(3328929) // (original deposit of 10000000 - fee) / 3
+				expectedOutputValue := int64(3329050) // (original deposit of 10000000 - fee) / 3
 				for _, outputTransaction := range decodedTransaction.TxOut {
 					if outputTransaction.Value != expectedOutputValue {
 						t.Errorf(
 							"incorrect output transaction value\nexpected: %d\nactual:   %d",
-							outputTransaction,
+							expectedOutputValue,
 							outputTransaction.Value,
 						)
 					}

--- a/pkg/extensions/tbtc/recovery/recovery_test.go
+++ b/pkg/extensions/tbtc/recovery/recovery_test.go
@@ -196,6 +196,9 @@ func TestBuildBitcoinTransaction(t *testing.T) {
 
 	result := make(map[string]string)
 
+	var providersInitializedWg sync.WaitGroup
+	providersInitializedWg.Add(groupSize)
+
 	for i, memberID := range groupMembers {
 		go func(memberID tss.MemberID, index int) {
 			memberPublicKey, err := memberID.PublicKey()
@@ -206,6 +209,9 @@ func TestBuildBitcoinTransaction(t *testing.T) {
 
 			memberNetworkKey := key.NetworkPublic(*memberPublicKey)
 			networkProvider := local.ConnectWithKey(&memberNetworkKey)
+
+			providersInitializedWg.Done()
+			providersInitializedWg.Wait()
 
 			defer waitGroup.Done()
 

--- a/pkg/extensions/tbtc/recovery/recovery_test.go
+++ b/pkg/extensions/tbtc/recovery/recovery_test.go
@@ -24,7 +24,7 @@ func TestPublicKeyToP2WPKHScriptCode(t *testing.T) {
 
 	publicKey, _ := btcec.ParsePubKey(serializedPublicKey, btcec.S256())
 
-	scriptCodeBytes, err := PublicKeyToP2WPKHScriptCode(publicKey.ToECDSA(), &chaincfg.MainNetParams)
+	scriptCodeBytes, err := publicKeyToP2WPKHScriptCode(publicKey.ToECDSA(), &chaincfg.MainNetParams)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -55,7 +55,7 @@ func TestConstructUnsignedTransaction(t *testing.T) {
 	expectedTx := wire.NewMsgTx(0)
 	expectedTx.Deserialize(bytes.NewReader(expectedTxBytes))
 
-	actualTx, err := ConstructUnsignedTransaction(
+	actualTx, err := constructUnsignedTransaction(
 		"0b99dea9655f219991001e9296cfe2103dd918a21ef477a14121d1a0ba9491f1",
 		uint32(0),
 		previousOutputValue,
@@ -86,7 +86,7 @@ func TestBuildSignedTransactionHexString(t *testing.T) {
 		RecoveryID: 1,
 	}
 
-	signedTxHex, err := BuildSignedTransactionHexString(
+	signedTxHex, err := buildSignedTransactionHexString(
 		decodeTransaction(t, unsignedTxHex),
 		signature,
 		publicKey,

--- a/pkg/extensions/tbtc/tbtc.go
+++ b/pkg/extensions/tbtc/tbtc.go
@@ -945,7 +945,7 @@ func (t *tbtc) waitKeepNotActiveConfirmation(
 		logger.Errorf(
 			"could not get current block while confirming "+
 				"keep [%v] is not active: [%v]",
-			keep.ID(),
+			keep.ID().Hex(),
 			err,
 		)
 		return false
@@ -962,7 +962,7 @@ func (t *tbtc) waitKeepNotActiveConfirmation(
 	if err != nil {
 		logger.Errorf(
 			"could not confirm if keep [%v] is not active: [%v]",
-			keep.ID(),
+			keep.ID().Hex(),
 			err,
 		)
 		return false

--- a/pkg/extensions/tbtc/tbtc_test.go
+++ b/pkg/extensions/tbtc/tbtc_test.go
@@ -1263,8 +1263,8 @@ func TestProvideRedemptionProof_StopEventOccurred_DepositRedemptionRequested(
 	// invoke the action which will trigger the stop event in result
 	err = tbtcChain.IncreaseRedemptionFee(
 		depositAddress,
-		toLittleEndianBytes(big.NewInt(990)),
-		toLittleEndianBytes(big.NewInt(980)),
+		toLittleEndianBytes(big.NewInt(9999990)),
+		toLittleEndianBytes(big.NewInt(9999980)),
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -2288,7 +2288,7 @@ func TestGetSignerActionDelay(t *testing.T) {
 
 func TestFundingInfo(t *testing.T) {
 	expectedFundingInfo := &chain.FundingInfo{
-		UtxoValueBytes: [8]uint8{0, 101, 205, 29, 0, 0, 0, 0},
+		UtxoValueBytes: [8]uint8{128, 150, 152, 0, 0, 0, 0, 0},
 		FundedAt:       big.NewInt(1615172517),
 		UtxoOutpoint: []byte{
 			194, 124, 59, 250, 130, 147, 172, 107, 48, 59,

--- a/pkg/firewall/firewall.go
+++ b/pkg/firewall/firewall.go
@@ -203,7 +203,7 @@ func (soakp *stakeOrActiveKeepPolicy) validateActiveKeepMembership(
 		if err != nil {
 			logger.Errorf(
 				"could not check if keep [%s] is active: [%v]",
-				keep.ID(),
+				keep.ID().Hex(),
 				err,
 			)
 			continue
@@ -218,7 +218,7 @@ func (soakp *stakeOrActiveKeepPolicy) validateActiveKeepMembership(
 		if err != nil {
 			logger.Errorf(
 				"could not get members of keep [%s]: [%v]",
-				keep.ID(),
+				keep.ID().Hex(),
 				err,
 			)
 			continue
@@ -313,7 +313,7 @@ func (soakp *stakeOrActiveKeepPolicy) isKeepActive(
 
 	logger.Debugf(
 		"checking if keep with ID [%v] is active on the chain",
-		keep.ID(),
+		keep.ID().Hex(),
 	)
 	isActive, err := keep.IsActive()
 	if err != nil {
@@ -354,7 +354,7 @@ func (soakp *stakeOrActiveKeepPolicy) getKeepMembers(
 
 	logger.Debugf(
 		"getting members of the keep with ID [%v] from the chain",
-		keep.ID(),
+		keep.ID().Hex(),
 	)
 	memberAddresses, err := keep.GetMembers()
 	if err != nil {

--- a/pkg/node/node.go
+++ b/pkg/node/node.go
@@ -152,7 +152,7 @@ func (n *Node) GenerateSignerForKeep(
 
 		logger.Infof(
 			"signer generation for keep [%s]; attempt [%v]",
-			keep.ID(),
+			keep.ID().Hex(),
 			attemptCounter,
 		)
 
@@ -160,7 +160,7 @@ func (n *Node) GenerateSignerForKeep(
 		if err != nil {
 			logger.Warningf(
 				"could not check if keep [%s] is still active: [%v]",
-				keep.ID(),
+				keep.ID().Hex(),
 				err,
 			)
 			time.Sleep(retryDelay) // TODO: #413 Replace with backoff.
@@ -233,7 +233,7 @@ func (n *Node) GenerateSignerForKeep(
 		if err != nil {
 			return nil, fmt.Errorf(
 				"could not make snapshot of signer for keep [%s]: [%v]",
-				keep.ID(),
+				keep.ID().Hex(),
 				err,
 			)
 		}
@@ -358,7 +358,7 @@ func (n *Node) publishSignature(
 		if err != nil {
 			logger.Errorf(
 				"failed to verify if keep [%s] is still active: [%v]",
-				keep.ID(),
+				keep.ID().Hex(),
 				err,
 			)
 			time.Sleep(retryDelay) // TODO: #413 Replace with backoff.
@@ -379,7 +379,7 @@ func (n *Node) publishSignature(
 		if err != nil {
 			logger.Errorf(
 				"failed to verify if keep [%s] is still awaiting signature: [%v]",
-				keep.ID(),
+				keep.ID().Hex(),
 				err,
 			)
 			time.Sleep(retryDelay) // TODO: #413 Replace with backoff.
@@ -395,7 +395,7 @@ func (n *Node) publishSignature(
 
 		logger.Infof(
 			"publishing signature for keep [%s]; attempt [%v]",
-			keep.ID(),
+			keep.ID().Hex(),
 			attemptCounter,
 		)
 
@@ -404,7 +404,7 @@ func (n *Node) publishSignature(
 			if err != nil {
 				logger.Errorf(
 					"failed to verify if keep [%s] is still awaiting signature: [%v]",
-					keep.ID(),
+					keep.ID().Hex(),
 					err,
 				)
 				time.Sleep(retryDelay) // TODO: #413 Replace with backoff.
@@ -425,7 +425,7 @@ func (n *Node) publishSignature(
 			logger.Errorf(
 				"failed to submit signature for keep [%s]: [%v]; "+
 					"will retry after 1 minute",
-				keep.ID(),
+				keep.ID().Hex(),
 				submissionErr,
 			)
 			time.Sleep(1 * time.Minute)
@@ -450,7 +450,7 @@ func (n *Node) waitSignaturePublicationDelay(keep chain.BondedECDSAKeepHandle) {
 		logger.Errorf(
 			"could not determine signature publication delay for keep [%s]: "+
 				"[%v]; the signature publication will not be delayed",
-			keep.ID(),
+			keep.ID().Hex(),
 			err,
 		)
 		return
@@ -462,7 +462,7 @@ func (n *Node) waitSignaturePublicationDelay(keep chain.BondedECDSAKeepHandle) {
 			"could not determine signature publication delay for keep [%s], "+
 				"signer index is less than zero; the signature publication "+
 				"will not be delayed",
-			keep.ID(),
+			keep.ID().Hex(),
 		)
 		return
 	}
@@ -472,7 +472,7 @@ func (n *Node) waitSignaturePublicationDelay(keep chain.BondedECDSAKeepHandle) {
 	logger.Infof(
 		"waiting [%v] before publishing signature for keep [%s]",
 		delay,
-		keep.ID(),
+		keep.ID().Hex(),
 	)
 
 	time.Sleep(delay)
@@ -508,7 +508,7 @@ func (n *Node) waitForSignature(
 
 	logger.Infof(
 		"waiting for signature for keep [%s] to appear on-chain",
-		keep.ID(),
+		keep.ID().Hex(),
 	)
 
 	for {
@@ -523,7 +523,7 @@ func (n *Node) waitForSignature(
 				logger.Errorf(
 					"failed to perform signature check while waiting "+
 						"for signature for keep [%s]: [%v]",
-					keep.ID(),
+					keep.ID().Hex(),
 					err,
 				)
 				continue
@@ -532,7 +532,7 @@ func (n *Node) waitForSignature(
 			if !isAwaitingSignature {
 				logger.Infof(
 					"signature for keep [%s] appeared on-chain",
-					keep.ID(),
+					keep.ID().Hex(),
 				)
 				return true
 			}
@@ -540,7 +540,7 @@ func (n *Node) waitForSignature(
 			logger.Errorf(
 				"signature for keep [%s] has not appeared on the chain "+
 					"after [%v] from submitting it",
-				keep.ID(),
+				keep.ID().Hex(),
 				waitTimeout,
 			)
 			return false
@@ -554,7 +554,7 @@ func (n *Node) confirmSignature(
 ) bool {
 	logger.Infof(
 		"confirming on-chain signature submission for keep [%s]",
-		keep.ID(),
+		keep.ID().Hex(),
 	)
 
 	currentBlock, err := n.ethereumChain.BlockCounter().CurrentBlock()
@@ -562,7 +562,7 @@ func (n *Node) confirmSignature(
 		logger.Errorf(
 			"could not get current block while confirming "+
 				"signature submission for keep [%s]: [%v]",
-			keep.ID(),
+			keep.ID().Hex(),
 			err,
 		)
 		return false
@@ -584,7 +584,7 @@ func (n *Node) confirmSignature(
 	if err != nil {
 		logger.Errorf(
 			"could not confirm signature submission for keep [%s]: [%v]",
-			keep.ID(),
+			keep.ID().Hex(),
 			err,
 		)
 		return false
@@ -594,7 +594,7 @@ func (n *Node) confirmSignature(
 		logger.Errorf(
 			"signature submission for keep [%s] not confirmed; "+
 				"trying to submit the signature again",
-			keep.ID(),
+			keep.ID().Hex(),
 		)
 		return false
 	}
@@ -602,7 +602,7 @@ func (n *Node) confirmSignature(
 	logger.Infof(
 		"signature for keep [%s] successfully submitted "+
 			"and confirmed on-chain",
-		keep.ID(),
+		keep.ID().Hex(),
 	)
 
 	return true
@@ -641,7 +641,7 @@ func (n *Node) monitorKeepPublicKeySubmission(
 	if err != nil {
 		logger.Errorf(
 			"failed on watching conflicting public key event for keep [%s]: [%v]",
-			keep.ID(),
+			keep.ID().Hex(),
 			err,
 		)
 	}
@@ -677,7 +677,7 @@ func (n *Node) monitorKeepPublicKeySubmission(
 			logger.Errorf(
 				"member [%x] has submitted conflicting public key for keep [%s]: [%x]",
 				event.SubmittingMember,
-				keep.ID(),
+				keep.ID().Hex(),
 				event.ConflictingPublicKey,
 			)
 			return
@@ -689,7 +689,7 @@ func (n *Node) monitorKeepPublicKeySubmission(
 					"monitoring of public key submission for keep [%s] "+
 						"has been cancelled because maximum checks count [%v] "+
 						"has been reached",
-					keep.ID(),
+					keep.ID().Hex(),
 					maxPubkeyChecksCount,
 				)
 				return
@@ -697,7 +697,7 @@ func (n *Node) monitorKeepPublicKeySubmission(
 
 			logger.Infof(
 				"confirming on-chain public key submission for keep [%s]",
-				keep.ID(),
+				keep.ID().Hex(),
 			)
 
 			// We check the public key periodically instead of relying on
@@ -709,7 +709,7 @@ func (n *Node) monitorKeepPublicKeySubmission(
 				logger.Errorf(
 					"failed to get keep public key during "+
 						"public key submission monitoring for keep [%s]: [%v]",
-					keep.ID(),
+					keep.ID().Hex(),
 					err,
 				)
 				continue
@@ -721,7 +721,7 @@ func (n *Node) monitorKeepPublicKeySubmission(
 							"failed to get the current block while "+
 								"performing public key submission confirmation "+
 								"for keep [%s]: [%v]",
-							keep.ID(),
+							keep.ID().Hex(),
 							err,
 						)
 						continue
@@ -745,7 +745,7 @@ func (n *Node) monitorKeepPublicKeySubmission(
 							"failed to perform keep public key "+
 								"confirmation during public key submission "+
 								"monitoring for keep [%s]: [%v]",
-							keep.ID(),
+							keep.ID().Hex(),
 							err,
 						)
 						continue
@@ -756,7 +756,7 @@ func (n *Node) monitorKeepPublicKeySubmission(
 							"public key [%x] for keep [%s] successfully "+
 								"submitted and confirmed on-chain",
 							keepPublicKey,
-							keep.ID(),
+							keep.ID().Hex(),
 						)
 						return
 					}
@@ -766,7 +766,7 @@ func (n *Node) monitorKeepPublicKeySubmission(
 			logger.Infof(
 				"keep [%s] still does not have a confirmed public key; "+
 					"re-submitting public key [%x]",
-				keep.ID(),
+				keep.ID().Hex(),
 				publicKey,
 			)
 
@@ -775,7 +775,7 @@ func (n *Node) monitorKeepPublicKeySubmission(
 				logger.Errorf(
 					"keep [%s] still does not have a confirmed public key "+
 						"and resubmission by this member failed with: [%v]",
-					keep.ID(),
+					keep.ID().Hex(),
 					err,
 				)
 				return


### PR DESCRIPTION
This PR makes calls to the newly merged liquidation recovery functions in order to construct a signed bitcoin transaction to recover the funds.

This PR does not implement persistence for address validation - that'll be separate!

To test:

https://github.com/keep-network/local-setup/blob/master/docs/manual-setup.adoc

Edit your `keep-ecdsa/configs/config.local.*.toml` files to have:
```
[Extensions.TBTC]
	TBTCSystem = "<value matching ethereum.ContractAddresses.TBTCSystem>"

  [Extensions.TBTC.BTCRefunds]
  	BeneficiaryAddress = "<either a valid btc address or a HD wallet key>"
  	MaxFeePerVByte = <integer>
```

* Get keep-core, and keep-ecdsa 1-3 running locally.
* from the `tbtc.js` project run:
```
$ bin/tbtc.js --rpc ws://127.0.0.1:8546 deposit new 10000000
```

That should give you a bitcoin address to make a deposit to:
```
Got deposit address: bcrt1q7h3eg2vn9npa4szyanwk9m82vgz7n4jdnke0cj ; fund with: 10000000 satoshis please.
```

Make the deposit with:
```
$ bitcoind-wallet sendToAddress bcrt1q7h3eg2vn9npa4szyanwk9m82vgz7n4jdnke0cj 0.1
```

Once that clears, from the `tbtc/solidity/scripts` directory run:
```
$ truffle exec multiply-local-eth-btc-price.js 0.7
```
That'll lower the price ratio of eth and btc enough to under-collateralize the deposit and make it available for liquidation.

back in `tbtc.js`, run:
```
$ bin/tbtc.js --rpc ws://127.0.0.1:8546 deposit list --vending-machine
```
and look for a line like:
```
<hex-to-liquidate>	ACTIVE	10000000	104
```

Grab your hex address and then run
```
$ bin/tbtc.js --rpc ws://127.0.0.1:8546 deposit <hex-to-liquidate> liquidate
```

Now, you can monitor your ecdsa logs, looking out for something that looks like:
![image](https://user-images.githubusercontent.com/1045160/112218320-f5aff880-8bf9-11eb-8204-27f16935852c.png)

repeated 5x

This is still a work in progress, but any early review would be valuable, @nkuba 

:tada:
