### PR TITLE
Removed println for signer loading

### DIFF
--- a/pkg/registry/keeps.go
+++ b/pkg/registry/keeps.go
@@ -144,7 +144,6 @@ func (k *Keeps) LoadExistingKeeps() {
 
 	go func() {
 		for keepSigner := range keepSignersChannel {
-			fmt.Println(keepSigner, keepSigner.keepID)
 			if _, exists := k.myKeeps[keepSigner.keepID]; exists {
 				logger.Errorf(
 					"signer for keep [%s] already loaded; "+


### PR DESCRIPTION
The println we're removing here is probably a leftover from development.
After the loading is done we already have following loggers:
info: "loaded [%d] keeps from the local storage"
debug: "loaded signer for keep [%s]"