### PR TITLE
Use chain-specific public key to address conversion in signing utility

### DIFF
--- a/cmd/signing.go
+++ b/cmd/signing.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	cecdsa "crypto/ecdsa"
-	"crypto/elliptic"
 	"encoding/hex"
 	"fmt"
 	"io/ioutil"
@@ -200,7 +199,7 @@ func SignDigest(c *cli.Context) error {
 	signingOutcomesChannel := make(chan *signingOutcome, len(signers))
 
 	pubKeyToAddressFn := func(publicKey cecdsa.PublicKey) []byte {
-		return elliptic.Marshal(publicKey.Curve, publicKey.X, publicKey.Y)
+		return cryptoPubkeyToAddress(publicKey).Bytes()
 	}
 
 	for i := range signers {


### PR DESCRIPTION
This change introduces a chain-specific public key to address conversion for the signing utility tool. This way the `pubKeyToAddressFn` should work as expected and translate the public key to a chain address correctly.