### PR TITLE
Check Unused Bitcoin Adddresses

### DIFF
--- a/pkg/chain/bitcoin/electrs.go
+++ b/pkg/chain/bitcoin/electrs.go
@@ -99,10 +99,16 @@ func (e ElectrsConnection) IsAddressUnused(btcAddress string) (bool, error) {
 		return false, err
 	}
 	if resp.StatusCode != 200 {
+		transactionIDBuffer := new(strings.Builder)
+		_, err = io.Copy(transactionIDBuffer, resp.Body)
+		if err != nil {
+			logger.Error("something went wrong trying to unmarshal the error response for address %s", btcAddress)
+		}
 		return false, fmt.Errorf(
-			"something went wrong trying to get information about address %s: [%s]",
+			"something went wrong trying to get information about address %s - status: [%s], payload: [%s]",
 			btcAddress,
 			resp.Status,
+			transactionIDBuffer.String(),
 		)
 	}
 

--- a/pkg/chain/bitcoin/electrs.go
+++ b/pkg/chain/bitcoin/electrs.go
@@ -61,8 +61,8 @@ func (e ElectrsConnection) Broadcast(transaction string) error {
 	return nil
 }
 
-// VbyteFee retrieves the 25-block estimate fee per vbyte on the bitcoin network.
-func (e ElectrsConnection) VbyteFee() (int32, error) {
+// VbyteFeeFor25Blocks retrieves the 25-block estimate fee per vbyte on the bitcoin network.
+func (e ElectrsConnection) VbyteFeeFor25Blocks() (int32, error) {
 	if e.apiURL == "" {
 		return 0, fmt.Errorf("attempted to call VbyteFee with no apiURL")
 	}

--- a/pkg/chain/bitcoin/electrs.go
+++ b/pkg/chain/bitcoin/electrs.go
@@ -89,3 +89,28 @@ func (e ElectrsConnection) VbyteFee() (int32, error) {
 	logger.Info("retrieved a vbyte fee of [%d]", fee)
 	return int32(fee), nil
 }
+
+func (e ElectrsConnection) IsAddressUnused(btcAddress string) (bool, error) {
+	if e.apiURL == "" {
+		return true, nil
+	}
+	resp, err := e.client.Get(fmt.Sprintf("%s/address/%s/txs", e.apiURL, btcAddress))
+	if err != nil {
+		return false, err
+	}
+	if resp.StatusCode != 200 {
+		return false, fmt.Errorf(
+			"something went wrong trying to get information about address %s: [%s]",
+			btcAddress,
+			resp.Status,
+		)
+	}
+
+	responses := []interface{}{}
+	err = json.NewDecoder(resp.Body).Decode(&responses)
+	if err != nil {
+		return false, err
+	}
+
+	return len(responses) == 0, nil
+}

--- a/pkg/chain/bitcoin/electrs.go
+++ b/pkg/chain/bitcoin/electrs.go
@@ -82,7 +82,7 @@ func (e ElectrsConnection) VbyteFeeFor25Blocks() (int32, error) {
 			return err
 		}
 		if resp.StatusCode != 200 {
-			return fmt.Errorf("something went wrong with broadcast: [%s]", resp.Status)
+			return fmt.Errorf("something went wrong retreiving the vbyte fee: [%s]", resp.Status)
 		}
 
 		var fees map[string]float32
@@ -104,6 +104,8 @@ func (e ElectrsConnection) VbyteFeeFor25Blocks() (int32, error) {
 	return vbyteFee, nil
 }
 
+// IsAddressUnused returns true if and only if the supplied bitcoin address has
+// no recorded transactions.
 func (e ElectrsConnection) IsAddressUnused(btcAddress string) (bool, error) {
 	if e.apiURL == "" {
 		return false, fmt.Errorf("attempted to call IsAddressUnused with no apiURL")

--- a/pkg/chain/bitcoin/electrs.go
+++ b/pkg/chain/bitcoin/electrs.go
@@ -24,28 +24,28 @@ type httpClient interface {
 	Get(url string) (*http.Response, error)
 }
 
-// ElectrsConnection exposes a native API for interacting with an electrs http API.
-type ElectrsConnection struct {
+// electrsConnection exposes a native API for interacting with an electrs http API.
+type electrsConnection struct {
 	apiURL  string
 	client  httpClient
 	timeout time.Duration
 }
 
-// NewElectrsConnection is a constructor for ElectrsConnection.
-func NewElectrsConnection(apiURL string) *ElectrsConnection {
-	return &ElectrsConnection{
+// newElectrsConnection is a constructor for ElectrsConnection.
+func newElectrsConnection(apiURL string) *electrsConnection {
+	return &electrsConnection{
 		apiURL:  apiURL,
 		client:  http.DefaultClient,
 		timeout: defaultTimeout,
 	}
 }
 
-func (e *ElectrsConnection) setClient(client httpClient) {
+func (e *electrsConnection) setClient(client httpClient) {
 	e.client = client
 }
 
 // Broadcast broadcasts a transaction the configured bitcoin network.
-func (e ElectrsConnection) Broadcast(transaction string) error {
+func (e electrsConnection) Broadcast(transaction string) error {
 	if e.apiURL == "" {
 		return fmt.Errorf("attempted to call Broadcast with no apiURL")
 	}
@@ -71,7 +71,7 @@ func (e ElectrsConnection) Broadcast(transaction string) error {
 }
 
 // VbyteFeeFor25Blocks retrieves the 25-block estimate fee per vbyte on the bitcoin network.
-func (e ElectrsConnection) VbyteFeeFor25Blocks() (int32, error) {
+func (e electrsConnection) VbyteFeeFor25Blocks() (int32, error) {
 	if e.apiURL == "" {
 		return 0, fmt.Errorf("attempted to call VbyteFee with no apiURL")
 	}
@@ -106,7 +106,7 @@ func (e ElectrsConnection) VbyteFeeFor25Blocks() (int32, error) {
 
 // IsAddressUnused returns true if and only if the supplied bitcoin address has
 // no recorded transactions.
-func (e ElectrsConnection) IsAddressUnused(btcAddress string) (bool, error) {
+func (e electrsConnection) IsAddressUnused(btcAddress string) (bool, error) {
 	if e.apiURL == "" {
 		return false, fmt.Errorf("attempted to call IsAddressUnused with no apiURL")
 	}

--- a/pkg/chain/bitcoin/electrs.go
+++ b/pkg/chain/bitcoin/electrs.go
@@ -38,10 +38,7 @@ func (e *ElectrsConnection) setClient(client httpClient) {
 // Broadcast broadcasts a transaction the configured bitcoin network.
 func (e ElectrsConnection) Broadcast(transaction string) error {
 	if e.apiURL == "" {
-		for i := 0; i < 5; i++ {
-			logger.Warningf("Please broadcast Bitcoin transaction %s", transaction)
-		}
-		return nil
+		return fmt.Errorf("attempted to call Broadcast with no apiURL")
 	}
 	resp, err := e.client.Post(fmt.Sprintf("%s/tx", e.apiURL), "text/plain", strings.NewReader(transaction))
 	if err != nil {
@@ -67,7 +64,7 @@ func (e ElectrsConnection) Broadcast(transaction string) error {
 // VbyteFee retrieves the 25-block estimate fee per vbyte on the bitcoin network.
 func (e ElectrsConnection) VbyteFee() (int32, error) {
 	if e.apiURL == "" {
-		return 0, nil
+		return 0, fmt.Errorf("attempted to call VbyteFee with no apiURL")
 	}
 	resp, err := e.client.Get(fmt.Sprintf("%s/fee-estimates", e.apiURL))
 	if err != nil {
@@ -92,7 +89,7 @@ func (e ElectrsConnection) VbyteFee() (int32, error) {
 
 func (e ElectrsConnection) IsAddressUnused(btcAddress string) (bool, error) {
 	if e.apiURL == "" {
-		return true, nil
+		return false, fmt.Errorf("attempted to call IsAddressUnused with no apiURL")
 	}
 	resp, err := e.client.Get(fmt.Sprintf("%s/address/%s/txs", e.apiURL, btcAddress))
 	if err != nil {

--- a/pkg/chain/bitcoin/electrs.go
+++ b/pkg/chain/bitcoin/electrs.go
@@ -1,16 +1,23 @@
 package bitcoin
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/ipfs/go-log"
+	"github.com/keep-network/keep-ecdsa/pkg/utils"
 )
 
 var logger = log.Logger("bitcoin")
+
+const (
+	defaultTimeout = 2 * time.Minute
+)
 
 type httpClient interface {
 	Post(url string, contentType string, body io.Reader) (*http.Response, error)
@@ -40,25 +47,25 @@ func (e ElectrsConnection) Broadcast(transaction string) error {
 	if e.apiURL == "" {
 		return fmt.Errorf("attempted to call Broadcast with no apiURL")
 	}
-	resp, err := e.client.Post(fmt.Sprintf("%s/tx", e.apiURL), "text/plain", strings.NewReader(transaction))
-	if err != nil {
-		return err
-	}
-	if resp.StatusCode != 200 {
-		return fmt.Errorf("something went wrong with broadcast: [%s], transaction: [%s]", resp.Status, transaction)
-	}
-	transactionIDBuffer := new(strings.Builder)
-	bytesCopied, err := io.Copy(transactionIDBuffer, resp.Body)
-	// if the status code was 200, but we were unable to read the body, log an
-	// error but return successfully anyway.
-	if err != nil {
-		logger.Errorf("something went wrong reading the electrs response body: [%v]", err)
-	}
-	if bytesCopied == 0 {
-		logger.Error("something went wrong reading the electrs response body: 0 bytes copied")
-	}
-	logger.Infof("successfully broadcast the bitcoin transaction: %s", transactionIDBuffer.String())
-	return nil
+	return utils.DoWithDefaultRetry(defaultTimeout, func(ctx context.Context) error {
+		resp, err := e.client.Post(fmt.Sprintf("%s/tx", e.apiURL), "text/plain", strings.NewReader(transaction))
+		if err != nil {
+			return err
+		}
+		if resp.StatusCode != 200 {
+			return fmt.Errorf("something went wrong with broadcast: [%s], transaction: [%s]", resp.Status, transaction)
+		}
+		transactionIDBuffer := new(strings.Builder)
+		bytesCopied, err := io.Copy(transactionIDBuffer, resp.Body)
+		if err != nil {
+			return fmt.Errorf("something went wrong reading the electrs response body: [%v]", err)
+		}
+		if bytesCopied == 0 {
+			return fmt.Errorf("something went wrong reading the electrs response body: 0 bytes copied")
+		}
+		logger.Infof("successfully broadcast the bitcoin transaction: %s", transactionIDBuffer.String())
+		return nil
+	})
 }
 
 // VbyteFeeFor25Blocks retrieves the 25-block estimate fee per vbyte on the bitcoin network.
@@ -66,54 +73,70 @@ func (e ElectrsConnection) VbyteFeeFor25Blocks() (int32, error) {
 	if e.apiURL == "" {
 		return 0, fmt.Errorf("attempted to call VbyteFee with no apiURL")
 	}
-	resp, err := e.client.Get(fmt.Sprintf("%s/fee-estimates", e.apiURL))
+	var vbyteFee int32
+	err := utils.DoWithDefaultRetry(defaultTimeout, func(ctx context.Context) error {
+		resp, err := e.client.Get(fmt.Sprintf("%s/fee-estimates", e.apiURL))
+		if err != nil {
+			return err
+		}
+		if resp.StatusCode != 200 {
+			return fmt.Errorf("something went wrong with broadcast: [%s]", resp.Status)
+		}
+
+		var fees map[string]float32
+		err = json.NewDecoder(resp.Body).Decode(&fees)
+		if err != nil {
+			return fmt.Errorf("something went wrong decoding the vbyte fees: [%v]", err)
+		}
+		fee, ok := fees["25"]
+		if !ok {
+			fee = 0
+		}
+		logger.Info("retrieved a vbyte fee of [%d]", fee)
+		vbyteFee = int32(fee)
+		return nil
+	})
 	if err != nil {
 		return 0, err
 	}
-	if resp.StatusCode != 200 {
-		return 0, fmt.Errorf("something went wrong with broadcast: [%s]", resp.Status)
-	}
-
-	var fees map[string]float32
-	err = json.NewDecoder(resp.Body).Decode(&fees)
-	if err != nil {
-		return 0, fmt.Errorf("something went wrong decoding the vbyte fees: [%v]", err)
-	}
-	fee, ok := fees["25"]
-	if !ok {
-		fee = 0
-	}
-	logger.Info("retrieved a vbyte fee of [%d]", fee)
-	return int32(fee), nil
+	return vbyteFee, nil
 }
 
 func (e ElectrsConnection) IsAddressUnused(btcAddress string) (bool, error) {
 	if e.apiURL == "" {
 		return false, fmt.Errorf("attempted to call IsAddressUnused with no apiURL")
 	}
-	resp, err := e.client.Get(fmt.Sprintf("%s/address/%s/txs", e.apiURL, btcAddress))
-	if err != nil {
-		return false, err
-	}
-	if resp.StatusCode != 200 {
-		transactionIDBuffer := new(strings.Builder)
-		_, err = io.Copy(transactionIDBuffer, resp.Body)
+	isAddressUnused := false
+	err := utils.DoWithDefaultRetry(defaultTimeout, func(ctx context.Context) error {
+		resp, err := e.client.Get(fmt.Sprintf("%s/address/%s/txs", e.apiURL, btcAddress))
 		if err != nil {
-			logger.Error("something went wrong trying to unmarshal the error response for address %s", btcAddress)
+			return err
 		}
-		return false, fmt.Errorf(
-			"something went wrong trying to get information about address %s - status: [%s], payload: [%s]",
-			btcAddress,
-			resp.Status,
-			transactionIDBuffer.String(),
-		)
-	}
+		if resp.StatusCode != 200 {
+			transactionIDBuffer := new(strings.Builder)
+			_, err = io.Copy(transactionIDBuffer, resp.Body)
+			if err != nil {
+				logger.Error("something went wrong trying to unmarshal the error response for address %s", btcAddress)
+			}
+			return fmt.Errorf(
+				"something went wrong trying to get information about address %s - status: [%s], payload: [%s]",
+				btcAddress,
+				resp.Status,
+				transactionIDBuffer.String(),
+			)
+		}
 
-	responses := []interface{}{}
-	err = json.NewDecoder(resp.Body).Decode(&responses)
+		responses := []interface{}{}
+		err = json.NewDecoder(resp.Body).Decode(&responses)
+		if err != nil {
+			return err
+		}
+
+		isAddressUnused = len(responses) == 0
+		return nil
+	})
 	if err != nil {
 		return false, err
 	}
-
-	return len(responses) == 0, nil
+	return isAddressUnused, nil
 }

--- a/pkg/chain/bitcoin/electrs.go
+++ b/pkg/chain/bitcoin/electrs.go
@@ -32,7 +32,7 @@ type electrsConnection struct {
 }
 
 // newElectrsConnection is a constructor for ElectrsConnection.
-func newElectrsConnection(apiURL string) *electrsConnection {
+func Connect(apiURL string) Handle {
 	return &electrsConnection{
 		apiURL:  apiURL,
 		client:  http.DefaultClient,

--- a/pkg/chain/bitcoin/electrs_test.go
+++ b/pkg/chain/bitcoin/electrs_test.go
@@ -24,6 +24,13 @@ func (m mockClient) Post(url string, contentType string, reader io.Reader) (*htt
 	return m.mockPost(url, contentType, reader)
 }
 
+func newElectrsConnection(apiURL string) *electrsConnection {
+	return &electrsConnection{
+		apiURL:  apiURL,
+		timeout: defaultTimeout,
+	}
+}
+
 func TestElectrsConnection_broadcast(t *testing.T) {
 	apiURL := "example.org/api"
 	electrs := newElectrsConnection(apiURL)

--- a/pkg/chain/bitcoin/electrs_test.go
+++ b/pkg/chain/bitcoin/electrs_test.go
@@ -26,7 +26,7 @@ func (m mockClient) Post(url string, contentType string, reader io.Reader) (*htt
 
 func TestElectrsConnection_broadcast(t *testing.T) {
 	apiURL := "example.org/api"
-	electrs := NewElectrsConnection(apiURL)
+	electrs := newElectrsConnection(apiURL)
 	transaction := "01000000000101ba84a592005742406bd1d6683e3a894c7ab13385bd437ff7bd7c74929bf141320000000000000000000309cc320000000000160014a0aedee089b0cfa34e1e29c2dd2e618b19e8b95309cc320000000000160014f8c4e8695f8c2e0f598f8f00c2c4a83b17b0c4fa09cc320000000000160014fada4235022b32a31f97adbc954e6a7bbb7b32ba024830450221008dd10d4f331a61c2afe948dec6f900b29996c29262a79fa4d72acacd0c19497a022063229d6751c47e3e9b67e567bd98500b66630a09ef8515377a18d0479135c84f01210329fb706ee25a944362c4a53a5b4fa6f47201354d567e753c3998f15a36996b8100000000"
 	electrs.setClient(mockClient{
 		mockGet: func(url string) (*http.Response, error) {
@@ -65,7 +65,7 @@ func TestElectrsConnection_broadcast(t *testing.T) {
 
 func TestElectrsConnection_vbyteFee(t *testing.T) {
 	apiURL := "example.org/api"
-	electrs := NewElectrsConnection(apiURL)
+	electrs := newElectrsConnection(apiURL)
 	jsonResponse := `{ "1": 87.882, "2": 87.882, "3": 87.882, "4": 87.882, "5": 81.129, "6": 68.285, "7": 65.182, "8": 63.876, "9": 61.153, "10": 60.172, "11": 57.721, "12": 54.753, "13": 52.879, "14": 46.872, "15": 42.871, "16": 39.989, "17": 35.919, "18": 30.821, "19": 25.888, "20": 21.876, "21": 16.156, "22": 11.222, "23": 10.982, "24": 9.654, "25": 7.883, "144": 1.027, "504": 1.027, "1008": 1.027 }`
 	electrs.setClient(mockClient{
 		mockGet: mockGet(
@@ -113,7 +113,7 @@ func TestElectrsConnection_IsAddressUnused(t *testing.T) {
 	for testName, testData := range testData {
 		t.Run(testName, func(t *testing.T) {
 			apiURL := "example.org/api"
-			electrs := NewElectrsConnection(apiURL)
+			electrs := newElectrsConnection(apiURL)
 			electrs.setClient(mockClient{
 				mockGet: mockGet(
 					fmt.Sprintf("%s/address/%s/txs", apiURL, testData.btcAddress),
@@ -165,7 +165,7 @@ func TestElectrsConnection_IsAddressUnused_ExpectedFailures(t *testing.T) {
 	apiURL := "example.org/api"
 	for testName, testData := range testData {
 		t.Run(testName, func(t *testing.T) {
-			electrs := NewElectrsConnection(apiURL)
+			electrs := newElectrsConnection(apiURL)
 			electrs.setClient(mockClient{
 				mockGet: mockGet(
 					fmt.Sprintf("%s/address/%s/txs", apiURL, testData.btcAddress),

--- a/pkg/chain/bitcoin/electrs_test.go
+++ b/pkg/chain/bitcoin/electrs_test.go
@@ -90,3 +90,55 @@ func TestElectrsConnection_vbyteFee(t *testing.T) {
 		t.Errorf("unexpected fee\nexpected: %d\nactual:   %d", expectedFee, fee)
 	}
 }
+
+func TestElectrsConnection_IsAddressUnused(t *testing.T) {
+	testData := map[string]struct {
+		btcAddress         string
+		response           string
+		expectedUnusedFlag bool
+	}{
+		"address with unspent funds": {
+			"bcrt1qy6n80gen875en87ka798svvzrneq2erhhwfzzf",
+			`[{"txid":"2fd4fd49a9719be53affe55c4761abf00df1cda9b7a02419411bc9c04174c3f7","version":2,"locktime":14154,"vin":[{"txid":"fc4e62537ad932a84b4888826e10810119c854cbed1244091e864502282cee92","vout":0,"prevout":{"scriptpubkey":"001401160c280c429cb349c5c37d786eedb5b7bfd3e2","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_20 01160c280c429cb349c5c37d786eedb5b7bfd3e2","scriptpubkey_type":"v0_p2wpkh","scriptpubkey_address":"bcrt1qqytqc2qvg2wtxjw9cd7hsmhdkkmml5lzqc04tk","value":9765625},"scriptsig":"","scriptsig_asm":"","witness":["304402202f3bf6827a90d566f7543119156d0b2aa19262379429ca58e95728479258c64d02202aee28e0083c900fe57a4a7f3f1a65fc2b012acdde88b99349a5bca17336486901","0360eda8d2a5e92cfa752f756a972442271381c1b2081f8e43e6f3475c7feedf76"],"is_coinbase":false,"sequence":4294967294},{"txid":"14e4defea6b2a164701562b0e9d379b23288b41b44ab8201749e5c5c312f0e59","vout":0,"prevout":{"scriptpubkey":"001401160c280c429cb349c5c37d786eedb5b7bfd3e2","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_20 01160c280c429cb349c5c37d786eedb5b7bfd3e2","scriptpubkey_type":"v0_p2wpkh","scriptpubkey_address":"bcrt1qqytqc2qvg2wtxjw9cd7hsmhdkkmml5lzqc04tk","value":4768},"scriptsig":"","scriptsig_asm":"","witness":["304402206feee35d7a3de261c4ddd0e9bbccdc65b24226a9be8aef2bcacc87b032eca93702206e2040856bd7d61f3a8d9f24ef515e7660a99984f4e55fcd2f7ea16ad56ecf2b01","0360eda8d2a5e92cfa752f756a972442271381c1b2081f8e43e6f3475c7feedf76"],"is_coinbase":false,"sequence":4294967294},{"txid":"246d552c11741b7196f0f7dfd7c65a22daba9da20264edc26dbb8afcc2906465","vout":0,"prevout":{"scriptpubkey":"001401160c280c429cb349c5c37d786eedb5b7bfd3e2","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_20 01160c280c429cb349c5c37d786eedb5b7bfd3e2","scriptpubkey_type":"v0_p2wpkh","scriptpubkey_address":"bcrt1qqytqc2qvg2wtxjw9cd7hsmhdkkmml5lzqc04tk","value":4768},"scriptsig":"","scriptsig_asm":"","witness":["304402206fc18ffa446f681d8901d7d211f7d972e5e18420ac991d44befd13f9740a26a5022030079817769551fb818149b1d146ff6c02859060e56118796b711ba6e9f5e37801","0360eda8d2a5e92cfa752f756a972442271381c1b2081f8e43e6f3475c7feedf76"],"is_coinbase":false,"sequence":4294967294},{"txid":"91517b69b67dee45c3cca4e2b1d5f0c4e04abc19363fc161b6dde9f72a2615ed","vout":0,"prevout":{"scriptpubkey":"001401160c280c429cb349c5c37d786eedb5b7bfd3e2","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_20 01160c280c429cb349c5c37d786eedb5b7bfd3e2","scriptpubkey_type":"v0_p2wpkh","scriptpubkey_address":"bcrt1qqytqc2qvg2wtxjw9cd7hsmhdkkmml5lzqc04tk","value":152587},"scriptsig":"","scriptsig_asm":"","witness":["3044022073658ccf19f921eba6d46fa642dadaed54bf011438c63656a0466ed21ceaf58202202a90e99d3b9e599f1f88e0816f2b8076ca8238ef9b5149c0bfe1dfd5a4967a2801","0360eda8d2a5e92cfa752f756a972442271381c1b2081f8e43e6f3475c7feedf76"],"is_coinbase":false,"sequence":4294967294},{"txid":"8cff43db341777dc4a8de065a2357e5d546a922524adabc6c650b82bdb4a9db1","vout":0,"prevout":{"scriptpubkey":"001401160c280c429cb349c5c37d786eedb5b7bfd3e2","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_20 01160c280c429cb349c5c37d786eedb5b7bfd3e2","scriptpubkey_type":"v0_p2wpkh","scriptpubkey_address":"bcrt1qqytqc2qvg2wtxjw9cd7hsmhdkkmml5lzqc04tk","value":10461},"scriptsig":"","scriptsig_asm":"","witness":["3044022056b40dd139f57caef154b327cb815e6976e4cacf226fa15c70f14ab0abe1059802204b864b4842e578c0ff11a0fea59bb91fb44162d1f7e9e9e048a1c560491cf62701","0360eda8d2a5e92cfa752f756a972442271381c1b2081f8e43e6f3475c7feedf76"],"is_coinbase":false,"sequence":4294967294},{"txid":"16c414db432c78fb2636e618b6b470265cbb68137d56101249c2d86a796cfc74","vout":0,"prevout":{"scriptpubkey":"001401160c280c429cb349c5c37d786eedb5b7bfd3e2","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_20 01160c280c429cb349c5c37d786eedb5b7bfd3e2","scriptpubkey_type":"v0_p2wpkh","scriptpubkey_address":"bcrt1qqytqc2qvg2wtxjw9cd7hsmhdkkmml5lzqc04tk","value":12901},"scriptsig":"","scriptsig_asm":"","witness":["304402202c3d563122099edf16996dadf0bebcc5105eb6e5e53d5e5a8ab8939731e12ff802205bc8bdf99feef369b55832e5676a9d39f006643af35b7778c9dfa891a4b9792b01","0360eda8d2a5e92cfa752f756a972442271381c1b2081f8e43e6f3475c7feedf76"],"is_coinbase":false,"sequence":4294967294},{"txid":"3d93c2fef5cd7c8349170ec48dd96a4477bb6ca6958b6fb80a074ee7e80a421f","vout":0,"prevout":{"scriptpubkey":"001401160c280c429cb349c5c37d786eedb5b7bfd3e2","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_20 01160c280c429cb349c5c37d786eedb5b7bfd3e2","scriptpubkey_type":"v0_p2wpkh","scriptpubkey_address":"bcrt1qqytqc2qvg2wtxjw9cd7hsmhdkkmml5lzqc04tk","value":19073},"scriptsig":"","scriptsig_asm":"","witness":["30440220034c0a3dbab8ccc7c9004ce8d5b1da25d3a527493368c98531acb47e147df37c02207646277753c9694aebc59ac47a230735c0c2b6c0ecf5d2251a9350b9171b330201","0360eda8d2a5e92cfa752f756a972442271381c1b2081f8e43e6f3475c7feedf76"],"is_coinbase":false,"sequence":4294967294},{"txid":"eb0d6c1f32f975b121fdbb0d5b010174fd47594fc7a2faa6184862d0688ac64d","vout":0,"prevout":{"scriptpubkey":"001401160c280c429cb349c5c37d786eedb5b7bfd3e2","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_20 01160c280c429cb349c5c37d786eedb5b7bfd3e2","scriptpubkey_type":"v0_p2wpkh","scriptpubkey_address":"bcrt1qqytqc2qvg2wtxjw9cd7hsmhdkkmml5lzqc04tk","value":4768},"scriptsig":"","scriptsig_asm":"","witness":["30440220748e72af5018b7cc5774d7debe225b7ad304a1cfe9e0a469470affe9622fbac102200ea7c7a94bd7813b0ac472be36b1c7cb77d59b4b63363aac39e580003ec55c8501","0360eda8d2a5e92cfa752f756a972442271381c1b2081f8e43e6f3475c7feedf76"],"is_coinbase":false,"sequence":4294967294},{"txid":"0beb097b66aafd83f914dad6ebfee3bfbdc17c2111fa4dde964b928bba724330","vout":0,"prevout":{"scriptpubkey":"001401160c280c429cb349c5c37d786eedb5b7bfd3e2","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_20 01160c280c429cb349c5c37d786eedb5b7bfd3e2","scriptpubkey_type":"v0_p2wpkh","scriptpubkey_address":"bcrt1qqytqc2qvg2wtxjw9cd7hsmhdkkmml5lzqc04tk","value":38146},"scriptsig":"","scriptsig_asm":"","witness":["30440220507ca93500dfd6f83f5b45b401b335563287a09906ee5a35e7877f2c1b87eaa202204c68e3eb43fa5f3054d823bacadfe644b4626e1b938d1ab564ee30dfe07dff8d01","0360eda8d2a5e92cfa752f756a972442271381c1b2081f8e43e6f3475c7feedf76"],"is_coinbase":false,"sequence":4294967294}],"vout":[{"scriptpubkey":"001426a677a3333fa9999fd6ef8a7831821cf2056477","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_20 26a677a3333fa9999fd6ef8a7831821cf2056477","scriptpubkey_type":"v0_p2wpkh","scriptpubkey_address":"bcrt1qy6n80gen875en87ka798svvzrneq2erhhwfzzf","value":10000000}],"size":1375,"weight":2605,"fee":13097,"status":{"confirmed":true,"block_height":14208,"block_hash":"3c95707c627031feca93af0473cf5dc81e3f4fd6a660023924a85900d3b294ce","block_time":1620420106}}]`,
+			false,
+		},
+		"address with no transactions": {
+			"bcrt1qy6n80gen875en87ka798svvzrneq2erhhwfzzf",
+			`[]`,
+			true,
+		},
+		"address used for recovery": {
+			"bcrt1q07njh90vzjzdjwfg7mr6ek7swylm99z2l4cg7q",
+			`[{"txid":"157617f0573262e466563272b643ce422dd378f86c0cfcac292776a979829b00","version":1,"locktime":0,"vin":[{"txid":"2fd4fd49a9719be53affe55c4761abf00df1cda9b7a02419411bc9c04174c3f7","vout":0,"prevout":{"scriptpubkey":"001426a677a3333fa9999fd6ef8a7831821cf2056477","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_20 26a677a3333fa9999fd6ef8a7831821cf2056477","scriptpubkey_type":"v0_p2wpkh","scriptpubkey_address":"bcrt1qy6n80gen875en87ka798svvzrneq2erhhwfzzf","value":10000000},"scriptsig":"","scriptsig_asm":"","witness":["3045022100fac6791f32fe18bcdd7373a7d0eec94640c34d392b3c4257220f6775c80dfeba022027bad28595c5ce84d9120b89645f4a074236e76df36ceeceaf50e6efe50a76a001","020a401579ff57588e7596fd192e04478dd7e24cddff34a2433d94eee5ce6462df"],"is_coinbase":false,"sequence":0}],"vout":[{"scriptpubkey":"00147fa72b95ec1484d93928f6c7acdbd0713fb2944a","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_20 7fa72b95ec1484d93928f6c7acdbd0713fb2944a","scriptpubkey_type":"v0_p2wpkh","scriptpubkey_address":"bcrt1q07njh90vzjzdjwfg7mr6ek7swylm99z2l4cg7q","value":3329033},{"scriptpubkey":"00142dd3fe9a8675e368702d232f5542a34f231e23b8","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_20 2dd3fe9a8675e368702d232f5542a34f231e23b8","scriptpubkey_type":"v0_p2wpkh","scriptpubkey_address":"bcrt1q9hflax5xwh3ksupdyvh42s4rfu33ugac8zjz4v","value":3329033},{"scriptpubkey":"0014c1dd3c3b6ec603aaf86be1cea289730c83492a75","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_20 c1dd3c3b6ec603aaf86be1cea289730c83492a75","scriptpubkey_type":"v0_p2wpkh","scriptpubkey_address":"bcrt1qc8wncwmwccp647rtu8829ztnpjp5j2n4x4pzxw","value":3329033}],"size":254,"weight":686,"fee":12901,"status":{"confirmed":true,"block_height":14212,"block_hash":"6b40428c4096d37d1edbc00234e8b4e5af52e42d1d1fdbb844fb735039af2f5a","block_time":1620420226}}]`,
+			false,
+		},
+	}
+	for testName, testData := range testData {
+		t.Run(testName, func(t *testing.T) {
+			apiURL := "example.org/api"
+			electrs := NewElectrsConnection(apiURL)
+			electrs.setClient(mockClient{
+				mockGet: func(url string) (*http.Response, error) {
+					expectedURL := fmt.Sprintf("%s/address/%s/txs", apiURL, testData.btcAddress)
+					if url != expectedURL {
+						t.Errorf("unexpected url\nexpected: %s\nactual:   %s", expectedURL, url)
+					}
+					return &http.Response{
+						StatusCode: 200,
+						Body:       ioutil.NopCloser(bytes.NewReader([]byte(testData.response))),
+					}, nil
+				},
+				mockPost: func(url string, contentType string, reader io.Reader) (*http.Response, error) {
+					return nil, nil
+				},
+			})
+			unusedFlag, err := electrs.IsAddressUnused(testData.btcAddress)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if unusedFlag != testData.expectedUnusedFlag {
+				t.Errorf("unexpected IsAddresssUnused result\nexpected: %v\nactual:   %v", testData.expectedUnusedFlag, unusedFlag)
+			}
+		})
+	}
+}

--- a/pkg/chain/bitcoin/electrs_test.go
+++ b/pkg/chain/bitcoin/electrs_test.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strings"
 	"testing"
+	"time"
 )
 
 type mockClient struct {
@@ -176,6 +177,7 @@ func TestElectrsConnection_IsAddressUnused_ExpectedFailures(t *testing.T) {
 					return nil, nil
 				},
 			})
+			electrs.timeout = 2 * time.Second
 			_, err := electrs.IsAddressUnused(testData.btcAddress)
 			if err == nil {
 				t.Errorf("unexected error\nexpected: %s\nactual:   nil", testData.err)

--- a/pkg/chain/bitcoin/electrs_test.go
+++ b/pkg/chain/bitcoin/electrs_test.go
@@ -78,7 +78,7 @@ func TestElectrsConnection_vbyteFee(t *testing.T) {
 		},
 	})
 	expectedFee := int32(7)
-	fee, err := electrs.VbyteFee()
+	fee, err := electrs.VbyteFeeFor25Blocks()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/chain/bitcoin/electrs_test.go
+++ b/pkg/chain/bitcoin/electrs_test.go
@@ -142,3 +142,65 @@ func TestElectrsConnection_IsAddressUnused(t *testing.T) {
 		})
 	}
 }
+
+func TestElectrsConnection_IsAddressUnused_ExpectedFailures(t *testing.T) {
+	testData := map[string]struct {
+		btcAddress   string
+		responseCode int
+		response     string
+		err          string
+	}{
+		"invalid btc address": {
+			"banana",
+			400,
+			"Invalid Bitcoin address",
+			"Invalid Bitcoin address",
+		},
+		"garbled response": {
+			"bcrt1qy6n80gen875en87ka798svvzrneq2erhhwfzzf",
+			200,
+			`[{"txi4fd49a9719be53affe55c4761abf00df1cda9b7a02419411bc9c04174c3f7","version":2,"locktime":14154,"vin":[{"txid":"fc4e62537ad932a84b4888826e10810119c854cbed1244091e864502282cee92","vout":0,"prevout":{"scriptpubkey":"001401160c280c429cb349c5c37d786eedb5b7bfd3e2","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_20 01160c280c429cb349c5c37d786eedb5b7bfd3e2","scriptpubkey_type":"v0_p2wpkh","scriptpubkey_address":"bcrt1qqytqc2qvg2wtxjw9cd7hsmhdkkmml5lzqc04tk","value":9765625},"scriptsig":"","scriptsig_asm":"","witness":["304402202f3bf6827a90d566f7543119156d0b2aa19262379429ca58e95728479258c64d02202aee28e0083c900fe57a4a7f3f1a65fc2b012acdde88b99349a5bca17336486901","0360eda8d2a5e92cfa752f756a972442271381c1b2081f8e43e6f3475c7feedf76"],"is_coinbase":false,"sequence":4294967294},{"txid":"14e4defea6b2a164701562b0e9d379b23288b41b44ab8201749e5c5c312f0e59","vout":0,"prevout":{"scriptpubkey":"001401160c280c429cb349c5c37d786eedb5b7bfd3e2","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_20 01160c280c429cb349c5c37d786eedb5b7bfd3e2","scriptpubkey_type":"v0_p2wpkh","scriptpubkey_address":"bcrt1qqytqc2qvg2wtxjw9cd7hsmhdkkmml5lzqc04tk","value":4768},"scriptsig":"","scriptsig_asm":"","witness":["304402206feee35d7a3de261c4ddd0e9bbccdc65b24226a9be8aef2bcacc87b032eca93702206e2040856bd7d61f3a8d9f24ef515e7660a99984f4e55fcd2f7ea16ad56ecf2b01","0360eda8d2a5e92cfa752f756a972442271381c1b2081f8e43e6f3475c7feedf76"],"is_coinbase":false,"sequence":4294967294},{"txid":"246d552c11741b7196f0f7dfd7c65a22daba9da20264edc26dbb8afcc2906465","vout":0,"prevout":{"scriptpubkey":"001401160c280c429cb349c5c37d786eedb5b7bfd3e2","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_20 01160c280c429cb349c5c37d786eedb5b7bfd3e2","scriptpubkey_type":"v0_p2wpkh","scriptpubkey_address":"bcrt1qqytqc2qvg2wtxjw9cd7hsmhdkkmml5lzqc04tk","value":4768},"scriptsig":"","scriptsig_asm":"","witness":["304402206fc18ffa446f681d8901d7d211f7d972e5e18420ac991d44befd13f9740a26a5022030079817769551fb818149b1d146ff6c02859060e56118796b711ba6e9f5e37801","0360eda8d2a5e92cfa752f756a972442271381c1b2081f8e43e6f3475c7feedf76"],"is_coinbase":false,"sequence":4294967294},{"txid":"91517b69b67dee45c3cca4e2b1d5f0c4e04abc19363fc161b6dde9f72a2615ed","vout":0,"prevout":{"scriptpubkey":"001401160c280c429cb349c5c37d786eedb5b7bfd3e2","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_20 01160c280c429cb349c5c37d786eedb5b7bfd3e2","scriptpubkey_type":"v0_p2wpkh","scriptpubkey_address":"bcrt1qqytqc2qvg2wtxjw9cd7hsmhdkkmml5lzqc04tk","value":152587},"scriptsig":"","scriptsig_asm":"","witness":["3044022073658ccf19f921eba6d46fa642dadaed54bf011438c63656a0466ed21ceaf58202202a90e99d3b9e599f1f88e0816f2b8076ca8238ef9b5149c0bfe1dfd5a4967a2801","0360eda8d2a5e92cfa752f756a972442271381c1b2081f8e43e6f3475c7feedf76"],"is_coinbase":false,"sequence":4294967294},{"txid":"8cff43db341777dc4a8de065a2357e5d546a922524adabc6c650b82bdb4a9db1","vout":0,"prevout":{"scriptpubkey":"001401160c280c429cb349c5c37d786eedb5b7bfd3e2","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_20 01160c280c429cb349c5c37d786eedb5b7bfd3e2","scriptpubkey_type":"v0_p2wpkh","scriptpubkey_address":"bcrt1qqytqc2qvg2wtxjw9cd7hsmhdkkmml5lzqc04tk","value":10461},"scriptsig":"","scriptsig_asm":"","witness":["3044022056b40dd139f57caef154b327cb815e6976e4cacf226fa15c70f14ab0abe1059802204b864b4842e578c0ff11a0fea59bb91fb44162d1f7e9e9e048a1c560491cf62701","0360eda8d2a5e92cfa752f756a972442271381c1b2081f8e43e6f3475c7feedf76"],"is_coinbase":false,"sequence":4294967294},{"txid":"16c414db432c78fb2636e618b6b470265cbb68137d56101249c2d86a796cfc74","vout":0,"prevout":{"scriptpubkey":"001401160c280c429cb349c5c37d786eedb5b7bfd3e2","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_20 01160c280c429cb349c5c37d786eedb5b7bfd3e2","scriptpubkey_type":"v0_p2wpkh","scriptpubkey_address":"bcrt1qqytqc2qvg2wtxjw9cd7hsmhdkkmml5lzqc04tk","value":12901},"scriptsig":"","scriptsig_asm":"","witness":["304402202c3d563122099edf16996dadf0bebcc5105eb6e5e53d5e5a8ab8939731e12ff802205bc8bdf99feef369b55832e5676a9d39f006643af35b7778c9dfa891a4b9792b01","0360eda8d2a5e92cfa752f756a972442271381c1b2081f8e43e6f3475c7feedf76"],"is_coinbase":false,"sequence":4294967294},{"txid":"3d93c2fef5cd7c8349170ec48dd96a4477bb6ca6958b6fb80a074ee7e80a421f","vout":0,"prevout":{"scriptpubkey":"001401160c280c429cb349c5c37d786eedb5b7bfd3e2","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_20 01160c280c429cb349c5c37d786eedb5b7bfd3e2","scriptpubkey_type":"v0_p2wpkh","scriptpubkey_address":"bcrt1qqytqc2qvg2wtxjw9cd7hsmhdkkmml5lzqc04tk","value":19073},"scriptsig":"","scriptsig_asm":"","witness":["30440220034c0a3dbab8ccc7c9004ce8d5b1da25d3a527493368c98531acb47e147df37c02207646277753c9694aebc59ac47a230735c0c2b6c0ecf5d2251a9350b9171b330201","0360eda8d2a5e92cfa752f756a972442271381c1b2081f8e43e6f3475c7feedf76"],"is_coinbase":false,"sequence":4294967294},{"txid":"eb0d6c1f32f975b121fdbb0d5b010174fd47594fc7a2faa6184862d0688ac64d","vout":0,"prevout":{"scriptpubkey":"001401160c280c429cb349c5c37d786eedb5b7bfd3e2","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_20 01160c280c429cb349c5c37d786eedb5b7bfd3e2","scriptpubkey_type":"v0_p2wpkh","scriptpubkey_address":"bcrt1qqytqc2qvg2wtxjw9cd7hsmhdkkmml5lzqc04tk","value":4768},"scriptsig":"","scriptsig_asm":"","witness":["30440220748e72af5018b7cc5774d7debe225b7ad304a1cfe9e0a469470affe9622fbac102200ea7c7a94bd7813b0ac472be36b1c7cb77d59b4b63363aac39e580003ec55c8501","0360eda8d2a5e92cfa752f756a972442271381c1b2081f8e43e6f3475c7feedf76"],"is_coinbase":false,"sequence":4294967294},{"txid":"0beb097b66aafd83f914dad6ebfee3bfbdc17c2111fa4dde964b928bba724330","vout":0,"prevout":{"scriptpubkey":"001401160c280c429cb349c5c37d786eedb5b7bfd3e2","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_20 01160c280c429cb349c5c37d786eedb5b7bfd3e2","scriptpubkey_type":"v0_p2wpkh","scriptpubkey_address":"bcrt1qqytqc2qvg2wtxjw9cd7hsmhdkkmml5lzqc04tk","value":38146},"scriptsig":"","scriptsig_asm":"","witness":["30440220507ca93500dfd6f83f5b45b401b335563287a09906ee5a35e7877f2c1b87eaa202204c68e3eb43fa5f3054d823bacadfe644b4626e1b938d1ab564ee30dfe07dff8d01","0360eda8d2a5e92cfa752f756a972442271381c1b2081f8e43e6f3475c7feedf76"],"is_coinbase":false,"sequence":4294967294}],"vout":[{"scriptpubkey":"001426a677a3333fa9999fd6ef8a7831821cf2056477","scriptpubkey_asm":"OP_0 OP_PUSHBYTES_20 26a677a3333fa9999fd6ef8a7831821cf2056477","scriptpubkey_type":"v0_p2wpkh","scriptpubkey_address":"bcrt1qy6n80gen875en87ka798svvzrneq2erhhwfzzf","value":10000000}],"size":1375,"weight":2605,"fee":13097,"status":{"confirmed":true,"block_height":14208,"block_hash":"3c95707c627031feca93af0473cf5dc81e3f4fd6a660023924a85900d3b294ce","block_time":1620420106}}]`,
+			"invalid character ',' after object key",
+		},
+		"unexpected integer response": {
+			"bcrt1qy6n80gen875en87ka798svvzrneq2erhhwfzzf",
+			200,
+			"73",
+			"json: cannot unmarshal number into Go value of type []interface {}",
+		},
+	}
+	apiURL := "example.org/api"
+	for testName, testData := range testData {
+		t.Run(testName, func(t *testing.T) {
+			electrs := NewElectrsConnection(apiURL)
+			electrs.setClient(mockClient{
+				mockGet: func(url string) (*http.Response, error) {
+					expectedURL := fmt.Sprintf("%s/address/%s/txs", apiURL, testData.btcAddress)
+					if url != expectedURL {
+						t.Errorf("unexpected url\nexpected: %s\nactual:   %s", expectedURL, url)
+					}
+					return &http.Response{
+						StatusCode: testData.responseCode,
+						Body:       ioutil.NopCloser(bytes.NewReader([]byte(testData.response))),
+					}, nil
+				},
+				mockPost: func(url string, contentType string, reader io.Reader) (*http.Response, error) {
+					return nil, nil
+				},
+			})
+			_, err := electrs.IsAddressUnused(testData.btcAddress)
+			if err == nil {
+				t.Errorf("unexected error\nexpected: %s\nactual:   nil", testData.err)
+			}
+			checkError(err, testData.err, t)
+		})
+	}
+}
+
+func checkError(err error, expected string, t *testing.T) {
+	if err == nil {
+		t.Errorf("unexected error\nexpected: %s\nactual:   nil", expected)
+	} else if !strings.Contains(err.Error(), expected) {
+		t.Errorf("unexpected error\nexpected: %s\nactual:   %v", expected, err)
+	}
+}

--- a/pkg/chain/bitcoin/handle.go
+++ b/pkg/chain/bitcoin/handle.go
@@ -1,0 +1,8 @@
+package bitcoin
+
+// Handle serves as an interface abstraction around bitcoin network queries
+type Handle interface {
+	Broadcast(transaction string) error
+	VbyteFee() (int32, error)
+	IsAddressUnused(btcAddress string) (bool, error)
+}

--- a/pkg/chain/bitcoin/handle.go
+++ b/pkg/chain/bitcoin/handle.go
@@ -6,3 +6,7 @@ type Handle interface {
 	VbyteFeeFor25Blocks() (int32, error)
 	IsAddressUnused(btcAddress string) (bool, error)
 }
+
+func Connect(apiURL string) Handle {
+	return newElectrsConnection(apiURL)
+}

--- a/pkg/chain/bitcoin/handle.go
+++ b/pkg/chain/bitcoin/handle.go
@@ -6,3 +6,26 @@ type Handle interface {
 	VbyteFee() (int32, error)
 	IsAddressUnused(btcAddress string) (bool, error)
 }
+
+type OfflineHandle struct{}
+
+// Broadcast logs a transaction as a warning five times in a row so that any
+// warning monitors would pick it up and alert on it.
+func (oh OfflineHandle) Broadcast(transaction string) error {
+	for i := 0; i < 5; i++ {
+		logger.Warningf("Please broadcast Bitcoin transaction %s", transaction)
+	}
+	return nil
+}
+
+// VbyteFee returns a default fee of 75 in lieu of a network to pull a current
+// fee from.
+func (oh OfflineHandle) VbyteFee() (int32, error) {
+	return 75, nil
+}
+
+// IsAddressUnused always returns true in lieu of a way to check whether or not
+// an address is used.
+func (oh OfflineHandle) IsAddressUnused(btcAddress string) (bool, error) {
+	return true, nil
+}

--- a/pkg/chain/bitcoin/handle.go
+++ b/pkg/chain/bitcoin/handle.go
@@ -6,7 +6,3 @@ type Handle interface {
 	VbyteFeeFor25Blocks() (int32, error)
 	IsAddressUnused(btcAddress string) (bool, error)
 }
-
-func Connect(apiURL string) Handle {
-	return newElectrsConnection(apiURL)
-}

--- a/pkg/chain/bitcoin/handle.go
+++ b/pkg/chain/bitcoin/handle.go
@@ -6,26 +6,3 @@ type Handle interface {
 	VbyteFeeFor25Blocks() (int32, error)
 	IsAddressUnused(btcAddress string) (bool, error)
 }
-
-type OfflineHandle struct{}
-
-// Broadcast logs a transaction as a warning five times in a row so that any
-// warning monitors would pick it up and alert on it.
-func (oh OfflineHandle) Broadcast(transaction string) error {
-	for i := 0; i < 5; i++ {
-		logger.Warningf("Please broadcast Bitcoin transaction %s", transaction)
-	}
-	return nil
-}
-
-// VbyteFeeFor25Blocks returns a default fee of 75 in lieu of a network to pull a current
-// fee from.
-func (oh OfflineHandle) VbyteFeeFor25Blocks() (int32, error) {
-	return 75, nil
-}
-
-// IsAddressUnused always returns true in lieu of a way to check whether or not
-// an address is used.
-func (oh OfflineHandle) IsAddressUnused(btcAddress string) (bool, error) {
-	return true, nil
-}

--- a/pkg/chain/bitcoin/handle.go
+++ b/pkg/chain/bitcoin/handle.go
@@ -3,7 +3,7 @@ package bitcoin
 // Handle serves as an interface abstraction around bitcoin network queries
 type Handle interface {
 	Broadcast(transaction string) error
-	VbyteFee() (int32, error)
+	VbyteFeeFor25Blocks() (int32, error)
 	IsAddressUnused(btcAddress string) (bool, error)
 }
 
@@ -18,9 +18,9 @@ func (oh OfflineHandle) Broadcast(transaction string) error {
 	return nil
 }
 
-// VbyteFee returns a default fee of 75 in lieu of a network to pull a current
+// VbyteFeeFor25Blocks returns a default fee of 75 in lieu of a network to pull a current
 // fee from.
-func (oh OfflineHandle) VbyteFee() (int32, error) {
+func (oh OfflineHandle) VbyteFeeFor25Blocks() (int32, error) {
 	return 75, nil
 }
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1083,7 +1083,7 @@ func monitorKeepTerminatedEvent(
 							return err
 						}
 
-						vbyteFee, vbyteFeeError := electrsConnection.VbyteFee()
+						vbyteFee, vbyteFeeError := electrsConnection.VbyteFeeFor25Blocks()
 						if vbyteFeeError != nil {
 							logger.Errorf(
 								"failed to retrieve a vbyte fee estimate from %s, [%v]",

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1060,12 +1060,7 @@ func monitorKeepTerminatedEvent(
 							return err
 						}
 
-						var electrsConnection bitcoin.Handle
-						if tbtcConfig.Bitcoin.ElectrsURLWithDefault() == "" {
-							electrsConnection = bitcoin.OfflineHandle{}
-						} else {
-							electrsConnection = bitcoin.NewElectrsConnection(tbtcConfig.Bitcoin.ElectrsURLWithDefault())
-						}
+						electrsConnection := bitcoin.NewElectrsConnection(tbtcConfig.Bitcoin.ElectrsURLWithDefault())
 
 						beneficiaryAddress, err := recovery.ResolveAddress(
 							tbtcConfig.Bitcoin.BeneficiaryAddress,

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1060,10 +1060,13 @@ func monitorKeepTerminatedEvent(
 							return err
 						}
 
-						beneficiaryAddress, addressIndex, err := recovery.ResolveAddress(
+						electrsConnection := bitcoin.NewElectrsConnection(tbtcConfig.Bitcoin.ElectrsURLWithDefault())
+
+						beneficiaryAddress, err := recovery.ResolveAddress(
 							tbtcConfig.Bitcoin.BeneficiaryAddress,
 							derivationIndexStorage,
 							chainParams,
+							electrsConnection,
 						)
 						if err != nil {
 							logger.Errorf(
@@ -1075,7 +1078,6 @@ func monitorKeepTerminatedEvent(
 							return err
 						}
 
-						electrsConnection := bitcoin.NewElectrsConnection(tbtcConfig.Bitcoin.ElectrsURLWithDefault())
 						vbyteFee, vbyteFeeError := electrsConnection.VbyteFee()
 						if vbyteFeeError != nil {
 							logger.Errorf(
@@ -1155,17 +1157,6 @@ func monitorKeepTerminatedEvent(
 
 							for i := 0; i < 5; i++ {
 								logger.Warningf("Please broadcast Bitcoin transaction %s", recoveryTransactionHex)
-							}
-						}
-
-						if tbtcConfig.Bitcoin.BeneficiaryAddress != beneficiaryAddress {
-							err = derivationIndexStorage.Save(tbtcConfig.Bitcoin.BeneficiaryAddress, addressIndex)
-							if err != nil {
-								logger.Errorf(
-									"failed to persist the latest address derivation index for keep [%s]: [%v]",
-									keep.ID(),
-									err,
-								)
 							}
 						}
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1060,13 +1060,13 @@ func monitorKeepTerminatedEvent(
 							return err
 						}
 
-						electrsConnection := bitcoin.NewElectrsConnection(tbtcConfig.Bitcoin.ElectrsURLWithDefault())
+						bitcoinHandle := bitcoin.Connect(tbtcConfig.Bitcoin.ElectrsURLWithDefault())
 
 						beneficiaryAddress, err := recovery.ResolveAddress(
 							tbtcConfig.Bitcoin.BeneficiaryAddress,
 							derivationIndexStorage,
 							chainParams,
-							electrsConnection,
+							bitcoinHandle,
 						)
 						if err != nil {
 							logger.Errorf(
@@ -1078,7 +1078,7 @@ func monitorKeepTerminatedEvent(
 							return err
 						}
 
-						vbyteFee, vbyteFeeError := electrsConnection.VbyteFeeFor25Blocks()
+						vbyteFee, vbyteFeeError := bitcoinHandle.VbyteFeeFor25Blocks()
 						if vbyteFeeError != nil {
 							logger.Errorf(
 								"failed to retrieve a vbyte fee estimate from %s, [%v]",
@@ -1147,7 +1147,7 @@ func monitorKeepTerminatedEvent(
 							return err
 						}
 
-						broadcastError := electrsConnection.Broadcast(recoveryTransactionHex)
+						broadcastError := bitcoinHandle.Broadcast(recoveryTransactionHex)
 						if broadcastError != nil {
 							logger.Errorf(
 								"failed to broadcast the recovery transaction to %s, [%v]",

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1060,7 +1060,12 @@ func monitorKeepTerminatedEvent(
 							return err
 						}
 
-						electrsConnection := bitcoin.NewElectrsConnection(tbtcConfig.Bitcoin.ElectrsURLWithDefault())
+						var electrsConnection bitcoin.Handle
+						if tbtcConfig.Bitcoin.ElectrsURLWithDefault() == "" {
+							electrsConnection = bitcoin.OfflineHandle{}
+						} else {
+							electrsConnection = bitcoin.NewElectrsConnection(tbtcConfig.Bitcoin.ElectrsURLWithDefault())
+						}
 
 						beneficiaryAddress, err := recovery.ResolveAddress(
 							tbtcConfig.Bitcoin.BeneficiaryAddress,

--- a/pkg/extensions/tbtc/recovery/derive_address.go
+++ b/pkg/extensions/tbtc/recovery/derive_address.go
@@ -6,6 +6,7 @@ import (
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/btcutil/hdkeychain"
+	"github.com/keep-network/keep-ecdsa/pkg/chain/bitcoin"
 )
 
 // deriveAddress uses the specified extended public key and address index to
@@ -131,6 +132,7 @@ func ResolveAddress(
 	beneficiaryAddress string,
 	storage *DerivationIndexStorage,
 	chainParams *chaincfg.Params,
+	electrs *bitcoin.ElectrsConnection,
 ) (string, uint32, error) {
 	// If the address decodes without error, then we have a valid bitcoin
 	// address. Otherwise, we assume that it's an extended key and we attempt to

--- a/pkg/extensions/tbtc/recovery/derive_address.go
+++ b/pkg/extensions/tbtc/recovery/derive_address.go
@@ -139,11 +139,7 @@ func ResolveAddress(
 	// derive the address.
 	_, err := btcutil.DecodeAddress(beneficiaryAddress, chainParams)
 	if err != nil {
-		addressIndex, err := storage.GetNextIndex(beneficiaryAddress, handle)
-		if err != nil {
-			return "", err
-		}
-		derivedAddress, err := deriveAddress(beneficiaryAddress, addressIndex)
+		derivedAddress, err := storage.GetNextAddress(beneficiaryAddress, handle)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/extensions/tbtc/recovery/derive_address.go
+++ b/pkg/extensions/tbtc/recovery/derive_address.go
@@ -132,22 +132,22 @@ func ResolveAddress(
 	beneficiaryAddress string,
 	storage *DerivationIndexStorage,
 	chainParams *chaincfg.Params,
-	electrs *bitcoin.ElectrsConnection,
-) (string, uint32, error) {
+	handle bitcoin.Handle,
+) (string, error) {
 	// If the address decodes without error, then we have a valid bitcoin
 	// address. Otherwise, we assume that it's an extended key and we attempt to
 	// derive the address.
 	_, err := btcutil.DecodeAddress(beneficiaryAddress, chainParams)
 	if err != nil {
-		addressIndex, err := storage.GetNextIndex(beneficiaryAddress)
+		addressIndex, err := storage.GetNextIndex(beneficiaryAddress, handle)
 		if err != nil {
-			return "", 0, err
+			return "", err
 		}
 		derivedAddress, err := deriveAddress(beneficiaryAddress, addressIndex)
 		if err != nil {
-			return "", 0, err
+			return "", err
 		}
-		return derivedAddress, addressIndex, nil
+		return derivedAddress, nil
 	}
-	return beneficiaryAddress, 0, nil
+	return beneficiaryAddress, nil
 }

--- a/pkg/extensions/tbtc/recovery/derive_address_test.go
+++ b/pkg/extensions/tbtc/recovery/derive_address_test.go
@@ -247,12 +247,16 @@ func TestResolveAddress(t *testing.T) {
 				t.Fatal(err)
 			}
 			for _, usedIndex := range testData.usedIndexes {
-				dis.Save(testData.beneficiaryAddress, usedIndex)
+				dis.save(testData.beneficiaryAddress, usedIndex)
 			}
-			resolvedAddress, _, err := ResolveAddress(
+
+			handle := newMockBitcoinHandle()
+
+			resolvedAddress, err := ResolveAddress(
 				testData.beneficiaryAddress,
 				dis,
 				testData.chainParams,
+				handle,
 			)
 			if err != nil {
 				t.Fatal(err)
@@ -307,10 +311,11 @@ func TestResolveBeneficiaryAddress_ExpectedFailure(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			_, _, err = ResolveAddress(
+			_, err = ResolveAddress(
 				testData.extendedAddress,
 				dis,
 				testData.chainParams,
+				nil,
 			)
 			if err == nil {
 				t.Errorf("no error found\nexpected: %s", testData.failure)

--- a/pkg/extensions/tbtc/recovery/storage.go
+++ b/pkg/extensions/tbtc/recovery/storage.go
@@ -154,8 +154,7 @@ func (dis *DerivationIndexStorage) GetNextAddress(
 	}
 
 	startIndex := uint32(lastIndex + 1)
-	numberOfTries := uint32(100)
-	for i := uint32(0); i < numberOfTries; i++ {
+	for i := uint32(0); true; i++ {
 		index := startIndex + i
 		derivedAddress, err := deriveAddress(strings.TrimSpace(extendedPublicKey), index)
 		if err != nil {
@@ -174,7 +173,7 @@ func (dis *DerivationIndexStorage) GetNextAddress(
 			return derivedAddress, nil
 		}
 	}
-	return "", fmt.Errorf("indexes %d through %d were all used", startIndex, startIndex+numberOfTries-1)
+	return "", fmt.Errorf("something unexpected happened to break us out of the GetNextAddress retry loop")
 }
 
 func closeFile(file *os.File) {

--- a/pkg/extensions/tbtc/recovery/storage.go
+++ b/pkg/extensions/tbtc/recovery/storage.go
@@ -162,6 +162,10 @@ func (dis *DerivationIndexStorage) GetNextAddress(
 			return "", err
 		}
 		ok, err := handle.IsAddressUnused(derivedAddress)
+		if err != nil {
+			return "", err
+		}
+
 		err = dis.save(extendedPublicKey, index)
 		if err != nil {
 			return "", err

--- a/pkg/extensions/tbtc/recovery/storage_test.go
+++ b/pkg/extensions/tbtc/recovery/storage_test.go
@@ -7,23 +7,23 @@ import (
 )
 
 type mockBitcoinHandle struct {
-	broadcast       func(transaction string) error
-	vbyteFee        func() (int32, error)
-	isAddressUnused func(btcAddress string) (bool, error)
+	broadcast           func(transaction string) error
+	vbyteFeeFor25Blocks func() (int32, error)
+	isAddressUnused     func(btcAddress string) (bool, error)
 }
 
 func newMockBitcoinHandle() *mockBitcoinHandle {
 	return &mockBitcoinHandle{
-		broadcast:       func(_ string) error { return nil },
-		vbyteFee:        func() (int32, error) { return 75, nil },
-		isAddressUnused: func(_ string) (bool, error) { return true, nil },
+		broadcast:           func(_ string) error { return nil },
+		vbyteFeeFor25Blocks: func() (int32, error) { return 75, nil },
+		isAddressUnused:     func(_ string) (bool, error) { return true, nil },
 	}
 }
 func (mbh mockBitcoinHandle) Broadcast(transaction string) error {
 	return mbh.broadcast(transaction)
 }
-func (mbh mockBitcoinHandle) VbyteFee() (int32, error) {
-	return mbh.vbyteFee()
+func (mbh mockBitcoinHandle) VbyteFeeFor25Blocks() (int32, error) {
+	return mbh.vbyteFeeFor25Blocks()
 }
 func (mbh mockBitcoinHandle) IsAddressUnused(btcAddress string) (bool, error) {
 	return mbh.isAddressUnused(btcAddress)

--- a/pkg/utils/wrappers.go
+++ b/pkg/utils/wrappers.go
@@ -20,19 +20,20 @@ func DoWithRetry(
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
+	var err error
 	for {
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("retry timeout [%v] exceeded", timeout)
+			return fmt.Errorf("retry timeout [%v] exceeded: [%v]", timeout, err)
 		default:
-			err := doFn(ctx)
+			err = doFn(ctx)
 			if err == nil {
 				return nil
 			}
 
 			timedOut := backoffWait(ctx, backoffTime)
 			if timedOut {
-				return fmt.Errorf("retry timeout [%v] exceeded", timeout)
+				return fmt.Errorf("retry timeout [%v] exceeded: [%v]", timeout, err)
 			}
 
 			backoffTime = calculateBackoff(

--- a/pkg/utils/wrappers.go
+++ b/pkg/utils/wrappers.go
@@ -24,7 +24,7 @@ func DoWithRetry(
 	for {
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("retry timeout [%v] exceeded: [%v]", timeout, err)
+			return fmt.Errorf("retry timeout [%v] exceeded; most recent error: [%v]", timeout, err)
 		default:
 			err = doFn(ctx)
 			if err == nil {
@@ -33,7 +33,7 @@ func DoWithRetry(
 
 			timedOut := backoffWait(ctx, backoffTime)
 			if timedOut {
-				return fmt.Errorf("retry timeout [%v] exceeded: [%v]", timeout, err)
+				return fmt.Errorf("retry timeout [%v] exceeded; most recent error: [%v]", timeout, err)
 			}
 
 			backoffTime = calculateBackoff(

--- a/pkg/utils/wrappers_test.go
+++ b/pkg/utils/wrappers_test.go
@@ -63,7 +63,7 @@ func TestDoWithRetryExceedTimeout(t *testing.T) {
 		t.Fatal("expected a timeout error")
 	}
 
-	expectedError := "retry timeout [1s] exceeded"
+	expectedError := "retry timeout [1s] exceeded: [try again please]"
 	if err.Error() != expectedError {
 		t.Errorf(
 			"unexpected error message\nactual:   [%v]\nexpected: [%v]",

--- a/pkg/utils/wrappers_test.go
+++ b/pkg/utils/wrappers_test.go
@@ -63,7 +63,7 @@ func TestDoWithRetryExceedTimeout(t *testing.T) {
 		t.Fatal("expected a timeout error")
 	}
 
-	expectedError := "retry timeout [1s] exceeded: [try again please]"
+	expectedError := "retry timeout [1s] exceeded; most recent error: [try again please]"
 	if err.Error() != expectedError {
 		t.Errorf(
 			"unexpected error message\nactual:   [%v]\nexpected: [%v]",


### PR DESCRIPTION
The current persistence solution has two main issues:

* Multiple concurrent calls to `GetNextIndex` return the same index. This can happen if a btc-eth price shift happens that triggers multiple liquidations in which an operator is a signer. Since this would lead to multiple liquidations being sent to the same btc address, this leaks user information and is counter to the purpose of using HD wallets.

* We do not leverage the electrs connection to check to see if a derived address is actually unused. This can lead to address reuse, which leaks user information in the same way described above.

To fix this, we make the following behavior changes:

* `GetNextIndex` is in charge of saving used addresses, and accepts a bitcoin handler that can check to see if addresses are used or not
* `GetNextIndex` keeps searching for unused addresses until it finds one, and blocks other concurrent calls to `GetNextIndex` until it does.
* Multiple calls to `GetNextIndex` have to wait until the first call finds an unused index, and then marks it as used, making sure that each call returns a different value.

open questions:
* How do we want the unused address search to work? Right now, it starts at the next index and checks the next 100 after that. That was a naive/easy implementation rather than a solid one to get this in a reviewable state.

tagging @Shadowfiend and @nkuba for review