### PR TITLE
Replace `--allow-paths` value in both Makefiles (ethereum and celo)

### DIFF
--- a/scripts/install-celo.sh
+++ b/scripts/install-celo.sh
@@ -93,7 +93,10 @@ if [ "$CONTRACTS_ONLY" = false ] ; then
         # command. We need to update the `--allow-paths` value to be the parent directory
         # that is assumed to contain both current project and dependent project.
         # Ref: https://github.com/ethereum/solidity/issues/4623
-        TMP_FILE=$(mktemp /tmp/Makefile.XXXXXXXXXX)
+        TMP_FILE=$(mktemp /tmp/Makefile-ethereum.XXXXXXXXXX)
+        sed 's/--allow-paths ${solidity_dir}/--allow-paths $(realpath ${SOLIDITY_DIR}\/..\/..\/)/g' pkg/chain/gen/ethereum/Makefile > $TMP_FILE
+        mv $TMP_FILE pkg/chain/gen/ethereum/Makefile
+        TMP_FILE=$(mktemp /tmp/Makefile-celo.XXXXXXXXXX)
         sed 's/--allow-paths ${solidity_dir}/--allow-paths $(realpath ${SOLIDITY_DIR}\/..\/..\/)/g' pkg/chain/gen/celo/Makefile > $TMP_FILE
         mv $TMP_FILE pkg/chain/gen/celo/Makefile
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -91,9 +91,12 @@ if [ "$CONTRACTS_ONLY" = false ] ; then
   # command. We need to update the `--allow-paths` value to be the parent directory
   # that is assumed to contain both current project and dependent project.
   # Ref: https://github.com/ethereum/solidity/issues/4623
-  TMP_FILE=$(mktemp /tmp/Makefile.XXXXXXXXXX)
+  TMP_FILE=$(mktemp /tmp/Makefile-ethereum.XXXXXXXXXX)
   sed 's/--allow-paths ${solidity_dir}/--allow-paths $(realpath ${SOLIDITY_DIR}\/..\/..\/)/g' pkg/chain/gen/ethereum/Makefile > $TMP_FILE
   mv $TMP_FILE pkg/chain/gen/ethereum/Makefile
+  TMP_FILE=$(mktemp /tmp/Makefile-celo.XXXXXXXXXX)
+  sed 's/--allow-paths ${solidity_dir}/--allow-paths $(realpath ${SOLIDITY_DIR}\/..\/..\/)/g' pkg/chain/gen/celo/Makefile > $TMP_FILE
+  mv $TMP_FILE pkg/chain/gen/celo/Makefile
 
   go generate ./...
   go build -a -o keep-ecdsa .


### PR DESCRIPTION
In order for the successful building of the `keep-ecdsa` client we need
to update the `--allow-paths` value in all Makefile files under
`pkg/chain/gen/..`. With only the `ethereum/Makefile` being updated
during execution of `install.sh`, the script was failing with following
error:
```
make: *** [abi/BondedECDSAKeepVendorImplV1.abi] Error 1
pkg/chain/gen/celo/gen.go:3: running "sh": exit status 2
```