### PR TITLE
Read chaincfg.Params from Config

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -155,7 +155,9 @@ func TestParseChainParams(t *testing.T) {
 	}
 	for testName, testData := range parseChainParamTests {
 		t.Run(testName, func(t *testing.T) {
-			// use a string builder and a single-value list to represent optionality
+			// Use a string builder and a single-value list to represent optionality.
+			// If the list has a chain name, we define it in the config, otherwise,
+			// we have an empty `[Extensions.TBTC.BTCRefunds]` section.
 			var b strings.Builder
 			fmt.Fprint(&b, "[Extensions.TBTC.BTCRefunds]")
 			for _, name := range testData.chainName {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -189,15 +189,11 @@ func TestParseChainParams_ExpectedFailure(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expecting an error but found none")
 	}
-	if !errorContains(err, expectedError) {
+	if expectedError != err.Error() {
 		t.Errorf(
 			"unexpected error\nexpected: %s\nactual:   %v",
 			expectedError,
 			err,
 		)
 	}
-}
-
-func errorContains(err error, expected string) bool {
-	return strings.Contains(err.Error(), expected)
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -99,8 +99,8 @@ func TestReadConfig(t *testing.T) {
 			readValueFunc: func(c *Config) interface{} { return c.Extensions.TBTC.BTCRefunds.MaxFeePerVByte },
 			expectedValue: int32(73),
 		},
-		"Extensions.TBTC.BTCRefunds.ChainName": {
-			readValueFunc: func(c *Config) interface{} { return c.Extensions.TBTC.BTCRefunds.ChainName },
+		"Extensions.TBTC.BTCRefunds.BitcoinChainName": {
+			readValueFunc: func(c *Config) interface{} { return c.Extensions.TBTC.BTCRefunds.BitcoinChainName },
 			expectedValue: "mainnet",
 		},
 		"Extensions.TBTC.BTCRefunds.ChainParams()": {
@@ -161,7 +161,7 @@ func TestParseChainParams(t *testing.T) {
 			var b strings.Builder
 			fmt.Fprint(&b, "[Extensions.TBTC.BTCRefunds]")
 			for _, name := range testData.chainName {
-				fmt.Fprintf(&b, "\nChainName=\"%s\"", name)
+				fmt.Fprintf(&b, "\nBitcoinChainName=\"%s\"", name)
 			}
 			config := &Config{}
 			if _, err := toml.Decode(b.String(), config); err != nil {
@@ -179,7 +179,7 @@ func TestParseChainParams(t *testing.T) {
 }
 
 func TestParseChainParams_ExpectedFailure(t *testing.T) {
-	configString := fmt.Sprintf("[Extensions.TBTC.BTCRefunds]\nChainName=\"%s\"", "bleeble blabble")
+	configString := fmt.Sprintf("[Extensions.TBTC.BTCRefunds]\nBitcoinChainName=\"%s\"", "bleeble blabble")
 	config := &Config{}
 	if _, err := toml.Decode(configString, config); err != nil {
 		t.Fatal(err)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,11 +1,16 @@
 package config
 
 import (
+	"fmt"
 	"math/big"
 	"os"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/BurntSushi/toml"
+	"github.com/btcsuite/btcd/chaincfg"
 )
 
 func TestReadConfig(t *testing.T) {
@@ -94,6 +99,17 @@ func TestReadConfig(t *testing.T) {
 			readValueFunc: func(c *Config) interface{} { return c.Extensions.TBTC.BTCRefunds.MaxFeePerVByte },
 			expectedValue: int32(73),
 		},
+		"Extensions.TBTC.BTCRefunds.ChainName": {
+			readValueFunc: func(c *Config) interface{} { return c.Extensions.TBTC.BTCRefunds.ChainName },
+			expectedValue: "mainnet",
+		},
+		"Extensions.TBTC.BTCRefunds.ChainParams()": {
+			readValueFunc: func(c *Config) interface{} {
+				params, _ := c.Extensions.TBTC.BTCRefunds.ChainParams()
+				return *params
+			},
+			expectedValue: chaincfg.MainNetParams,
+		},
 	}
 
 	for testName, test := range configReadTests {
@@ -105,5 +121,81 @@ func TestReadConfig(t *testing.T) {
 			}
 		})
 	}
+}
 
+func TestParseChainParams(t *testing.T) {
+	var parseChainParamTests = map[string]struct {
+		chainName   []string
+		chainParams chaincfg.Params
+	}{
+		"main network": {
+			[]string{"mainnet"},
+			chaincfg.MainNetParams,
+		},
+		"regtest": {
+			[]string{"regtest"},
+			chaincfg.RegressionNetParams,
+		},
+		"simnet": {
+			[]string{"simnet"},
+			chaincfg.SimNetParams,
+		},
+		"testnet3": {
+			[]string{"testnet3"},
+			chaincfg.TestNet3Params,
+		},
+		"undefined": {
+			[]string{},
+			chaincfg.MainNetParams,
+		},
+		"empty": {
+			[]string{""},
+			chaincfg.MainNetParams,
+		},
+	}
+	for testName, testData := range parseChainParamTests {
+		t.Run(testName, func(t *testing.T) {
+			// use a string builder and a single-value list to represent optionality
+			var b strings.Builder
+			fmt.Fprint(&b, "[Extensions.TBTC.BTCRefunds]")
+			for _, name := range testData.chainName {
+				fmt.Fprintf(&b, "\nChainName=\"%s\"", name)
+			}
+			config := &Config{}
+			if _, err := toml.Decode(b.String(), config); err != nil {
+				t.Fatal(err)
+			}
+			chainParams, err := config.Extensions.TBTC.BTCRefunds.ChainParams()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(*chainParams, testData.chainParams) {
+				t.Errorf("unexpected net params\nexpected: %v\nactual:   %v", testData.chainParams, chainParams)
+			}
+		})
+	}
+}
+
+func TestParseChainParams_ExpectedFailure(t *testing.T) {
+	configString := fmt.Sprintf("[Extensions.TBTC.BTCRefunds]\nChainName=\"%s\"", "bleeble blabble")
+	config := &Config{}
+	if _, err := toml.Decode(configString, config); err != nil {
+		t.Fatal(err)
+	}
+	_, err := config.Extensions.TBTC.BTCRefunds.ChainParams()
+	expectedError := "unable to find chaincfg param for name: [bleeble blabble]"
+	if err == nil {
+		t.Fatalf("expecting an error but found none")
+	}
+	if !errorContains(err, expectedError) {
+		t.Errorf(
+			"unexpected error\nexpected: %s\nactual:   %v",
+			expectedError,
+			err,
+		)
+	}
+}
+
+func errorContains(err error, expected string) bool {
+	return strings.Contains(err.Error(), expected)
 }

--- a/internal/testdata/config.toml
+++ b/internal/testdata/config.toml
@@ -33,3 +33,4 @@
   [Extensions.TBTC.BTCRefunds]
   	BeneficiaryAddress = "bcrt1q0umle4fe6penqqyzuwsysqezwwptuyqa82jas4"
   	MaxFeePerVByte = 73
+    ChainName = "mainnet"

--- a/internal/testdata/config.toml
+++ b/internal/testdata/config.toml
@@ -33,4 +33,4 @@
 	[Extensions.TBTC.BTCRefunds]
 		BeneficiaryAddress = "bcrt1q0umle4fe6penqqyzuwsysqezwwptuyqa82jas4"
 		MaxFeePerVByte = 73
-		ChainName = "mainnet"
+		BitcoinChainName = "mainnet"

--- a/internal/testdata/config.toml
+++ b/internal/testdata/config.toml
@@ -30,7 +30,7 @@
 [Extensions.TBTC]
 	TBTCSystem = "0xa4888eDD97A5a3A739B4E0807C71817c8a418273"
 
-  [Extensions.TBTC.BTCRefunds]
-  	BeneficiaryAddress = "bcrt1q0umle4fe6penqqyzuwsysqezwwptuyqa82jas4"
-  	MaxFeePerVByte = 73
-    ChainName = "mainnet"
+	[Extensions.TBTC.BTCRefunds]
+		BeneficiaryAddress = "bcrt1q0umle4fe6penqqyzuwsysqezwwptuyqa82jas4"
+		MaxFeePerVByte = 73
+		ChainName = "mainnet"

--- a/pkg/chain/bitcoin/config.go
+++ b/pkg/chain/bitcoin/config.go
@@ -16,7 +16,8 @@ type Config struct {
 // ChainParams parses the net param name into the associated chaincfg.Params
 func (c Config) ChainParams() (*chaincfg.Params, error) {
 	switch c.ChainName {
-	case "mainnet":
+	case "mainnet", "":
+		// If no chain name is provided, use the main net
 		return &chaincfg.MainNetParams, nil
 	case "regtest":
 		return &chaincfg.RegressionNetParams, nil
@@ -24,9 +25,6 @@ func (c Config) ChainParams() (*chaincfg.Params, error) {
 		return &chaincfg.SimNetParams, nil
 	case "testnet3":
 		return &chaincfg.TestNet3Params, nil
-	case "":
-		// If no chain name is provided, use the main net
-		return &chaincfg.MainNetParams, nil
 	default:
 		return nil, fmt.Errorf("unable to find chaincfg param for name: [%s]", c.ChainName)
 	}

--- a/pkg/chain/bitcoin/config.go
+++ b/pkg/chain/bitcoin/config.go
@@ -1,7 +1,33 @@
 package bitcoin
 
+import (
+	"fmt"
+
+	"github.com/btcsuite/btcd/chaincfg"
+)
+
 // Config stores configuration related to recovering BTC from a closed keep.
 type Config struct {
 	BeneficiaryAddress string
 	MaxFeePerVByte     int32
+	ChainName          string
+}
+
+// ChainParams parses the net param name into the associated chaincfg.Params
+func (c Config) ChainParams() (*chaincfg.Params, error) {
+	switch c.ChainName {
+	case "mainnet":
+		return &chaincfg.MainNetParams, nil
+	case "regtest":
+		return &chaincfg.RegressionNetParams, nil
+	case "simnet":
+		return &chaincfg.SimNetParams, nil
+	case "testnet3":
+		return &chaincfg.TestNet3Params, nil
+	case "":
+		// If no chain name is provided, use the main net
+		return &chaincfg.MainNetParams, nil
+	default:
+		return nil, fmt.Errorf("unable to find chaincfg param for name: [%s]", c.ChainName)
+	}
 }

--- a/pkg/chain/bitcoin/config.go
+++ b/pkg/chain/bitcoin/config.go
@@ -10,12 +10,12 @@ import (
 type Config struct {
 	BeneficiaryAddress string
 	MaxFeePerVByte     int32
-	ChainName          string
+	BitcoinChainName   string
 }
 
 // ChainParams parses the net param name into the associated chaincfg.Params
 func (c Config) ChainParams() (*chaincfg.Params, error) {
-	switch c.ChainName {
+	switch c.BitcoinChainName {
 	case "mainnet", "":
 		// If no chain name is provided, use the main net
 		return &chaincfg.MainNetParams, nil
@@ -26,6 +26,6 @@ func (c Config) ChainParams() (*chaincfg.Params, error) {
 	case "testnet3":
 		return &chaincfg.TestNet3Params, nil
 	default:
-		return nil, fmt.Errorf("unable to find chaincfg param for name: [%s]", c.ChainName)
+		return nil, fmt.Errorf("unable to find chaincfg param for name: [%s]", c.BitcoinChainName)
 	}
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -6,7 +6,6 @@ import (
 	"math/big"
 	"time"
 
-	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/keep-network/keep-common/pkg/chain/ethlike"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -1038,8 +1037,14 @@ func monitorKeepTerminatedEvent(
 							return err
 						}
 
-						//FIXME: derive the chain params from config
-						chainParams := &chaincfg.MainNetParams
+						chainParams, err := bitcoinConfig.ChainParams()
+						if err != nil {
+							logger.Errorf(
+								"failed to parse the the configured net params: [%v]",
+								err,
+							)
+							return err
+						}
 
 						beneficiaryAddress, err := recovery.ResolveAddress(
 							bitcoinConfig.BeneficiaryAddress,


### PR DESCRIPTION
This PR allows the user to supply a target BTC network at `Extensions.TBTC.BTCRefunds.ChainName` in the configuration. If none is supplied, we default to the main network.

tagging @nkuba for review!