### PR TITLE
Use `balanceOf` for undelegated operators

### DIFF
--- a/staker-rewards/lib/assets-calculator.js
+++ b/staker-rewards/lib/assets-calculator.js
@@ -124,7 +124,6 @@ export default class AssetsCalculator {
 
   async calculateKeepStaked(operator) {
     const block = this.interval.endBlock
-    const timestamp = this.interval.end
 
     const operatorContract = this.bondedECDSAKeepFactory.options.address
 
@@ -144,24 +143,19 @@ export default class AssetsCalculator {
       )
 
       for (let i = 0; i < locks.creators.length; i++) {
-        if (timestamp < locks.expirations[i]) {
-          const keepOpenedTimestamp = await callWithRetry(
-            this.bondedECDSAKeepFactory.methods.getKeepOpenedTimestamp(
-              locks.creators[i]
-            ),
+        const keepOpenedTimestamp = await callWithRetry(
+          this.bondedECDSAKeepFactory.methods.getKeepOpenedTimestamp(
+            locks.creators[i]
+          ),
+          block
+        )
+
+        if (keepOpenedTimestamp > 0) {
+          keepStaked = await callWithRetry(
+            this.tokenStaking.methods.balanceOf(operator),
             block
           )
-
-          if (keepOpenedTimestamp > 0) {
-            keepStaked = await callWithRetry(
-              this.tokenStaking.methods.activeStake(
-                operator,
-                locks.creators[i]
-              ),
-              block
-            )
-            break
-          }
+          break
         }
       }
     }

--- a/staker-rewards/test/assets-calculator.test.js
+++ b/staker-rewards/test/assets-calculator.test.js
@@ -20,7 +20,6 @@ console.debug = function () {}
 const interval = {
   startBlock: 1000,
   endBlock: 2000,
-  end: 1619740800,
 }
 
 const operator = "0xF1De9490Bf7298b5F350cE74332Ad7cf8d5cB181"
@@ -57,6 +56,13 @@ const setupContractsMock = (context) => {
             (inputs) =>
               inputs.operator === operator &&
               inputs.operatorContract === operatorContract
+          ),
+        }),
+        balanceOf: (operator) => ({
+          call: mockMethod(
+            TokenStakingAddress,
+            "balanceOf",
+            (inputs) => inputs.operator === operator
           ),
         }),
         getLocks: (operator) => ({

--- a/staker-rewards/test/data/test-blockchain.json
+++ b/staker-rewards/test/data/test-blockchain.json
@@ -216,10 +216,11 @@
               "operator": "0x88Ed51f84c21Ae246c23137D090cdF441009D916",
               "operatorContract": "0xA7d9E842EFB252389d613dA88EDa3731512e40bD",
               "output": "0"
-            },
+            }
+          ],
+          "balanceOf": [
             {
               "operator": "0x88Ed51f84c21Ae246c23137D090cdF441009D916",
-              "operatorContract": "0xa3CdCC1B0f2a5b7eb24e502D967Ae97a81F48ed5",
               "output": "350000000000000000000000"
             }
           ],


### PR DESCRIPTION
Here we improve the logic which computes the `keepStaked` parameter for undelegated operators who still have stakes in active keeps. The previous logic took stakes using `activeStake` against keeps with active locks. However, in that
way, it omitted a corner case when the lock expires and the keep is still active. Using `balanceOf` directly, without checking the lock state, should cover all cases in a correct way.