### PR TITLE
Split upload of artifacts for initcontainer to two steps

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -224,13 +224,19 @@ jobs:
           echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }} > .npmrc
           npm publish --access=public
 
-      - name: Upload contracts artifacts for initcontainer build
+      - name: Upload contracts artifacts for initcontainer build (from solidity/build)
         uses: actions/upload-artifact@v2
         with:
           name: Selected contracts (Node.js ${{ matrix.node-version }})
           path: |
             ./solidity/build/contracts/BondedECDSAKeepFactory.json
             ./solidity/build/contracts/KeepBonding.json
+
+      - name: Upload contracts artifacts for initcontainer build (from solidity/node_modules)
+        uses: actions/upload-artifact@v2
+        with:
+          name: Selected contracts (Node.js ${{ matrix.node-version }})
+          path: |
             ./solidity/node_modules/@keep-network/keep-core/artifacts/KeepToken.json
             ./solidity/node_modules/@keep-network/keep-core/artifacts/TokenStaking.json
 


### PR DESCRIPTION
When we're building initcontainer from Docker image, we expect to have
four contracts (artifacts of previous job) in the step's working
directory.
When upload of artifacts was done in one step, artifacts (which come
from two different directories) were being saved together with their
path structure (least common ancestor is used as root directory).
Spliting the action to two allowed for upload of files without their
parent folders.