### PR TITLE
Updated log level filter in k8s configs

### DIFF
--- a/infrastructure/kube/keep-dev/keep-ecdsa-0-statefulset.yaml
+++ b/infrastructure/kube/keep-dev/keep-ecdsa-0-statefulset.yaml
@@ -51,7 +51,7 @@ spec:
                   name: eth-account-passphrases
                   key: account-0
             - name: LOG_LEVEL
-              value: 'keep*=debug tss-lib=warning'
+              value: 'keep*=debug tss-lib=warn'
             - name: IPFS_LOGGING_FMT
               value: nocolor
           volumeMounts:

--- a/infrastructure/kube/keep-dev/keep-ecdsa-1-statefulset.yaml
+++ b/infrastructure/kube/keep-dev/keep-ecdsa-1-statefulset.yaml
@@ -51,7 +51,7 @@ spec:
                   name: eth-account-passphrases
                   key: account-1
             - name: LOG_LEVEL
-              value: 'keep*=debug tss-lib=warning'
+              value: 'keep*=debug tss-lib=warn'
             - name: IPFS_LOGGING_FMT
               value: nocolor
           volumeMounts:

--- a/infrastructure/kube/keep-dev/keep-ecdsa-2-statefulset.yaml
+++ b/infrastructure/kube/keep-dev/keep-ecdsa-2-statefulset.yaml
@@ -52,7 +52,7 @@ spec:
                   name: eth-account-passphrases
                   key: account-2
             - name: LOG_LEVEL
-              value: 'keep*=debug tss-lib=warning'
+              value: 'keep*=debug tss-lib=warn'
             - name: IPFS_LOGGING_FMT
               value: nocolor
           volumeMounts:

--- a/infrastructure/kube/keep-dev/keep-ecdsa-3-statefulset.yaml
+++ b/infrastructure/kube/keep-dev/keep-ecdsa-3-statefulset.yaml
@@ -52,7 +52,7 @@ spec:
                   name: eth-account-passphrases
                   key: account-3
             - name: LOG_LEVEL
-              value: 'keep*=debug tss-lib=warning'
+              value: 'keep*=debug tss-lib=warn'
             - name: IPFS_LOGGING_FMT
               value: nocolor
           volumeMounts:

--- a/infrastructure/kube/keep-dev/keep-ecdsa-4-statefulset.yaml
+++ b/infrastructure/kube/keep-dev/keep-ecdsa-4-statefulset.yaml
@@ -52,7 +52,7 @@ spec:
                   name: eth-account-passphrases
                   key: account-4
             - name: LOG_LEVEL
-              value: 'keep*=debug tss-lib=warning'
+              value: 'keep*=debug tss-lib=warn'
             - name: IPFS_LOGGING_FMT
               value: nocolor
           volumeMounts:

--- a/infrastructure/kube/keep-test/celo/keep-ecdsa-0-statefulset.yaml
+++ b/infrastructure/kube/keep-test/celo/keep-ecdsa-0-statefulset.yaml
@@ -58,7 +58,7 @@ spec:
                   name: eth-account-passphrases
                   key: account-0
             - name: LOG_LEVEL
-              value: 'keep*=debug tss-lib=warning'
+              value: 'keep*=debug tss-lib=warn'
             - name: IPFS_LOGGING_FMT
               value: nocolor
           volumeMounts:

--- a/infrastructure/kube/keep-test/celo/keep-ecdsa-1-statefulset.yaml
+++ b/infrastructure/kube/keep-test/celo/keep-ecdsa-1-statefulset.yaml
@@ -58,7 +58,7 @@ spec:
                   name: eth-account-passphrases
                   key: account-1
             - name: LOG_LEVEL
-              value: 'keep*=debug tss-lib=warning'
+              value: 'keep*=debug tss-lib=warn'
             - name: IPFS_LOGGING_FMT
               value: nocolor
           volumeMounts:

--- a/infrastructure/kube/keep-test/celo/keep-ecdsa-2-statefulset.yaml
+++ b/infrastructure/kube/keep-test/celo/keep-ecdsa-2-statefulset.yaml
@@ -58,7 +58,7 @@ spec:
                   name: eth-account-passphrases
                   key: account-2
             - name: LOG_LEVEL
-              value: 'keep*=debug tss-lib=warning'
+              value: 'keep*=debug tss-lib=warn'
             - name: IPFS_LOGGING_FMT
               value: nocolor
           volumeMounts:

--- a/infrastructure/kube/keep-test/celo/keep-ecdsa-3-statefulset.yaml
+++ b/infrastructure/kube/keep-test/celo/keep-ecdsa-3-statefulset.yaml
@@ -58,7 +58,7 @@ spec:
                   name: eth-account-passphrases
                   key: account-3
             - name: LOG_LEVEL
-              value: 'keep*=debug tss-lib=warning'
+              value: 'keep*=debug tss-lib=warn'
             - name: IPFS_LOGGING_FMT
               value: nocolor
           volumeMounts:

--- a/infrastructure/kube/keep-test/celo/keep-ecdsa-4-statefulset.yaml
+++ b/infrastructure/kube/keep-test/celo/keep-ecdsa-4-statefulset.yaml
@@ -58,7 +58,7 @@ spec:
                   name: eth-account-passphrases
                   key: account-4
             - name: LOG_LEVEL
-              value: 'keep*=debug tss-lib=warning'
+              value: 'keep*=debug tss-lib=warn'
             - name: IPFS_LOGGING_FMT
               value: nocolor
           volumeMounts:

--- a/infrastructure/kube/keep-test/celo/keep-ecdsa-5-statefulset.yaml
+++ b/infrastructure/kube/keep-test/celo/keep-ecdsa-5-statefulset.yaml
@@ -58,7 +58,7 @@ spec:
                   name: eth-account-passphrases
                   key: account-5
             - name: LOG_LEVEL
-              value: 'keep*=debug tss-lib=warning'
+              value: 'keep*=debug tss-lib=warn'
             - name: IPFS_LOGGING_FMT
               value: nocolor
           volumeMounts:

--- a/infrastructure/kube/keep-test/celo/keep-ecdsa-6-statefulset.yaml
+++ b/infrastructure/kube/keep-test/celo/keep-ecdsa-6-statefulset.yaml
@@ -58,7 +58,7 @@ spec:
                   name: eth-account-passphrases
                   key: account-6
             - name: LOG_LEVEL
-              value: 'keep*=debug tss-lib=warning'
+              value: 'keep*=debug tss-lib=warn'
             - name: IPFS_LOGGING_FMT
               value: nocolor
           volumeMounts:

--- a/infrastructure/kube/keep-test/celo/keep-ecdsa-7-statefulset.yaml
+++ b/infrastructure/kube/keep-test/celo/keep-ecdsa-7-statefulset.yaml
@@ -58,7 +58,7 @@ spec:
                   name: eth-account-passphrases
                   key: account-7
             - name: LOG_LEVEL
-              value: 'keep*=debug tss-lib=warning'
+              value: 'keep*=debug tss-lib=warn'
             - name: IPFS_LOGGING_FMT
               value: nocolor
           volumeMounts:

--- a/infrastructure/kube/keep-test/celo/keep-ecdsa-8-statefulset.yaml
+++ b/infrastructure/kube/keep-test/celo/keep-ecdsa-8-statefulset.yaml
@@ -58,7 +58,7 @@ spec:
                   name: eth-account-passphrases
                   key: account-8
             - name: LOG_LEVEL
-              value: 'keep*=debug tss-lib=warning'
+              value: 'keep*=debug tss-lib=warn'
             - name: IPFS_LOGGING_FMT
               value: nocolor
           volumeMounts:

--- a/infrastructure/kube/keep-test/celo/keep-ecdsa-9-statefulset.yaml
+++ b/infrastructure/kube/keep-test/celo/keep-ecdsa-9-statefulset.yaml
@@ -58,7 +58,7 @@ spec:
                   name: eth-account-passphrases
                   key: account-9
             - name: LOG_LEVEL
-              value: 'keep*=debug tss-lib=warning'
+              value: 'keep*=debug tss-lib=warn'
             - name: IPFS_LOGGING_FMT
               value: nocolor
           volumeMounts:

--- a/infrastructure/kube/keep-test/ethereum/keep-ecdsa-0-statefulset.yaml
+++ b/infrastructure/kube/keep-test/ethereum/keep-ecdsa-0-statefulset.yaml
@@ -58,7 +58,7 @@ spec:
                   name: eth-account-passphrases
                   key: account-0
             - name: LOG_LEVEL
-              value: 'keep*=debug tss-lib=warning'
+              value: 'keep*=debug tss-lib=warn'
             - name: IPFS_LOGGING_FMT
               value: nocolor
           volumeMounts:

--- a/infrastructure/kube/keep-test/ethereum/keep-ecdsa-1-statefulset.yaml
+++ b/infrastructure/kube/keep-test/ethereum/keep-ecdsa-1-statefulset.yaml
@@ -58,7 +58,7 @@ spec:
                   name: eth-account-passphrases
                   key: account-1
             - name: LOG_LEVEL
-              value: 'keep*=debug tss-lib=warning'
+              value: 'keep*=debug tss-lib=warn'
             - name: IPFS_LOGGING_FMT
               value: nocolor
           volumeMounts:

--- a/infrastructure/kube/keep-test/ethereum/keep-ecdsa-2-statefulset.yaml
+++ b/infrastructure/kube/keep-test/ethereum/keep-ecdsa-2-statefulset.yaml
@@ -58,7 +58,7 @@ spec:
                   name: eth-account-passphrases
                   key: account-2
             - name: LOG_LEVEL
-              value: 'keep*=debug tss-lib=warning'
+              value: 'keep*=debug tss-lib=warn'
             - name: IPFS_LOGGING_FMT
               value: nocolor
           volumeMounts:

--- a/infrastructure/kube/keep-test/ethereum/keep-ecdsa-3-statefulset.yaml
+++ b/infrastructure/kube/keep-test/ethereum/keep-ecdsa-3-statefulset.yaml
@@ -58,7 +58,7 @@ spec:
                   name: eth-account-passphrases
                   key: account-3
             - name: LOG_LEVEL
-              value: 'keep*=debug tss-lib=warning'
+              value: 'keep*=debug tss-lib=warn'
             - name: IPFS_LOGGING_FMT
               value: nocolor
           volumeMounts:

--- a/infrastructure/kube/keep-test/ethereum/keep-ecdsa-4-statefulset.yaml
+++ b/infrastructure/kube/keep-test/ethereum/keep-ecdsa-4-statefulset.yaml
@@ -58,7 +58,7 @@ spec:
                   name: eth-account-passphrases
                   key: account-4
             - name: LOG_LEVEL
-              value: 'keep*=debug tss-lib=warning'
+              value: 'keep*=debug tss-lib=warn'
             - name: IPFS_LOGGING_FMT
               value: nocolor
           volumeMounts:

--- a/infrastructure/kube/keep-test/ethereum/keep-ecdsa-5-statefulset.yaml
+++ b/infrastructure/kube/keep-test/ethereum/keep-ecdsa-5-statefulset.yaml
@@ -58,7 +58,7 @@ spec:
                   name: eth-account-passphrases
                   key: account-5
             - name: LOG_LEVEL
-              value: 'keep*=debug tss-lib=warning'
+              value: 'keep*=debug tss-lib=warn'
             - name: IPFS_LOGGING_FMT
               value: nocolor
           volumeMounts:

--- a/infrastructure/kube/keep-test/ethereum/keep-ecdsa-6-statefulset.yaml
+++ b/infrastructure/kube/keep-test/ethereum/keep-ecdsa-6-statefulset.yaml
@@ -58,7 +58,7 @@ spec:
                   name: eth-account-passphrases
                   key: account-6
             - name: LOG_LEVEL
-              value: 'keep*=debug tss-lib=warning'
+              value: 'keep*=debug tss-lib=warn'
             - name: IPFS_LOGGING_FMT
               value: nocolor
           volumeMounts:

--- a/infrastructure/kube/keep-test/ethereum/keep-ecdsa-7-statefulset.yaml
+++ b/infrastructure/kube/keep-test/ethereum/keep-ecdsa-7-statefulset.yaml
@@ -58,7 +58,7 @@ spec:
                   name: eth-account-passphrases
                   key: account-7
             - name: LOG_LEVEL
-              value: 'keep*=debug tss-lib=warning'
+              value: 'keep*=debug tss-lib=warn'
             - name: IPFS_LOGGING_FMT
               value: nocolor
           volumeMounts:

--- a/infrastructure/kube/keep-test/ethereum/keep-ecdsa-8-statefulset.yaml
+++ b/infrastructure/kube/keep-test/ethereum/keep-ecdsa-8-statefulset.yaml
@@ -58,7 +58,7 @@ spec:
                   name: eth-account-passphrases
                   key: account-8
             - name: LOG_LEVEL
-              value: 'keep*=debug tss-lib=warning'
+              value: 'keep*=debug tss-lib=warn'
             - name: IPFS_LOGGING_FMT
               value: nocolor
           volumeMounts:

--- a/infrastructure/kube/keep-test/ethereum/keep-ecdsa-9-statefulset.yaml
+++ b/infrastructure/kube/keep-test/ethereum/keep-ecdsa-9-statefulset.yaml
@@ -58,7 +58,7 @@ spec:
                   name: eth-account-passphrases
                   key: account-9
             - name: LOG_LEVEL
-              value: 'keep*=debug tss-lib=warning'
+              value: 'keep*=debug tss-lib=warn'
             - name: IPFS_LOGGING_FMT
               value: nocolor
           volumeMounts:


### PR DESCRIPTION
`warning` wasn't correct filter for log level filtering in the client.
The client logged warning about that. We replaced it with `warn` which
seems to be correct.