### PR TITLE
Publish ethereum image under the old name

### DIFF
--- a/.github/workflows/client-ethereum.yml
+++ b/.github/workflows/client-ethereum.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Build and publish Docker Runtime Image
         uses: docker/build-push-action@v2
         env:
-          IMAGE_NAME: 'keep-ecdsa-ethereum'
+          IMAGE_NAME: 'keep-ecdsa'
           GOOGLE_PROJECT_ID: ${{ secrets.KEEP_TEST_GOOGLE_PROJECT_ID }}
         with:
           # GCR image should be named according to following convention:


### PR DESCRIPTION
We name the image `keep-ecdsa` instead of `keep-ecdsa-ethereum`
to provide backward compatibility, as this is the default image for the
client.