### PR TITLE
Make sed invocations cross-platform

### DIFF
--- a/scripts/install-celo.sh
+++ b/scripts/install-celo.sh
@@ -93,7 +93,9 @@ if [ "$CONTRACTS_ONLY" = false ] ; then
         # command. We need to update the `--allow-paths` value to be the parent directory
         # that is assumed to contain both current project and dependent project.
         # Ref: https://github.com/ethereum/solidity/issues/4623
-        sed -i '' 's/--allow-paths ${solidity_dir}/--allow-paths $(realpath ${SOLIDITY_DIR}\/..\/..\/)/g' pkg/chain/gen/*/Makefile
+        TMP_FILE=$(mktemp /tmp/Makefile.XXXXXXXXXX)
+        sed 's/--allow-paths ${solidity_dir}/--allow-paths $(realpath ${SOLIDITY_DIR}\/..\/..\/)/g' pkg/chain/gen/celo/Makefile > $TMP_FILE
+        mv $TMP_FILE pkg/chain/gen/celo/Makefile
 
         go generate ./...
         go build -a -o keep-ecdsa .

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -91,7 +91,9 @@ if [ "$CONTRACTS_ONLY" = false ] ; then
   # command. We need to update the `--allow-paths` value to be the parent directory
   # that is assumed to contain both current project and dependent project.
   # Ref: https://github.com/ethereum/solidity/issues/4623
-  sed -i '' 's/--allow-paths ${solidity_dir}/--allow-paths $(realpath ${SOLIDITY_DIR}\/..\/..\/)/g' pkg/chain/gen/*/Makefile
+  TMP_FILE=$(mktemp /tmp/Makefile.XXXXXXXXXX)
+  sed 's/--allow-paths ${solidity_dir}/--allow-paths $(realpath ${SOLIDITY_DIR}\/..\/..\/)/g' pkg/chain/gen/ethereum/Makefile > $TMP_FILE
+  mv $TMP_FILE pkg/chain/gen/ethereum/Makefile
 
   go generate ./...
   go build -a -o keep-ecdsa .


### PR DESCRIPTION
Syntax of the `sed -i` command is different for MacOS and for GNU
systems. The command in its old shape was failing when run on Ubuntu
(during execution of workflow with E2E tests in the `local-setup`
repository). Fixed by doing replacement using temporary file, instead of
replacing in the current file.