### PR TITLE
Updates to run client guide after ropsten migrations

### DIFF
--- a/docs/run-keep-ecdsa.adoc
+++ b/docs/run-keep-ecdsa.adoc
@@ -394,8 +394,8 @@ Contract addresses needed to boot a Keep ECDSA client:
 |BondedECDSAKeepFactory
 |`0xA7d9E842EFB252389d613dA88EDa3731512e40bD`
 
-|Sanctioned Applications
-|`0xe20A5C79b39bC8C363f0f49ADcFa82C2a01ab64a` (tBTC's system contract)
+|TBTCSystem
+|`0xe20A5C79b39bC8C363f0f49ADcFa82C2a01ab64a`
 
 |tBTC Sortition pool (for <<Authorizations,authorization>>)
 |`0xa3748633c6786e1842b5cc44fa43db1ecc710501`
@@ -452,8 +452,8 @@ Contract addresses needed to boot a Keep ECDSA client:
 |BondedECDSAKeepFactory
 |`0x3521bFaa52D09Ce6F0cE882a69E59e9386feB676`
 
-|Sanctioned Applications
-|`0x3b9072d3F1E3a7af139A9eF2A4f035cBFcf27BaF` (tBTC's system contract)
+|TBTCSystem
+|`0x3b9072d3F1E3a7af139A9eF2A4f035cBFcf27BaF`
 
 |tBTC Sortition pool (for <<Authorizations,authorization>>)
 |`0x1c56eB39fe8EcF577D79cd586D090239ec25701a`

--- a/docs/run-keep-ecdsa.adoc
+++ b/docs/run-keep-ecdsa.adoc
@@ -450,13 +450,13 @@ Contract addresses needed to boot a Keep ECDSA client:
 |
 
 |BondedECDSAKeepFactory
-|`0x26dBc9eF92a062c41FB07513313D14Fd54B630e5`
+|`0x3521bFaa52D09Ce6F0cE882a69E59e9386feB676`
 
 |Sanctioned Applications
-|`0xA41ffe9d9BAD45aD884e5100E6e201854912373E` (tBTC's system contract)
+|`0x3b9072d3F1E3a7af139A9eF2A4f035cBFcf27BaF` (tBTC's system contract)
 
 |tBTC Sortition pool (for <<Authorizations,authorization>>)
-|`0xBE0994212CBFd7A22bCA9F73F253AB15e767053b`
+|`0x1c56eB39fe8EcF577D79cd586D090239ec25701a`
 |===
 
 

--- a/infrastructure/kube/keep-test/ethereum/keep-ecdsa-0-statefulset.yaml
+++ b/infrastructure/kube/keep-test/ethereum/keep-ecdsa-0-statefulset.yaml
@@ -116,7 +116,7 @@ spec:
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
             - name: TBTC_SYSTEM_ADDRESS
-              value: '0xA41ffe9d9BAD45aD884e5100E6e201854912373E' # Shall we extract this property to a configmap?
+              value: '0x3b9072d3F1E3a7af139A9eF2A4f035cBFcf27BaF' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-test/ethereum/keep-ecdsa-1-statefulset.yaml
+++ b/infrastructure/kube/keep-test/ethereum/keep-ecdsa-1-statefulset.yaml
@@ -116,7 +116,7 @@ spec:
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
             - name: TBTC_SYSTEM_ADDRESS
-              value: '0xA41ffe9d9BAD45aD884e5100E6e201854912373E' # Shall we extract this property to a configmap?
+              value: '0x3b9072d3F1E3a7af139A9eF2A4f035cBFcf27BaF' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-test/ethereum/keep-ecdsa-2-statefulset.yaml
+++ b/infrastructure/kube/keep-test/ethereum/keep-ecdsa-2-statefulset.yaml
@@ -116,7 +116,7 @@ spec:
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
             - name: TBTC_SYSTEM_ADDRESS
-              value: '0xA41ffe9d9BAD45aD884e5100E6e201854912373E' # Shall we extract this property to a configmap?
+              value: '0x3b9072d3F1E3a7af139A9eF2A4f035cBFcf27BaF' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-test/ethereum/keep-ecdsa-3-statefulset.yaml
+++ b/infrastructure/kube/keep-test/ethereum/keep-ecdsa-3-statefulset.yaml
@@ -116,7 +116,7 @@ spec:
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
             - name: TBTC_SYSTEM_ADDRESS
-              value: '0xA41ffe9d9BAD45aD884e5100E6e201854912373E' # Shall we extract this property to a configmap?
+              value: '0x3b9072d3F1E3a7af139A9eF2A4f035cBFcf27BaF' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-test/ethereum/keep-ecdsa-4-statefulset.yaml
+++ b/infrastructure/kube/keep-test/ethereum/keep-ecdsa-4-statefulset.yaml
@@ -116,7 +116,7 @@ spec:
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
             - name: TBTC_SYSTEM_ADDRESS
-              value: '0x576ad5Ced9D0030D2F26E2F08BD2E92de9fcD858' # Shall we extract this property to a configmap?
+              value: '0x3b9072d3F1E3a7af139A9eF2A4f035cBFcf27BaF' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-test/ethereum/keep-ecdsa-5-statefulset.yaml
+++ b/infrastructure/kube/keep-test/ethereum/keep-ecdsa-5-statefulset.yaml
@@ -116,7 +116,7 @@ spec:
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
             - name: TBTC_SYSTEM_ADDRESS
-              value: '0x576ad5Ced9D0030D2F26E2F08BD2E92de9fcD858' # Shall we extract this property to a configmap?
+              value: '0x3b9072d3F1E3a7af139A9eF2A4f035cBFcf27BaF' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-test/ethereum/keep-ecdsa-6-statefulset.yaml
+++ b/infrastructure/kube/keep-test/ethereum/keep-ecdsa-6-statefulset.yaml
@@ -116,7 +116,7 @@ spec:
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
             - name: TBTC_SYSTEM_ADDRESS
-              value: '0x576ad5Ced9D0030D2F26E2F08BD2E92de9fcD858' # Shall we extract this property to a configmap?
+              value: '0x3b9072d3F1E3a7af139A9eF2A4f035cBFcf27BaF' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-test/ethereum/keep-ecdsa-7-statefulset.yaml
+++ b/infrastructure/kube/keep-test/ethereum/keep-ecdsa-7-statefulset.yaml
@@ -116,7 +116,7 @@ spec:
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
             - name: TBTC_SYSTEM_ADDRESS
-              value: '0x576ad5Ced9D0030D2F26E2F08BD2E92de9fcD858' # Shall we extract this property to a configmap?
+              value: '0x3b9072d3F1E3a7af139A9eF2A4f035cBFcf27BaF' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-test/ethereum/keep-ecdsa-8-statefulset.yaml
+++ b/infrastructure/kube/keep-test/ethereum/keep-ecdsa-8-statefulset.yaml
@@ -116,7 +116,7 @@ spec:
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
             - name: TBTC_SYSTEM_ADDRESS
-              value: '0x576ad5Ced9D0030D2F26E2F08BD2E92de9fcD858' # Shall we extract this property to a configmap?
+              value: '0x3b9072d3F1E3a7af139A9eF2A4f035cBFcf27BaF' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config

--- a/infrastructure/kube/keep-test/ethereum/keep-ecdsa-9-statefulset.yaml
+++ b/infrastructure/kube/keep-test/ethereum/keep-ecdsa-9-statefulset.yaml
@@ -116,7 +116,7 @@ spec:
             - name: KEEP_DATA_DIR
               value: /mnt/keep-ecdsa/data
             - name: TBTC_SYSTEM_ADDRESS
-              value: '0x576ad5Ced9D0030D2F26E2F08BD2E92de9fcD858' # Shall we extract this property to a configmap?
+              value: '0x3b9072d3F1E3a7af139A9eF2A4f035cBFcf27BaF' # Shall we extract this property to a configmap?
           volumeMounts:
             - name: keep-ecdsa-config
               mountPath: /mnt/keep-ecdsa/config


### PR DESCRIPTION
We update guides with addresses of the contracts that were recently migrated on ropsten and are backed by keep-test nodes. Jobs that migrated contracts: 
- https://github.com/keep-network/keep-ecdsa/actions/runs/690005293
- https://github.com/keep-network/tbtc/actions/runs/698185957

We no longer define Sanctioned Applications property in the `config.toml` file. Instead, we have TBTCSystem property.