### PR TITLE
Fix panic on liquidation recovery transaction broadcast failure

### DIFF
--- a/pkg/chain/bitcoin/electrs.go
+++ b/pkg/chain/bitcoin/electrs.go
@@ -31,7 +31,7 @@ type electrsConnection struct {
 	timeout time.Duration
 }
 
-// newElectrsConnection is a constructor for ElectrsConnection.
+// Connect is a constructor for electrsConnection.
 func Connect(apiURL string) Handle {
 	return &electrsConnection{
 		apiURL:  apiURL,

--- a/pkg/chain/config.go
+++ b/pkg/chain/config.go
@@ -2,7 +2,7 @@ package chain
 
 import "github.com/keep-network/keep-ecdsa/pkg/chain/bitcoin"
 
-// TBTC stores configuration of application extension responsible for
+// Config stores configuration of application extension responsible for
 // executing signer actions specific for TBTC application.
 type Config struct {
 	TBTCSystem string

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1081,8 +1081,7 @@ func monitorKeepTerminatedEvent(
 						vbyteFee, vbyteFeeError := bitcoinHandle.VbyteFeeFor25Blocks()
 						if vbyteFeeError != nil {
 							logger.Errorf(
-								"failed to retrieve a vbyte fee estimate from %s, [%v]",
-								tbtcConfig.Bitcoin.ElectrsURLWithDefault(),
+								"failed to retrieve a vbyte fee estimate, [%v]",
 								vbyteFeeError,
 							)
 							// Since the electrs connection is optional, we don't return the error
@@ -1150,8 +1149,8 @@ func monitorKeepTerminatedEvent(
 						broadcastError := bitcoinHandle.Broadcast(recoveryTransactionHex)
 						if broadcastError != nil {
 							logger.Errorf(
-								"failed to broadcast the recovery transaction to %s, [%v]",
-								*tbtcConfig.Bitcoin.ElectrsURL,
+								"failed to broadcast liquidation recovery transaction for keep [%s]: [%v]",
+								keep.ID(),
 								broadcastError,
 							)
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1054,7 +1054,7 @@ func monitorKeepTerminatedEvent(
 						chainParams, err := tbtcConfig.Bitcoin.ChainParams()
 						if err != nil {
 							logger.Errorf(
-								"failed to parse the the configured net params: [%v]",
+								"failed to parse the configured net params: [%v]",
 								err,
 							)
 							return err

--- a/pkg/extensions/tbtc/recovery/recovery.go
+++ b/pkg/extensions/tbtc/recovery/recovery.go
@@ -174,11 +174,14 @@ func buildSignedTransactionHexString(
 	// transaction to be sent out of our network or executed on the bitcoin
 	// blockchain, rather than persisting the information. For more information,
 	// check out the btcsuite/btcd/wire/msgtx.go documentation.
-	signedTransaction.BtcEncode(
+	err := signedTransaction.BtcEncode(
 		transactionWriter,
 		wire.ProtocolVersion,
 		wire.WitnessEncoding,
 	)
+	if err != nil {
+		return "", fmt.Errorf("failed to encode signed transaction: [%w]", err)
+	}
 
 	return transactionHexBuilder.String(), nil
 }


### PR DESCRIPTION
In this PR we removed logging of ElectrsURL in case of electrs function failure.

we don't need to include the Electrs URL in the logged errors. The address is configured by the operator in the config file and can be checked there. If the address is provided with an empty string the electrs api functions will return an error saying that it's empty.

Closes: https://github.com/keep-network/keep-ecdsa/issues/811