### PR TITLE
Add PreParamsTargetPoolSize to the list of integer keys

### DIFF
--- a/solidity/scripts/lcl-client-config.js
+++ b/solidity/scripts/lcl-client-config.js
@@ -54,7 +54,7 @@ module.exports = async function () {
               // Find keys that match exactly `Port`, `MiningCheckInterval`,
               // `MaxGasPrice` or end with `MetricsTick` or `Limit`.
               key.match(
-                /(^Port|^MiningCheckInterval|^MaxGasPrice|MetricsTick|Limit)$/
+                /(^Port|^MiningCheckInterval|^MaxGasPrice|^PreParamsTargetPoolSize|MetricsTick|Limit)$/
               )
                 ? value.toFixed(0) // convert float to integer
                 : false // do nothing


### PR DESCRIPTION
Without this, if `PreParamsTargetPoolSize` ever finds its way into local-setup/configs/keep-ecdsa/config.local.*.toml, then when it is copied over, the integer size will be changed to a float, which causes config-based runtime errors in keep-ecdsa.

The original PR, https://github.com/keep-network/keep-ecdsa/pull/780, was pointed at an eslint cleanup branch that we discovered was unnecessary, so now this one is pointed at master.

Tagging @pdyraga for review (since he merged the original)