### PR TITLE
Use env property to get TBTCTSystem address in init script

### DIFF
--- a/infrastructure/kube/keep-dev/keep-ecdsa-0-statefulset.yaml
+++ b/infrastructure/kube/keep-dev/keep-ecdsa-0-statefulset.yaml
@@ -108,7 +108,7 @@ spec:
               value: '3919'
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
-            - name: SANCTIONED_APPLICATIONS
+            - name: TBTC_SYSTEM_ADDRESS
               value: '0x7F68B90dce19d2ac034477B7ba2229106656A084' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config

--- a/infrastructure/kube/keep-dev/keep-ecdsa-1-statefulset.yaml
+++ b/infrastructure/kube/keep-dev/keep-ecdsa-1-statefulset.yaml
@@ -108,7 +108,7 @@ spec:
               value: '3919'
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
-            - name: SANCTIONED_APPLICATIONS
+            - name: TBTC_SYSTEM_ADDRESS
               value: '0x7F68B90dce19d2ac034477B7ba2229106656A084' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config

--- a/infrastructure/kube/keep-dev/keep-ecdsa-2-statefulset.yaml
+++ b/infrastructure/kube/keep-dev/keep-ecdsa-2-statefulset.yaml
@@ -109,7 +109,7 @@ spec:
               value: '3919'
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
-            - name: SANCTIONED_APPLICATIONS
+            - name: TBTC_SYSTEM_ADDRESS
               value: '0x7F68B90dce19d2ac034477B7ba2229106656A084' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config

--- a/infrastructure/kube/keep-dev/keep-ecdsa-3-statefulset.yaml
+++ b/infrastructure/kube/keep-dev/keep-ecdsa-3-statefulset.yaml
@@ -109,7 +109,7 @@ spec:
               value: '3919'
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
-            - name: SANCTIONED_APPLICATIONS
+            - name: TBTC_SYSTEM_ADDRESS
               value: '0x7F68B90dce19d2ac034477B7ba2229106656A084' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config

--- a/infrastructure/kube/keep-dev/keep-ecdsa-4-statefulset.yaml
+++ b/infrastructure/kube/keep-dev/keep-ecdsa-4-statefulset.yaml
@@ -109,7 +109,7 @@ spec:
               value: '3919'
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
-            - name: SANCTIONED_APPLICATIONS
+            - name: TBTC_SYSTEM_ADDRESS
               value: '0x7F68B90dce19d2ac034477B7ba2229106656A084' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config

--- a/infrastructure/kube/keep-test/celo/keep-ecdsa-0-statefulset.yaml
+++ b/infrastructure/kube/keep-test/celo/keep-ecdsa-0-statefulset.yaml
@@ -117,7 +117,7 @@ spec:
               value: '3919'
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
-            - name: SANCTIONED_APPLICATIONS
+            - name: TBTC_SYSTEM_ADDRESS
               value: '0x87ABAD43f9e31067712dd5E2460C70b666AFfcE0' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config

--- a/infrastructure/kube/keep-test/celo/keep-ecdsa-1-statefulset.yaml
+++ b/infrastructure/kube/keep-test/celo/keep-ecdsa-1-statefulset.yaml
@@ -117,7 +117,7 @@ spec:
               value: '3919'
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
-            - name: SANCTIONED_APPLICATIONS
+            - name: TBTC_SYSTEM_ADDRESS
               value: '0x87ABAD43f9e31067712dd5E2460C70b666AFfcE0' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config

--- a/infrastructure/kube/keep-test/celo/keep-ecdsa-2-statefulset.yaml
+++ b/infrastructure/kube/keep-test/celo/keep-ecdsa-2-statefulset.yaml
@@ -117,7 +117,7 @@ spec:
               value: '3919'
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
-            - name: SANCTIONED_APPLICATIONS
+            - name: TBTC_SYSTEM_ADDRESS
               value: '0x87ABAD43f9e31067712dd5E2460C70b666AFfcE0' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config

--- a/infrastructure/kube/keep-test/celo/keep-ecdsa-3-statefulset.yaml
+++ b/infrastructure/kube/keep-test/celo/keep-ecdsa-3-statefulset.yaml
@@ -117,7 +117,7 @@ spec:
               value: '3919'
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
-            - name: SANCTIONED_APPLICATIONS
+            - name: TBTC_SYSTEM_ADDRESS
               value: '0x87ABAD43f9e31067712dd5E2460C70b666AFfcE0' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config

--- a/infrastructure/kube/keep-test/celo/keep-ecdsa-4-statefulset.yaml
+++ b/infrastructure/kube/keep-test/celo/keep-ecdsa-4-statefulset.yaml
@@ -117,7 +117,7 @@ spec:
               value: '3919'
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
-            - name: SANCTIONED_APPLICATIONS
+            - name: TBTC_SYSTEM_ADDRESS
               value: '0x87ABAD43f9e31067712dd5E2460C70b666AFfcE0' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config

--- a/infrastructure/kube/keep-test/celo/keep-ecdsa-5-statefulset.yaml
+++ b/infrastructure/kube/keep-test/celo/keep-ecdsa-5-statefulset.yaml
@@ -117,7 +117,7 @@ spec:
               value: '3919'
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
-            - name: SANCTIONED_APPLICATIONS
+            - name: TBTC_SYSTEM_ADDRESS
               value: '0x87ABAD43f9e31067712dd5E2460C70b666AFfcE0' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config

--- a/infrastructure/kube/keep-test/celo/keep-ecdsa-6-statefulset.yaml
+++ b/infrastructure/kube/keep-test/celo/keep-ecdsa-6-statefulset.yaml
@@ -117,7 +117,7 @@ spec:
               value: '3919'
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
-            - name: SANCTIONED_APPLICATIONS
+            - name: TBTC_SYSTEM_ADDRESS
               value: '0x87ABAD43f9e31067712dd5E2460C70b666AFfcE0' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config

--- a/infrastructure/kube/keep-test/celo/keep-ecdsa-7-statefulset.yaml
+++ b/infrastructure/kube/keep-test/celo/keep-ecdsa-7-statefulset.yaml
@@ -117,7 +117,7 @@ spec:
               value: '3919'
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
-            - name: SANCTIONED_APPLICATIONS
+            - name: TBTC_SYSTEM_ADDRESS
               value: '0x87ABAD43f9e31067712dd5E2460C70b666AFfcE0' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config

--- a/infrastructure/kube/keep-test/celo/keep-ecdsa-8-statefulset.yaml
+++ b/infrastructure/kube/keep-test/celo/keep-ecdsa-8-statefulset.yaml
@@ -117,7 +117,7 @@ spec:
               value: '3919'
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
-            - name: SANCTIONED_APPLICATIONS
+            - name: TBTC_SYSTEM_ADDRESS
               value: '0x87ABAD43f9e31067712dd5E2460C70b666AFfcE0' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config

--- a/infrastructure/kube/keep-test/celo/keep-ecdsa-9-statefulset.yaml
+++ b/infrastructure/kube/keep-test/celo/keep-ecdsa-9-statefulset.yaml
@@ -117,7 +117,7 @@ spec:
               value: '3919'
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
-            - name: SANCTIONED_APPLICATIONS
+            - name: TBTC_SYSTEM_ADDRESS
               value: '0x87ABAD43f9e31067712dd5E2460C70b666AFfcE0' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config

--- a/infrastructure/kube/keep-test/ethereum/keep-ecdsa-0-statefulset.yaml
+++ b/infrastructure/kube/keep-test/ethereum/keep-ecdsa-0-statefulset.yaml
@@ -115,7 +115,7 @@ spec:
               value: '3919'
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
-            - name: SANCTIONED_APPLICATIONS
+            - name: TBTC_SYSTEM_ADDRESS
               value: '0xA41ffe9d9BAD45aD884e5100E6e201854912373E' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config

--- a/infrastructure/kube/keep-test/ethereum/keep-ecdsa-1-statefulset.yaml
+++ b/infrastructure/kube/keep-test/ethereum/keep-ecdsa-1-statefulset.yaml
@@ -115,7 +115,7 @@ spec:
               value: '3919'
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
-            - name: SANCTIONED_APPLICATIONS
+            - name: TBTC_SYSTEM_ADDRESS
               value: '0xA41ffe9d9BAD45aD884e5100E6e201854912373E' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config

--- a/infrastructure/kube/keep-test/ethereum/keep-ecdsa-2-statefulset.yaml
+++ b/infrastructure/kube/keep-test/ethereum/keep-ecdsa-2-statefulset.yaml
@@ -115,7 +115,7 @@ spec:
               value: '3919'
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
-            - name: SANCTIONED_APPLICATIONS
+            - name: TBTC_SYSTEM_ADDRESS
               value: '0xA41ffe9d9BAD45aD884e5100E6e201854912373E' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config

--- a/infrastructure/kube/keep-test/ethereum/keep-ecdsa-3-statefulset.yaml
+++ b/infrastructure/kube/keep-test/ethereum/keep-ecdsa-3-statefulset.yaml
@@ -115,7 +115,7 @@ spec:
               value: '3919'
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
-            - name: SANCTIONED_APPLICATIONS
+            - name: TBTC_SYSTEM_ADDRESS
               value: '0xA41ffe9d9BAD45aD884e5100E6e201854912373E' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config

--- a/infrastructure/kube/keep-test/ethereum/keep-ecdsa-4-statefulset.yaml
+++ b/infrastructure/kube/keep-test/ethereum/keep-ecdsa-4-statefulset.yaml
@@ -115,7 +115,7 @@ spec:
               value: '3919'
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
-            - name: SANCTIONED_APPLICATIONS
+            - name: TBTC_SYSTEM_ADDRESS
               value: '0x576ad5Ced9D0030D2F26E2F08BD2E92de9fcD858' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config

--- a/infrastructure/kube/keep-test/ethereum/keep-ecdsa-5-statefulset.yaml
+++ b/infrastructure/kube/keep-test/ethereum/keep-ecdsa-5-statefulset.yaml
@@ -115,7 +115,7 @@ spec:
               value: '3919'
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
-            - name: SANCTIONED_APPLICATIONS
+            - name: TBTC_SYSTEM_ADDRESS
               value: '0x576ad5Ced9D0030D2F26E2F08BD2E92de9fcD858' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config

--- a/infrastructure/kube/keep-test/ethereum/keep-ecdsa-6-statefulset.yaml
+++ b/infrastructure/kube/keep-test/ethereum/keep-ecdsa-6-statefulset.yaml
@@ -115,7 +115,7 @@ spec:
               value: '3919'
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
-            - name: SANCTIONED_APPLICATIONS
+            - name: TBTC_SYSTEM_ADDRESS
               value: '0x576ad5Ced9D0030D2F26E2F08BD2E92de9fcD858' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config

--- a/infrastructure/kube/keep-test/ethereum/keep-ecdsa-7-statefulset.yaml
+++ b/infrastructure/kube/keep-test/ethereum/keep-ecdsa-7-statefulset.yaml
@@ -115,7 +115,7 @@ spec:
               value: '3919'
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
-            - name: SANCTIONED_APPLICATIONS
+            - name: TBTC_SYSTEM_ADDRESS
               value: '0x576ad5Ced9D0030D2F26E2F08BD2E92de9fcD858' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config

--- a/infrastructure/kube/keep-test/ethereum/keep-ecdsa-8-statefulset.yaml
+++ b/infrastructure/kube/keep-test/ethereum/keep-ecdsa-8-statefulset.yaml
@@ -115,7 +115,7 @@ spec:
               value: '3919'
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
-            - name: SANCTIONED_APPLICATIONS
+            - name: TBTC_SYSTEM_ADDRESS
               value: '0x576ad5Ced9D0030D2F26E2F08BD2E92de9fcD858' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config

--- a/infrastructure/kube/keep-test/ethereum/keep-ecdsa-9-statefulset.yaml
+++ b/infrastructure/kube/keep-test/ethereum/keep-ecdsa-9-statefulset.yaml
@@ -115,7 +115,7 @@ spec:
               value: '3919'
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
-            - name: SANCTIONED_APPLICATIONS
+            - name: TBTC_SYSTEM_ADDRESS
               value: '0x576ad5Ced9D0030D2F26E2F08BD2E92de9fcD858' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config

--- a/infrastructure/kube/templates/keep-ecdsa/initcontainer/provision-keep-ecdsa/Dockerfile
+++ b/infrastructure/kube/templates/keep-ecdsa/initcontainer/provision-keep-ecdsa/Dockerfile
@@ -15,8 +15,6 @@ COPY ./TokenStaking.json /tmp/TokenStaking.json
 
 COPY ./KeepToken.json /tmp/KeepToken.json
 
-COPY ./TBTCSystem.json /tmp/TBTCSystem.json
-
 COPY ./keep-ecdsa-config-template.toml /tmp/keep-ecdsa-config-template.toml
 
 COPY ./provision-keep-ecdsa.js /tmp/provision-keep-ecdsa.js

--- a/infrastructure/kube/templates/keep-ecdsa/initcontainer/provision-keep-ecdsa/provision-keep-ecdsa.js
+++ b/infrastructure/kube/templates/keep-ecdsa/initcontainer/provision-keep-ecdsa/provision-keep-ecdsa.js
@@ -131,7 +131,7 @@ async function provisionKeepTecdsa() {
       !sortitionPoolContractAddress ||
       sortitionPoolContractAddress === "0x0000000000000000000000000000000000000000"
     ) {
-      throw new Error(`missing sortition pool for application: [${tbtcSystemAddress}]`)
+      throw new Error(`missing sortition pool for TBTCSystem contract: [${tbtcSystemAddress}]`)
     }
 
     console.log(

--- a/infrastructure/kube/templates/keep-ecdsa/initcontainer/provision-keep-ecdsa/provision-keep-ecdsa.js
+++ b/infrastructure/kube/templates/keep-ecdsa/initcontainer/provision-keep-ecdsa/provision-keep-ecdsa.js
@@ -24,8 +24,8 @@ const web3Provider = {
       }
 
       const contractOwnerProvider = new HDWalletProvider(
-          process.env.CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY,
-          ethRPCUrl
+        process.env.CONTRACT_OWNER_ETH_ACCOUNT_PRIVATE_KEY,
+        ethRPCUrl
       )
 
       return new Web3(contractOwnerProvider, null, web3Options)
@@ -59,6 +59,14 @@ const libp2pPeers = [process.env.KEEP_TECDSA_PEERS]
 const libp2pPort = Number(process.env.KEEP_TECDSA_PORT)
 const libp2pAnnouncedAddresses = [process.env.KEEP_TECDSA_ANNOUNCED_ADDRESSES]
 
+// TBTCSystem contract address
+// TODO: The value is required to be defined as an environment variable
+// the address could be pulled from a contract artifact, but this gives an
+// additional dependency from keep-ecdsa to tbtc projects in the release
+// cycle, which would be too complex at this point. We should revisit it when
+// implementing RFC-18 modules integration.
+const tbtcSystemAddress = process.env.TBTC_SYSTEM_ADDRESS
+
 const web3 = web3Provider[hostChain].getWeb3()
 
 /*
@@ -69,11 +77,6 @@ const bondedECDSAKeepFactory = getWeb3Contract("BondedECDSAKeepFactory")
 const keepBondingContract = getWeb3Contract("KeepBonding")
 const tokenStakingContract = getWeb3Contract("TokenStaking")
 const keepTokenContract = getWeb3Contract("KeepToken")
-const tbtcSystemContract = getWeb3Contract("TBTCSystem")
-
-// Addresses of the external contracts (e.g. TBTCSystem) which should be set for
-// the InitContainer execution. Addresses should be separated with spaces.
-const sanctionedApplications = process.env.SANCTIONED_APPLICATIONS.split(" ")
 
 // Returns a web3 contract object based on a truffle contract artifact JSON file.
 function getWeb3Contract(contractName) {
@@ -117,36 +120,28 @@ async function provisionKeepTecdsa() {
     )
     await depositUnbondedValue(operatorAddress, purse, "10")
 
-    for (let i = 0; i < sanctionedApplications.length; i++) {
-      const sanctionedApplicationAddress = sanctionedApplications[i]
+    console.log(
+      `\n<<<<<<<<<<<< Check Sortition Pool for TBTCSystem: ${tbtcSystemAddress} >>>>>>>>>>>>`
+    )
+    const sortitionPoolContractAddress = await getSortitionPool(
+      tbtcSystemAddress
+    )
 
-      console.log(
-        `\n<<<<<<<<<<<< Check Sortition Pool for Sanctioned Application: ${sanctionedApplicationAddress} >>>>>>>>>>>>`
-      )
-      const sortitionPoolContractAddress = await getSortitionPool(
-        sanctionedApplicationAddress
-      )
-
-      const ADDRESS_ZERO = "0x0000000000000000000000000000000000000000"
-      if (
-        !sortitionPoolContractAddress ||
-        sortitionPoolContractAddress === ADDRESS_ZERO
-      ) {
-        console.error(
-          `missing sortition pool for application: [${applicationAddress}]`
-        )
-        continue
-      }
-
-      console.log(
-        `\n<<<<<<<<<<<< Authorizing Sortition Pool Contract ${sortitionPoolContractAddress} >>>>>>>>>>>>`
-      )
-      await authorizeSortitionPoolContract(
-        operatorAddress,
-        sortitionPoolContractAddress,
-        authorizer
-      )
+    if (
+      !sortitionPoolContractAddress ||
+      sortitionPoolContractAddress === "0x0000000000000000000000000000000000000000"
+    ) {
+      throw new Error(`missing sortition pool for application: [${tbtcSystemAddress}]`)
     }
+
+    console.log(
+      `\n<<<<<<<<<<<< Authorizing Sortition Pool Contract ${sortitionPoolContractAddress} >>>>>>>>>>>>`
+    )
+    await authorizeSortitionPoolContract(
+      operatorAddress,
+      sortitionPoolContractAddress,
+      authorizer
+    )
 
     console.log("\n<<<<<<<<<<<< Creating keep-ecdsa Config File >>>>>>>>>>>>")
     await createKeepTecdsaConfig()
@@ -363,10 +358,10 @@ async function createKeepTecdsaConfig() {
   parsedConfigFile[hostChain].account.KeyFile = operatorKeyFile
 
   parsedConfigFile[hostChain].ContractAddresses.BondedECDSAKeepFactory =
-      bondedECDSAKeepFactory.options.address
+    bondedECDSAKeepFactory.options.address
 
   parsedConfigFile[hostChain].ContractAddresses.TBTCSystem =
-      tbtcSystemContract.options.address
+    tbtcSystemAddress
 
   parsedConfigFile.LibP2P.Peers = libp2pPeers
   parsedConfigFile.LibP2P.Port = libp2pPort


### PR DESCRIPTION
Adding a dependency to TBTCSystem contract to obtain its address in the init container (https://github.com/keep-network/keep-ecdsa/commit/23db2b85e47c11c9b5b5deaa97614011366bda20) gave an additional cyclic dependency to `tbtc` which already depends on `keep-ecdsa`. We used to handle this case by defining the TBTCSystem address as an environment variable on the pod (SANCTIONED_APPLICATIONS). With this PR, we go back to this solution.

Right now keep-ecdsa init container build is coupled with keep-ecdsa contracts migration. We could separate them and add tbtc migration in between but this isn't that straightforward as it would require calls to external projects: `keep-ecdsa migration -> tbtc migration -> keep-ecdsa initcontainer build`. We are planning to handle such situations soon with RFC-18. We will revisit pulling the address from a contract artifact when working on the integration of the modules.