### PR TITLE
Updated keep-core contracts dependency version

### DIFF
--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -2048,9 +2048,9 @@
       }
     },
     "@keep-network/keep-core": {
-      "version": "1.7.0-pre.5",
-      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.7.0-pre.5.tgz",
-      "integrity": "sha512-1G7ls/G2D0nNnXppP8QPuppompk6YCFwveePqcWIYoV+ym/ac4IznoSBv4v4S4/p900pu2ZNrbXfj/VoHLqyrA==",
+      "version": "1.8.0-pre.5",
+      "resolved": "https://registry.npmjs.org/@keep-network/keep-core/-/keep-core-1.8.0-pre.5.tgz",
+      "integrity": "sha512-s8B+FHMvcLW3EHqqHBRq50eqhD1HhQkpsCTtwvtYfWkHwFOrm9ku9FTlxPzmC1vFwGO6Ld4G2zB6lET6o186WQ==",
       "requires": {
         "@openzeppelin/upgrades": "^2.7.2",
         "openzeppelin-solidity": "2.4.0"

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "1.7.0-pre.0",
+  "version": "1.7.0-pre",
   "description": "Smart contracts for ECDSA Keep",
   "repository": {
     "type": "git",
@@ -31,7 +31,7 @@
   },
   "homepage": "https://github.com/keep-network/keep-ecdsa",
   "dependencies": {
-    "@keep-network/keep-core": ">1.7.0-pre <1.7.0-rc",
+    "@keep-network/keep-core": ">1.8.0-pre <1.8.0-rc",
     "@keep-network/sortition-pools": ">1.2.0-pre <1.2.0-rc",
     "@openzeppelin/upgrades": "^2.7.2",
     "openzeppelin-solidity": "2.3.0"


### PR DESCRIPTION
We're updating the range for keep-core package dependency to match the latest migrated on ropsten (https://github.com/keep-network/keep-core/actions/runs/676818591).