### PR TITLE
Configure The Liquidation Recovery Timeout

### DIFF
--- a/config/config_test.go
+++ b/config/config_test.go
@@ -91,6 +91,10 @@ func TestReadConfig(t *testing.T) {
 			readValueFunc: func(c *Config) interface{} { return c.Extensions.TBTC.TBTCSystem },
 			expectedValue: "0xa4888eDD97A5a3A739B4E0807C71817c8a418273",
 		},
+		"Extensions.TBTC.LiquidationRecoveryTimeout": {
+			readValueFunc: func(c *Config) interface{} { return c.Extensions.TBTC.GetLiquidationRecoveryTimeout() },
+			expectedValue: time.Duration(49 * 60 * 60 * 1000000000), // 49 hours in nanoseconds
+		},
 		"Extensions.TBTC.Bitcoin.ElectrsURL": {
 			readValueFunc: func(c *Config) interface{} { return *c.Extensions.TBTC.Bitcoin.ElectrsURL },
 			expectedValue: "example.com",

--- a/internal/testdata/config.toml
+++ b/internal/testdata/config.toml
@@ -28,7 +28,8 @@
 	PreParamsTargetPoolSize = 36
 
 [Extensions.TBTC]
-	TBTCSystem = "0xa4888eDD97A5a3A739B4E0807C71817c8a418273"
+  TBTCSystem = "0xa4888eDD97A5a3A739B4E0807C71817c8a418273"
+  LiquidationRecoveryTimeout = "49h"
 
 	[Extensions.TBTC.Bitcoin]
 		BeneficiaryAddress = "bcrt1q0umle4fe6penqqyzuwsysqezwwptuyqa82jas4"

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -989,7 +989,7 @@ func monitorKeepTerminatedEvent(
 
 			go func(event *chain.KeepTerminatedEvent) {
 				err := utils.DoWithDefaultRetry(
-					clientConfig.GetSigningTimeout(),
+					tbtcConfig.GetLiquidationRecoveryTimeout(),
 					func(ctx context.Context) error {
 						if shouldHandle := eventDeduplicator.NotifyTerminatingStarted(keep.ID()); !shouldHandle {
 							logger.Infof(

--- a/pkg/extensions/tbtc/config.go
+++ b/pkg/extensions/tbtc/config.go
@@ -1,10 +1,33 @@
 package tbtc
 
-import "github.com/keep-network/keep-ecdsa/pkg/chain/bitcoin"
+import (
+	"time"
+
+	"github.com/keep-network/keep-ecdsa/pkg/chain/bitcoin"
+
+	configtime "github.com/keep-network/keep-ecdsa/config/time"
+)
+
+const (
+	// The default value of a timeout for liquidation recovery.
+	defaultLiquidationRecoveryTimeout = 48 * time.Hour
+)
 
 // Config stores configuration of application extensions responsible for
 // executing signer actions specific for TBTC application.
 type Config struct {
-	TBTCSystem string
-	Bitcoin    bitcoin.Config
+	TBTCSystem                 string
+	Bitcoin                    bitcoin.Config
+	LiquidationRecoveryTimeout configtime.Duration
+}
+
+// GetLiquidationRecoveryTimeout returns the liquidation recovery timeout. If a
+// value is not set it returns a default value.
+func (c *Config) GetLiquidationRecoveryTimeout() time.Duration {
+	timeout := c.LiquidationRecoveryTimeout.ToDuration()
+	if timeout == 0 {
+		timeout = defaultLiquidationRecoveryTimeout
+	}
+
+	return timeout
 }


### PR DESCRIPTION
Previously, we were using the signing timeout to serve as the broader liquidation timeout (not intentionally, just a missed detail). This PR adds a new configurable timeout, `Extensions.TBTC.LiquidationRecoveryTimeout`, that governs how long we'll attempt recovery for before giving up.

Tagging @nkuba for review