### PR TITLE
Add PreParamsTargetPoolSize to the List of Integer Keys

### DIFF
--- a/solidity/scripts/lcl-client-config.js
+++ b/solidity/scripts/lcl-client-config.js
@@ -54,7 +54,7 @@ module.exports = async function () {
               // Find keys that match exactly `Port`, `MiningCheckInterval`,
               // `MaxGasPrice` or end with `MetricsTick` or `Limit`.
               key.match(
-                /(^Port|^MiningCheckInterval|^MaxGasPrice|MetricsTick|Limit)$/,
+                /(^Port|^MiningCheckInterval|^MaxGasPrice|^PreParamsTargetPoolSize|MetricsTick|Limit)$/,
               )
                 ? value.toFixed(0) // convert float to integer
                 : false // do nothing


### PR DESCRIPTION
This PR adds `PreParamsTargetPoolSize` to the list of integer-based keys in the config file. We generally call `solidity/scripts/lcl-client-config.js` from `scripts/initialize.sh`, which in turn is called by the `tbtc` project setup script. It's purpose is to modify the config file to point at the proper addresses and whatnot from the configured ethereum network. Unfortunately, part of how we marshal/unmarshal the `toml` files means that we default the numbers to floats unless otherwise specified, so that a configured `2` becomes `2.0` after the file executes. 

To handle this, we have a code block that takes a list of key names that are known to be integers and marshals those separately.