### PR TITLE
Add step resolving latest contracts to Solidity workflow

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -135,6 +135,12 @@ jobs:
           ETH_NETWORK_ID: ${{ secrets.KEEP_TEST_ETH_NETWORK_ID }} # currently ='3' (ropsten)
         run: ./scripts/ci-provision-external-contracts.sh
 
+      - name: Resolve latest contracts
+        run: |
+            npm update \
+              @keep-network/keep-core \
+              @keep-network/sortition-pools
+
       - name: Migrate contracts
         env:
           TRUFFLE_NETWORK: ${{ secrets.KEEP_TEST_ETH_TRUFFLE_NETWORK }}
@@ -295,6 +301,12 @@ jobs:
           CONTRACT_DATA_BUCKET_DIR: keep-core-celo
           ETH_NETWORK_ID: ${{ secrets.KEEP_TEST_CELO_NETWORK_ID }}
         run: ./scripts/ci-provision-external-contracts.sh
+
+      - name: Resolve latest contracts
+        run: |
+            npm update \
+              @keep-network/keep-core \
+              @keep-network/sortition-pools
 
       - name: Migrate contracts
         env:


### PR DESCRIPTION
As part of work on RFC-18 `contracts.yml` workflow was created. This
PR adds step resolving latest contracts which was missing from
`migrate-and-publish-ethereum` and `migrate-and-publish-celo` jobs.