### PR TITLE
Fail Fast With Bad BTC Configuration

### DIFF
--- a/cmd/start.go
+++ b/cmd/start.go
@@ -19,6 +19,7 @@ import (
 	"github.com/keep-network/keep-core/pkg/net/libp2p"
 	"github.com/keep-network/keep-core/pkg/net/retransmission"
 	"github.com/keep-network/keep-ecdsa/config"
+	"github.com/keep-network/keep-ecdsa/pkg/chain/bitcoin"
 	"github.com/keep-network/keep-ecdsa/pkg/client"
 	"github.com/keep-network/keep-ecdsa/pkg/extensions/tbtc/recovery"
 	"github.com/keep-network/keep-ecdsa/pkg/firewall"
@@ -140,11 +141,12 @@ func Start(c *cli.Context) error {
 		return err
 	}
 
-	isUnconfigured, err := config.Extensions.TBTC.Bitcoin.Validate()
+	err = config.Extensions.TBTC.Bitcoin.Validate()
 	if err != nil {
-		if isUnconfigured {
+		if (bitcoin.Config{}) == config.Extensions.TBTC.Bitcoin {
 			logger.Warnf("missing bitcoin configuration for tbtc extension: [%v]", err)
 		} else {
+			logger.Errorf("misconfigured bitcoin configured for tbtc extension: [%v]", err)
 			return err
 		}
 	}

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -140,6 +140,11 @@ func Start(c *cli.Context) error {
 		return err
 	}
 
+	err = config.Extensions.TBTC.Bitcoin.Validate()
+	if err != nil {
+		logger.Warnf("invalid Bitcoin configuration: [%v]", err)
+	}
+
 	clientHandle := client.Initialize(
 		ctx,
 		operatorKeys.public,

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -142,7 +142,7 @@ func Start(c *cli.Context) error {
 
 	err = config.Extensions.TBTC.Bitcoin.Validate()
 	if err != nil {
-		logger.Warnf("invalid Bitcoin configuration: [%v]", err)
+		logger.Warnf("invalid bitcoin configuration for tbtc extension: [%v]", err)
 	}
 
 	clientHandle := client.Initialize(

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -140,9 +140,13 @@ func Start(c *cli.Context) error {
 		return err
 	}
 
-	err = config.Extensions.TBTC.Bitcoin.Validate()
+	isUnconfigured, err := config.Extensions.TBTC.Bitcoin.Validate()
 	if err != nil {
-		logger.Warnf("invalid bitcoin configuration for tbtc extension: [%v]", err)
+		if isUnconfigured {
+			logger.Warnf("missing bitcoin configuration for tbtc extension: [%v]", err)
+		} else {
+			return err
+		}
 	}
 
 	clientHandle := client.Initialize(

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -124,17 +124,9 @@ func TestReadConfig(t *testing.T) {
 		},
 		"Extensions.TBTC.Bitcoin.Validate() error": {
 			readValueFunc: func(c *Config) interface{} {
-				_, err := c.Extensions.TBTC.Bitcoin.Validate()
-				return err
+				return c.Extensions.TBTC.Bitcoin.Validate()
 			},
 			expectedValue: nil,
-		},
-		"Extensions.TBTC.Bitcoin.Validate() isUnconfigured": {
-			readValueFunc: func(c *Config) interface{} {
-				isUnconfigured, _ := c.Extensions.TBTC.Bitcoin.Validate()
-				return isUnconfigured
-			},
-			expectedValue: true,
 		},
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -105,7 +105,7 @@ func TestReadConfig(t *testing.T) {
 		},
 		"Extensions.TBTC.Bitcoin.BeneficiaryAddress": {
 			readValueFunc: func(c *Config) interface{} { return c.Extensions.TBTC.Bitcoin.BeneficiaryAddress },
-			expectedValue: "bcrt1q0umle4fe6penqqyzuwsysqezwwptuyqa82jas4",
+			expectedValue: "xpub6Cg41S21VrxkW1WBTZJn95KNpHozP2Xc6AhG27ZcvZvH8XyNzunEqLdk9dxyXQUoy7ALWQFNn5K1me74aEMtS6pUgNDuCYTTMsJzCAk9sk1",
 		},
 		"Extensions.TBTC.Bitcoin.MaxFeePerVByte": {
 			readValueFunc: func(c *Config) interface{} { return c.Extensions.TBTC.Bitcoin.MaxFeePerVByte },

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -122,9 +122,19 @@ func TestReadConfig(t *testing.T) {
 			},
 			expectedValue: chaincfg.MainNetParams,
 		},
-		"Extensions.TBTC.Bitcoin.Validate()": {
-			readValueFunc: func(c *Config) interface{} { return c.Extensions.TBTC.Bitcoin.Validate() },
+		"Extensions.TBTC.Bitcoin.Validate() error": {
+			readValueFunc: func(c *Config) interface{} {
+				_, err := c.Extensions.TBTC.Bitcoin.Validate()
+				return err
+			},
 			expectedValue: nil,
+		},
+		"Extensions.TBTC.Bitcoin.Validate() isUnconfigured": {
+			readValueFunc: func(c *Config) interface{} {
+				isUnconfigured, _ := c.Extensions.TBTC.Bitcoin.Validate()
+				return isUnconfigured
+			},
+			expectedValue: true,
 		},
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -122,6 +122,10 @@ func TestReadConfig(t *testing.T) {
 			},
 			expectedValue: chaincfg.MainNetParams,
 		},
+		"Extensions.TBTC.Bitcoin.Validate()": {
+			readValueFunc: func(c *Config) interface{} { return c.Extensions.TBTC.Bitcoin.Validate() },
+			expectedValue: nil,
+		},
 	}
 
 	for testName, test := range configReadTests {

--- a/internal/testdata/config.toml
+++ b/internal/testdata/config.toml
@@ -32,7 +32,7 @@
   LiquidationRecoveryTimeout = "49h"
 
 	[Extensions.TBTC.Bitcoin]
-		BeneficiaryAddress = "bcrt1q0umle4fe6penqqyzuwsysqezwwptuyqa82jas4"
+		BeneficiaryAddress = "xpub6Cg41S21VrxkW1WBTZJn95KNpHozP2Xc6AhG27ZcvZvH8XyNzunEqLdk9dxyXQUoy7ALWQFNn5K1me74aEMtS6pUgNDuCYTTMsJzCAk9sk1"
 		MaxFeePerVByte = 73
 		BitcoinChainName = "mainnet"
 		ElectrsURL = "example.com"

--- a/pkg/chain/bitcoin/config.go
+++ b/pkg/chain/bitcoin/config.go
@@ -16,22 +16,22 @@ type Config struct {
 
 // Validate returns nil if the configuration is suitable for bitcoin recovery,
 // and an error detailing what went wrong if not.
-func (c Config) Validate() (bool, error) {
+func (c Config) Validate() error {
 	if c.BeneficiaryAddress == "" {
-		return true, fmt.Errorf("a bitcoin address or extended public key (*pub) is required; configure one at [Extensions.TBTC.Bitcoin.BeneficiaryAddress]")
+		return fmt.Errorf("a bitcoin address or extended public key (*pub) is required; configure one at [Extensions.TBTC.Bitcoin.BeneficiaryAddress]")
 	}
 	chainParams, err := c.ChainParams()
 	if err != nil {
-		return false, fmt.Errorf("a valid chain name is required; choose between [mainnet, regtest, simnet, testnet3] and configure it at [Extensions.TBTC.Bitcoin.BitcoinChainName]: [%w]", err)
+		return fmt.Errorf("a valid chain name is required; choose between [mainnet, regtest, simnet, testnet3] and configure it at [Extensions.TBTC.Bitcoin.BitcoinChainName]: [%w]", err)
 	}
 	err = ValidateAddress(c.BeneficiaryAddress, chainParams)
 	if err != nil {
-		return false, fmt.Errorf(
+		return fmt.Errorf(
 			"a valid bitcoin address or extended public key (*pub) is required; configure one at [Extensions.TBTC.Bitcoin.BeneficiaryAddress]: [%w]",
 			err,
 		)
 	}
-	return true, nil
+	return nil
 }
 
 // ChainParams parses the net param name into the associated chaincfg.Params

--- a/pkg/chain/bitcoin/config.go
+++ b/pkg/chain/bitcoin/config.go
@@ -14,6 +14,19 @@ type Config struct {
 	ElectrsURL         *string
 }
 
+// Validate returns nil if the configuration is suitable for bitcoin recovery,
+// and an error detailing what went wrong if not.
+func (c Config) Validate() error {
+	if c.BeneficiaryAddress == "" {
+		return fmt.Errorf("a bitcoin address or extended public key (*pub) is required; configure one at [Extensions.TBTC.Bitcoin.BeneficiaryAddress]")
+	}
+	_, err := c.ChainParams()
+	if err != nil {
+		return fmt.Errorf("a valid chain name is required; choose between [mainnet, regtest, simnet, testnet3] and configure it at [Extensions.TBTC.Bitcoin.BitcoinChainName]: [%v]", err)
+	}
+	return nil
+}
+
 // ChainParams parses the net param name into the associated chaincfg.Params
 func (c Config) ChainParams() (*chaincfg.Params, error) {
 	switch c.BitcoinChainName {

--- a/pkg/chain/bitcoin/config.go
+++ b/pkg/chain/bitcoin/config.go
@@ -20,9 +20,16 @@ func (c Config) Validate() error {
 	if c.BeneficiaryAddress == "" {
 		return fmt.Errorf("a bitcoin address or extended public key (*pub) is required; configure one at [Extensions.TBTC.Bitcoin.BeneficiaryAddress]")
 	}
-	_, err := c.ChainParams()
+	chainParams, err := c.ChainParams()
 	if err != nil {
-		return fmt.Errorf("a valid chain name is required; choose between [mainnet, regtest, simnet, testnet3] and configure it at [Extensions.TBTC.Bitcoin.BitcoinChainName]: [%v]", err)
+		return fmt.Errorf("a valid chain name is required; choose between [mainnet, regtest, simnet, testnet3] and configure it at [Extensions.TBTC.Bitcoin.BitcoinChainName]: [%w]", err)
+	}
+	err = ValidateAddress(c.BeneficiaryAddress, chainParams)
+	if err != nil {
+		return fmt.Errorf(
+			"a valid bitcoin address or extended public key (*pub) is required; configure one at [Extensions.TBTC.Bitcoin.BeneficiaryAddress]: [%w]",
+			err,
+		)
 	}
 	return nil
 }

--- a/pkg/chain/bitcoin/config.go
+++ b/pkg/chain/bitcoin/config.go
@@ -16,22 +16,22 @@ type Config struct {
 
 // Validate returns nil if the configuration is suitable for bitcoin recovery,
 // and an error detailing what went wrong if not.
-func (c Config) Validate() error {
+func (c Config) Validate() (bool, error) {
 	if c.BeneficiaryAddress == "" {
-		return fmt.Errorf("a bitcoin address or extended public key (*pub) is required; configure one at [Extensions.TBTC.Bitcoin.BeneficiaryAddress]")
+		return true, fmt.Errorf("a bitcoin address or extended public key (*pub) is required; configure one at [Extensions.TBTC.Bitcoin.BeneficiaryAddress]")
 	}
 	chainParams, err := c.ChainParams()
 	if err != nil {
-		return fmt.Errorf("a valid chain name is required; choose between [mainnet, regtest, simnet, testnet3] and configure it at [Extensions.TBTC.Bitcoin.BitcoinChainName]: [%w]", err)
+		return false, fmt.Errorf("a valid chain name is required; choose between [mainnet, regtest, simnet, testnet3] and configure it at [Extensions.TBTC.Bitcoin.BitcoinChainName]: [%w]", err)
 	}
 	err = ValidateAddress(c.BeneficiaryAddress, chainParams)
 	if err != nil {
-		return fmt.Errorf(
+		return false, fmt.Errorf(
 			"a valid bitcoin address or extended public key (*pub) is required; configure one at [Extensions.TBTC.Bitcoin.BeneficiaryAddress]: [%w]",
 			err,
 		)
 	}
-	return nil
+	return true, nil
 }
 
 // ChainParams parses the net param name into the associated chaincfg.Params

--- a/pkg/chain/bitcoin/derive_address.go
+++ b/pkg/chain/bitcoin/derive_address.go
@@ -128,12 +128,15 @@ func ValidateAddress(btcAddress string, chainParams *chaincfg.Params) error {
 	_, err := btcutil.DecodeAddress(btcAddress, chainParams)
 	if err != nil {
 		_, err = DeriveAddress(btcAddress, 0)
-		return fmt.Errorf(
-			"[%s] is not a valid btc address using chain [%s]: [%w]",
-			btcAddress,
-			chainParams.Name,
-			err,
-		)
+		if err != nil {
+			return fmt.Errorf(
+				"[%s] is not a valid btc address using chain [%s]: [%w]",
+				btcAddress,
+				chainParams.Name,
+				err,
+			)
+		}
+		return nil
 	}
 	return nil
 }

--- a/pkg/chain/bitcoin/derive_address.go
+++ b/pkg/chain/bitcoin/derive_address.go
@@ -1,4 +1,4 @@
-package recovery
+package bitcoin
 
 import (
 	"fmt"
@@ -6,10 +6,9 @@ import (
 	"github.com/btcsuite/btcd/chaincfg"
 	"github.com/btcsuite/btcutil"
 	"github.com/btcsuite/btcutil/hdkeychain"
-	"github.com/keep-network/keep-ecdsa/pkg/chain/bitcoin"
 )
 
-// deriveAddress uses the specified extended public key and address index to
+// DeriveAddress uses the specified extended public key and address index to
 // derive an address string in the appropriate format at the specified address
 // index. The extended public key can be at any level. deriveAddress will take
 // the first child `/0` until a depth of 4 is reached, and then produce the
@@ -36,7 +35,7 @@ import (
 // [BIP44]: https://github.com/bitcoin/bips/blob/master/bip-0044.mediawiki
 // [BIP49]: https://github.com/bitcoin/bips/blob/master/bip-0049.mediawiki
 // [BIP84]: https://github.com/bitcoin/bips/blob/master/bip-0084.mediawiki
-func deriveAddress(extendedPublicKey string, addressIndex uint32) (string, error) {
+func DeriveAddress(extendedPublicKey string, addressIndex uint32) (string, error) {
 	extendedKey, err := hdkeychain.NewKeyFromString(extendedPublicKey)
 	if err != nil {
 		return "", fmt.Errorf(
@@ -123,27 +122,18 @@ func deriveAddress(extendedPublicKey string, addressIndex uint32) (string, error
 	return finalAddress.EncodeAddress(), nil
 }
 
-// ResolveAddress resolves a configured beneficiaryAddress into a
-// valid bitcoin address. If the supplied address is already a valid bitcoin
-// address, we don't have to do anything. If the supplied address is an
-// extended public key of a HD wallet, attempt to derive the bitcoin address at
-// the specified index.
-func ResolveAddress(
-	beneficiaryAddress string,
-	storage *DerivationIndexStorage,
-	chainParams *chaincfg.Params,
-	handle bitcoin.Handle,
-) (string, error) {
-	// If the address decodes without error, then we have a valid bitcoin
-	// address. Otherwise, we assume that it's an extended key and we attempt to
-	// derive the address.
-	_, err := btcutil.DecodeAddress(beneficiaryAddress, chainParams)
+// ValidateAddress checks to see if the supplied btc address is valid on the
+// supplied chain. We check both raw btc addresses and *pub extended keys.
+func ValidateAddress(btcAddress string, chainParams *chaincfg.Params) error {
+	_, err := btcutil.DecodeAddress(btcAddress, chainParams)
 	if err != nil {
-		derivedAddress, err := storage.GetNextAddress(beneficiaryAddress, handle)
-		if err != nil {
-			return "", err
-		}
-		return derivedAddress, nil
+		_, err = DeriveAddress(btcAddress, 0)
+		return fmt.Errorf(
+			"[%s] is not a valid btc address using chain [%s]: [%w]",
+			btcAddress,
+			chainParams.Name,
+			err,
+		)
 	}
-	return beneficiaryAddress, nil
+	return nil
 }

--- a/pkg/chain/bitcoin/derive_address_test.go
+++ b/pkg/chain/bitcoin/derive_address_test.go
@@ -1,12 +1,8 @@
-package recovery
+package bitcoin
 
 import (
-	"io/ioutil"
-	"os"
 	"strings"
 	"testing"
-
-	"github.com/btcsuite/btcd/chaincfg"
 )
 
 // These tests use https://iancoleman.io/bip39/ with the bip39 mnemonic: loyal
@@ -126,7 +122,7 @@ var deriveAddressTestData = map[string]struct {
 func TestDeriveAddress(t *testing.T) {
 	for testName, testData := range deriveAddressTestData {
 		t.Run(testName, func(t *testing.T) {
-			address, err := deriveAddress(testData.extendedAddress, uint32(testData.addressIndex))
+			address, err := DeriveAddress(testData.extendedAddress, uint32(testData.addressIndex))
 
 			if err != nil {
 				t.Fatal(err)
@@ -174,152 +170,8 @@ func ErrorContains(err error, expected string) bool {
 func TestDeriveAddress_ExpectedFailure(t *testing.T) {
 	for testName, testData := range deriveAddressTestFailureData {
 		t.Run(testName, func(t *testing.T) {
-			_, err := deriveAddress(testData.extendedAddress, uint32(testData.addressIndex))
+			_, err := DeriveAddress(testData.extendedAddress, uint32(testData.addressIndex))
 			if !ErrorContains(err, testData.failure) {
-				t.Errorf(
-					"unexpected error message\nexpected: %s\nactual:   %s",
-					testData.failure,
-					err.Error(),
-				)
-			}
-		})
-	}
-}
-
-var resolveAddressData = map[string]struct {
-	beneficiaryAddress string
-	usedIndexes        []uint32
-	chainParams        *chaincfg.Params
-	expectedAddress    string
-}{
-	"BIP44: xpub at m/44'/0'/0'/0/0": {
-		"xpub6Cg41S21VrxkW1WBTZJn95KNpHozP2Xc6AhG27ZcvZvH8XyNzunEqLdk9dxyXQUoy7ALWQFNn5K1me74aEMtS6pUgNDuCYTTMsJzCAk9sk1",
-		[]uint32{},
-		&chaincfg.MainNetParams,
-		"1MjCqoLqMZ6Ru64TTtP16XnpSdiE8Kpgcx",
-	},
-	"BIP44: xpub at m/44'/0'/0'/0/4": {
-		"xpub6Cg41S21VrxkW1WBTZJn95KNpHozP2Xc6AhG27ZcvZvH8XyNzunEqLdk9dxyXQUoy7ALWQFNn5K1me74aEMtS6pUgNDuCYTTMsJzCAk9sk1",
-		[]uint32{3},
-		&chaincfg.MainNetParams,
-		"1EEX8qZnTw1thadyxsueV748v3Y6tTMccc",
-	},
-
-	"Standard mainnet P2PKH btc address": {
-		"1MjCqoLqMZ6Ru64TTtP16XnpSdiE8Kpgcx",
-		[]uint32{},
-		&chaincfg.MainNetParams,
-		"1MjCqoLqMZ6Ru64TTtP16XnpSdiE8Kpgcx",
-	},
-
-	"Standard mainnet P2SH btc address": {
-		"3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy",
-		[]uint32{},
-		&chaincfg.MainNetParams,
-		"3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy",
-	},
-
-	"Standard mainnet Bech32 btc address": {
-		"bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
-		[]uint32{},
-		&chaincfg.MainNetParams,
-		"bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
-	},
-
-	"Standard testnet btc address": {
-		"mkHS9ne12qx9pS9VojpwU5xtRd4T7X7ZUt",
-		[]uint32{},
-		&chaincfg.TestNet3Params,
-		"mkHS9ne12qx9pS9VojpwU5xtRd4T7X7ZUt",
-	},
-}
-
-func TestResolveAddress(t *testing.T) {
-	for testName, testData := range resolveAddressData {
-		t.Run(testName, func(t *testing.T) {
-			dir, err := ioutil.TempDir("", "example")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer os.RemoveAll(dir)
-			dis, err := NewDerivationIndexStorage(dir)
-			if err != nil {
-				t.Fatal(err)
-			}
-			for _, usedIndex := range testData.usedIndexes {
-				dis.save(testData.beneficiaryAddress, usedIndex)
-			}
-
-			handle := newMockBitcoinHandle()
-
-			resolvedAddress, err := ResolveAddress(
-				testData.beneficiaryAddress,
-				dis,
-				testData.chainParams,
-				handle,
-			)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if resolvedAddress != testData.expectedAddress {
-				t.Errorf(
-					"the resolved address does not match\nexpected: %s\nactual:   %s",
-					testData.expectedAddress,
-					resolvedAddress,
-				)
-			}
-		})
-	}
-}
-
-var resolveAddressExpectedFailureData = map[string]struct {
-	extendedAddress string
-	chainParams     *chaincfg.Params
-	failure         string
-}{
-	"WIF": {
-		"5Hwgr3u458GLafKBgxtssHSPqJnYoGrSzgQsPwLFhLNYskDPyyA",
-		&chaincfg.MainNetParams,
-		"the provided serialized extended key length is invalid",
-	},
-	"empty string": {
-		"",
-		&chaincfg.MainNetParams,
-		"insufficient length for public key",
-	},
-	"BIP32 private key": {
-		"xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzF93Y5wvzdUayhgkkFoicQZcP3y52uPPxFnfoLZB21Teqt1VvEHx",
-		&chaincfg.MainNetParams,
-		"unusable seed",
-	},
-	"complete nonsense": {
-		"lorem ipsum dolor sit amet, consec",
-		&chaincfg.MainNetParams,
-		"the provided serialized extended key length is invalid",
-	},
-}
-
-func TestResolveBeneficiaryAddress_ExpectedFailure(t *testing.T) {
-	for testName, testData := range resolveAddressExpectedFailureData {
-		t.Run(testName, func(t *testing.T) {
-			dir, err := ioutil.TempDir("", "example")
-			if err != nil {
-				t.Fatal(err)
-			}
-			defer os.RemoveAll(dir)
-			dis, err := NewDerivationIndexStorage(dir)
-			if err != nil {
-				t.Fatal(err)
-			}
-			_, err = ResolveAddress(
-				testData.extendedAddress,
-				dis,
-				testData.chainParams,
-				nil,
-			)
-			if err == nil {
-				t.Errorf("no error found\nexpected: %s", testData.failure)
-			} else if !ErrorContains(err, testData.failure) {
 				t.Errorf(
 					"unexpected error message\nexpected: %s\nactual:   %s",
 					testData.failure,

--- a/pkg/chain/bitcoin/derive_address_test.go
+++ b/pkg/chain/bitcoin/derive_address_test.go
@@ -249,32 +249,37 @@ func TestValidateAddress_ExpectedFailures(t *testing.T) {
 		"nonsense address": {
 			"banana123",
 			&chaincfg.MainNetParams,
-			"[banana123] is not a valid btc address using chain [mainnet]: [error parsing extended public key: [the provided serialized extended key length is invalid]]",
+			"[banana123] is not a valid btc address using chain [mainnet]: decode address failed with [checksum mismatch] and derive address failed with [error parsing extended public key: [the provided serialized extended key length is invalid]]",
 		},
 		"empty string": {
 			"",
 			&chaincfg.RegressionNetParams,
-			"[] is not a valid btc address using chain [regtest]: [error parsing extended public key: [the provided serialized extended key length is invalid]]",
+			"[] is not a valid btc address using chain [regtest]: decode address failed with [decoded address is of unknown format] and derive address failed with [error parsing extended public key: [the provided serialized extended key length is invalid]]",
 		},
 		"Mainnet private key": {
 			"5Hwgr3u458GLafKBgxtssHSPqJnYoGrSzgQsPwLFhLNYskDPyyA",
 			&chaincfg.MainNetParams,
-			"[5Hwgr3u458GLafKBgxtssHSPqJnYoGrSzgQsPwLFhLNYskDPyyA] is not a valid btc address using chain [mainnet]: [error parsing extended public key: [the provided serialized extended key length is invalid]]",
+			"[5Hwgr3u458GLafKBgxtssHSPqJnYoGrSzgQsPwLFhLNYskDPyyA] is not a valid btc address using chain [mainnet]: decode address failed with [decoded address is of unknown size] and derive address failed with [error parsing extended public key: [the provided serialized extended key length is invalid]]",
 		},
 		"testnet private key": {
 			"92Pg46rUhgTT7romnV7iGW6W1gbGdeezqdbJCzShkCsYNzyyNcc",
 			&chaincfg.TestNet3Params,
-			"[92Pg46rUhgTT7romnV7iGW6W1gbGdeezqdbJCzShkCsYNzyyNcc] is not a valid btc address using chain [testnet3]: [error parsing extended public key: [the provided serialized extended key length is invalid]]",
+			"[92Pg46rUhgTT7romnV7iGW6W1gbGdeezqdbJCzShkCsYNzyyNcc] is not a valid btc address using chain [testnet3]: decode address failed with [decoded address is of unknown size] and derive address failed with [error parsing extended public key: [the provided serialized extended key length is invalid]]",
 		},
 		"testnet public key against mainnet": {
 			"mkHS9ne12qx9pS9VojpwU5xtRd4T7X7ZUt",
 			&chaincfg.MainNetParams,
-			"[mkHS9ne12qx9pS9VojpwU5xtRd4T7X7ZUt] is not a valid btc address using chain [mainnet]: [error parsing extended public key: [the provided serialized extended key length is invalid]]",
+			"[mkHS9ne12qx9pS9VojpwU5xtRd4T7X7ZUt] is not a valid btc address using chain [mainnet]: decode address failed with [unknown address type] and derive address failed with [error parsing extended public key: [the provided serialized extended key length is invalid]]",
 		},
 		"mainnet public key against testnet": {
 			"1MjCqoLqMZ6Ru64TTtP16XnpSdiE8Kpgcx",
 			&chaincfg.TestNet3Params,
-			"[1MjCqoLqMZ6Ru64TTtP16XnpSdiE8Kpgcx] is not a valid btc address using chain [testnet3]: [error parsing extended public key: [the provided serialized extended key length is invalid]]",
+			"[1MjCqoLqMZ6Ru64TTtP16XnpSdiE8Kpgcx] is not a valid btc address using chain [testnet3]: decode address failed with [unknown address type] and derive address failed with [error parsing extended public key: [the provided serialized extended key length is invalid]]",
+		},
+		"bech32 address against testnet": {
+			"bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
+			&chaincfg.TestNet3Params,
+			"provided address [bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq] is not a valid btc address for chain [testnet3]",
 		},
 	}
 	for testName, testData := range testData {

--- a/pkg/chain/bitcoin/derive_address_test.go
+++ b/pkg/chain/bitcoin/derive_address_test.go
@@ -266,6 +266,16 @@ func TestValidateAddress_ExpectedFailures(t *testing.T) {
 			&chaincfg.TestNet3Params,
 			"[92Pg46rUhgTT7romnV7iGW6W1gbGdeezqdbJCzShkCsYNzyyNcc] is not a valid btc address using chain [testnet3]: [error parsing extended public key: [the provided serialized extended key length is invalid]]",
 		},
+		"testnet public key against mainnet": {
+			"mkHS9ne12qx9pS9VojpwU5xtRd4T7X7ZUt",
+			&chaincfg.MainNetParams,
+			"[mkHS9ne12qx9pS9VojpwU5xtRd4T7X7ZUt] is not a valid btc address using chain [mainnet]: [error parsing extended public key: [the provided serialized extended key length is invalid]]",
+		},
+		"mainnet public key against testnet": {
+			"1MjCqoLqMZ6Ru64TTtP16XnpSdiE8Kpgcx",
+			&chaincfg.TestNet3Params,
+			"[1MjCqoLqMZ6Ru64TTtP16XnpSdiE8Kpgcx] is not a valid btc address using chain [testnet3]: [error parsing extended public key: [the provided serialized extended key length is invalid]]",
+		},
 	}
 	for testName, testData := range testData {
 		t.Run(testName, func(t *testing.T) {

--- a/pkg/chain/bitcoin/derive_address_test.go
+++ b/pkg/chain/bitcoin/derive_address_test.go
@@ -193,24 +193,40 @@ func TestValidateAddress(t *testing.T) {
 			"xpub6Cg41S21VrxkW1WBTZJn95KNpHozP2Xc6AhG27ZcvZvH8XyNzunEqLdk9dxyXQUoy7ALWQFNn5K1me74aEMtS6pUgNDuCYTTMsJzCAk9sk1",
 			&chaincfg.MainNetParams,
 		},
-
-		"Standard mainnet P2PKH btc address": {
+		"Mainnet P2PKH btc address": {
 			"1MjCqoLqMZ6Ru64TTtP16XnpSdiE8Kpgcx",
 			&chaincfg.MainNetParams,
 		},
-
-		"Standard mainnet P2SH btc address": {
+		"Mainnet P2SH btc address": {
 			"3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy",
 			&chaincfg.MainNetParams,
 		},
-
-		"Standard mainnet Bech32 btc address": {
+		"Mainnet Bech32 btc address": {
 			"bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
 			&chaincfg.MainNetParams,
 		},
-
-		"Standard testnet btc address": {
+		"Testnet btc address": {
 			"mkHS9ne12qx9pS9VojpwU5xtRd4T7X7ZUt",
+			&chaincfg.TestNet3Params,
+		},
+		"Regression Network btc address": {
+			"bcrt1qlmyyz6klzk6ckv7lqy65k26763xdp6y4dpn9he",
+			&chaincfg.RegressionNetParams,
+		},
+		"Mainnet public key hash": {
+			"17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhem",
+			&chaincfg.MainNetParams,
+		},
+		"Mainnet script hash": {
+			"3EktnHQD7RiAE6uzMj2ZifT9YgRrkSgzQX",
+			&chaincfg.MainNetParams,
+		},
+		"Testnet public key hash": {
+			"mipcBbFg9gMiCh81Kj8tqqdgoZub1ZJRfn",
+			&chaincfg.TestNet3Params,
+		},
+		"Testnet script hash": {
+			"2MzQwSSnBHWHqSAqtTVQ6v47XtaisrJa1Vc",
 			&chaincfg.TestNet3Params,
 		},
 	}
@@ -235,11 +251,31 @@ func TestValidateAddress_ExpectedFailures(t *testing.T) {
 			&chaincfg.MainNetParams,
 			"[banana123] is not a valid btc address using chain [mainnet]: [error parsing extended public key: [the provided serialized extended key length is invalid]]",
 		},
+		"empty string": {
+			"",
+			&chaincfg.RegressionNetParams,
+			"[] is not a valid btc address using chain [regtest]: [error parsing extended public key: [the provided serialized extended key length is invalid]]",
+		},
+		"Mainnet private key": {
+			"5Hwgr3u458GLafKBgxtssHSPqJnYoGrSzgQsPwLFhLNYskDPyyA",
+			&chaincfg.MainNetParams,
+			"[5Hwgr3u458GLafKBgxtssHSPqJnYoGrSzgQsPwLFhLNYskDPyyA] is not a valid btc address using chain [mainnet]: [error parsing extended public key: [the provided serialized extended key length is invalid]]",
+		},
+		"testnet private key": {
+			"92Pg46rUhgTT7romnV7iGW6W1gbGdeezqdbJCzShkCsYNzyyNcc",
+			&chaincfg.TestNet3Params,
+			"[92Pg46rUhgTT7romnV7iGW6W1gbGdeezqdbJCzShkCsYNzyyNcc] is not a valid btc address using chain [testnet3]: [error parsing extended public key: [the provided serialized extended key length is invalid]]",
+		},
 	}
 	for testName, testData := range testData {
 		t.Run(testName, func(t *testing.T) {
 			err := ValidateAddress(testData.beneficiaryAddress, testData.chainParams)
-			if !ErrorContains(err, testData.err) {
+			if err == nil {
+				t.Errorf(
+					"unexpected error message\nexpected: %s\nactual:   nil",
+					testData.err,
+				)
+			} else if !ErrorContains(err, testData.err) {
 				t.Errorf(
 					"unexpected error message\nexpected: %s\nactual:   %s",
 					testData.err,

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1063,7 +1063,7 @@ func monitorKeepTerminatedEvent(
 						chainParams, err := tbtcConfig.Bitcoin.ChainParams()
 						if err != nil {
 							logger.Errorf(
-								"failed to parse the the configured net params: [%v]",
+								"failed to parse the configured net params: [%v]",
 								err,
 							)
 							return err
@@ -1090,8 +1090,7 @@ func monitorKeepTerminatedEvent(
 						vbyteFee, vbyteFeeError := bitcoinHandle.VbyteFeeFor25Blocks()
 						if vbyteFeeError != nil {
 							logger.Errorf(
-								"failed to retrieve a vbyte fee estimate from %s, [%v]",
-								tbtcConfig.Bitcoin.ElectrsURLWithDefault(),
+								"failed to retrieve a vbyte fee estimate, [%v]",
 								vbyteFeeError,
 							)
 							// Since the electrs connection is optional, we don't return the error
@@ -1159,8 +1158,8 @@ func monitorKeepTerminatedEvent(
 						broadcastError := bitcoinHandle.Broadcast(recoveryTransactionHex)
 						if broadcastError != nil {
 							logger.Errorf(
-								"failed to broadcast the recovery transaction to %s, [%v]",
-								*tbtcConfig.Bitcoin.ElectrsURL,
+								"failed to broadcast liquidation recovery transaction for keep [%s]: [%v]",
+								keep.ID(),
 								broadcastError,
 							)
 

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -989,186 +989,188 @@ func monitorKeepTerminatedEvent(
 
 			go func(event *chain.KeepTerminatedEvent) {
 				err := tbtcConfig.Bitcoin.Validate()
-				if err == nil {
-					err = utils.DoWithDefaultRetry(
-						tbtcConfig.GetLiquidationRecoveryTimeout(),
-						func(ctx context.Context) error {
-							if shouldHandle := eventDeduplicator.NotifyTerminatingStarted(keep.ID()); !shouldHandle {
-								logger.Infof(
-									"terminate event for keep [%s] already handled",
-									keep.ID(),
-								)
-
-								// currently handling or already handled in the past
-								// in case this event is a duplicate.
-								return nil
-							}
-							defer eventDeduplicator.NotifyTerminatingCompleted(keep.ID())
-
-							isKeepActive, err := ethlike.WaitForBlockConfirmations(
-								hostChain.BlockCounter(),
-								event.BlockNumber,
-								blockConfirmations,
-								func() (bool, error) {
-									return keep.IsActive()
-								},
-							)
-							if err != nil {
-								logger.Errorf(
-									"failed to confirm keep [%s] termination: [%v]",
-									keep.ID(),
-									err,
-								)
-								return err
-							}
-
-							if isKeepActive {
-								logger.Warningf("keep [%s] has not been terminated", keep.ID())
-								return err
-							}
-
-							members, err := keep.GetMembers()
-							if err != nil {
-								logger.Errorf(
-									"failed to retrieve members from keep [%s]: [%v]",
-									keep.ID(),
-									err,
-								)
-								return err
-							}
-							memberID := tss.MemberIDFromPublicKey(operatorPublicKey)
-							memberIDs, err := tssNode.AnnounceSignerPresence(
-								ctx,
-								operatorPublicKey,
-								keep.ID(),
-								members,
-							)
-
-							if err != nil {
-								logger.Errorf(
-									"failed to announce signer presence on keep [%s] termination: [%v]",
-									keep.ID(),
-									err,
-								)
-								return err
-							}
-
-							chainParams, err := tbtcConfig.Bitcoin.ChainParams()
-							if err != nil {
-								logger.Errorf(
-									"failed to parse the the configured net params: [%v]",
-									err,
-								)
-								return err
-							}
-
-							bitcoinHandle := bitcoin.Connect(tbtcConfig.Bitcoin.ElectrsURLWithDefault())
-
-							beneficiaryAddress, err := recovery.ResolveAddress(
-								tbtcConfig.Bitcoin.BeneficiaryAddress,
-								derivationIndexStorage,
-								chainParams,
-								bitcoinHandle,
-							)
-							if err != nil {
-								logger.Errorf(
-									"failed to resolve a btc address for keep: [%s] address: [%s] err: [%v]",
-									keep.ID(),
-									tbtcConfig.Bitcoin.BeneficiaryAddress,
-									err,
-								)
-								return err
-							}
-
-							vbyteFee, vbyteFeeError := bitcoinHandle.VbyteFeeFor25Blocks()
-							if vbyteFeeError != nil {
-								logger.Errorf(
-									"failed to retrieve a vbyte fee estimate from %s, [%v]",
-									tbtcConfig.Bitcoin.ElectrsURLWithDefault(),
-									vbyteFeeError,
-								)
-								// Since the electrs connection is optional, we don't return the error
-							}
-							if vbyteFee == 0 {
-								vbyteFee = tbtcConfig.Bitcoin.MaxFeePerVByte
-							}
-							if vbyteFee == 0 {
-								vbyteFee = 75
-							}
-
-							btcAddresses, maxFeePerVByte, err := tss.BroadcastRecoveryAddress(
-								ctx,
-								beneficiaryAddress,
-								vbyteFee,
-								keep.ID().String(),
-								memberID,
-								memberIDs,
-								uint(len(memberIDs)-1),
-								networkProvider,
-								hostChain.Signing().PublicKeyToAddress,
-								chainParams,
-							)
-							if err != nil {
-								logger.Errorf(
-									"failed to communicate recovery details for keep [%s]: [%v]",
-									keep.ID(),
-									err,
-								)
-								return err
-							}
-
-							signer, err := keepsRegistry.GetSigner(keep.ID())
-							if err != nil {
-								// If there are no signer for loaded keep that something is clearly
-								// wrong. We don't want to continue processing for this keep.
-								logger.Errorf(
-									"no signer for keep [%s]: [%v]",
-									keep.ID(),
-									err,
-								)
-								return err
-							}
-
-							recoveryTransactionHex, err := recovery.BuildBitcoinTransaction(
-								ctx,
-								networkProvider,
-								hostChain,
-								tbtcHandle,
-								keep,
-								signer,
-								chainParams,
-								btcAddresses,
-								maxFeePerVByte,
-							)
-							if err != nil {
-								logger.Errorf(
-									"failed to build the transaction for keep [%s]: [%v]",
-									keep.ID(),
-									err,
-								)
-								return err
-							}
-
-							broadcastError := bitcoinHandle.Broadcast(recoveryTransactionHex)
-							if broadcastError != nil {
-								logger.Errorf(
-									"failed to broadcast the recovery transaction to %s, [%v]",
-									*tbtcConfig.Bitcoin.ElectrsURL,
-									broadcastError,
-								)
-
-								for i := 0; i < 5; i++ {
-									logger.Warningf("Please broadcast Bitcoin transaction %s", recoveryTransactionHex)
-								}
-							}
-
-							keepsRegistry.UnregisterKeep(keep.ID())
-							keepTerminated <- event
-
-							return nil
-						},
-					)
+				if err != nil {
+					logger.Errorf("failed to handle KeepTerminatedEvent due to invalid bitcoin configuration for tbtc extension: [%v]", err)
+					return
 				}
+				err = utils.DoWithDefaultRetry(
+					tbtcConfig.GetLiquidationRecoveryTimeout(),
+					func(ctx context.Context) error {
+						if shouldHandle := eventDeduplicator.NotifyTerminatingStarted(keep.ID()); !shouldHandle {
+							logger.Infof(
+								"terminate event for keep [%s] already handled",
+								keep.ID(),
+							)
+
+							// currently handling or already handled in the past
+							// in case this event is a duplicate.
+							return nil
+						}
+						defer eventDeduplicator.NotifyTerminatingCompleted(keep.ID())
+
+						isKeepActive, err := ethlike.WaitForBlockConfirmations(
+							hostChain.BlockCounter(),
+							event.BlockNumber,
+							blockConfirmations,
+							func() (bool, error) {
+								return keep.IsActive()
+							},
+						)
+						if err != nil {
+							logger.Errorf(
+								"failed to confirm keep [%s] termination: [%v]",
+								keep.ID(),
+								err,
+							)
+							return err
+						}
+
+						if isKeepActive {
+							logger.Warningf("keep [%s] has not been terminated", keep.ID())
+							return err
+						}
+
+						members, err := keep.GetMembers()
+						if err != nil {
+							logger.Errorf(
+								"failed to retrieve members from keep [%s]: [%v]",
+								keep.ID(),
+								err,
+							)
+							return err
+						}
+						memberID := tss.MemberIDFromPublicKey(operatorPublicKey)
+						memberIDs, err := tssNode.AnnounceSignerPresence(
+							ctx,
+							operatorPublicKey,
+							keep.ID(),
+							members,
+						)
+
+						if err != nil {
+							logger.Errorf(
+								"failed to announce signer presence on keep [%s] termination: [%v]",
+								keep.ID(),
+								err,
+							)
+							return err
+						}
+
+						chainParams, err := tbtcConfig.Bitcoin.ChainParams()
+						if err != nil {
+							logger.Errorf(
+								"failed to parse the the configured net params: [%v]",
+								err,
+							)
+							return err
+						}
+
+						bitcoinHandle := bitcoin.Connect(tbtcConfig.Bitcoin.ElectrsURLWithDefault())
+
+						beneficiaryAddress, err := recovery.ResolveAddress(
+							tbtcConfig.Bitcoin.BeneficiaryAddress,
+							derivationIndexStorage,
+							chainParams,
+							bitcoinHandle,
+						)
+						if err != nil {
+							logger.Errorf(
+								"failed to resolve a btc address for keep: [%s] address: [%s] err: [%v]",
+								keep.ID(),
+								tbtcConfig.Bitcoin.BeneficiaryAddress,
+								err,
+							)
+							return err
+						}
+
+						vbyteFee, vbyteFeeError := bitcoinHandle.VbyteFeeFor25Blocks()
+						if vbyteFeeError != nil {
+							logger.Errorf(
+								"failed to retrieve a vbyte fee estimate from %s, [%v]",
+								tbtcConfig.Bitcoin.ElectrsURLWithDefault(),
+								vbyteFeeError,
+							)
+							// Since the electrs connection is optional, we don't return the error
+						}
+						if vbyteFee == 0 {
+							vbyteFee = tbtcConfig.Bitcoin.MaxFeePerVByte
+						}
+						if vbyteFee == 0 {
+							vbyteFee = 75
+						}
+
+						btcAddresses, maxFeePerVByte, err := tss.BroadcastRecoveryAddress(
+							ctx,
+							beneficiaryAddress,
+							vbyteFee,
+							keep.ID().String(),
+							memberID,
+							memberIDs,
+							uint(len(memberIDs)-1),
+							networkProvider,
+							hostChain.Signing().PublicKeyToAddress,
+							chainParams,
+						)
+						if err != nil {
+							logger.Errorf(
+								"failed to communicate recovery details for keep [%s]: [%v]",
+								keep.ID(),
+								err,
+							)
+							return err
+						}
+
+						signer, err := keepsRegistry.GetSigner(keep.ID())
+						if err != nil {
+							// If there are no signer for loaded keep that something is clearly
+							// wrong. We don't want to continue processing for this keep.
+							logger.Errorf(
+								"no signer for keep [%s]: [%v]",
+								keep.ID(),
+								err,
+							)
+							return err
+						}
+
+						recoveryTransactionHex, err := recovery.BuildBitcoinTransaction(
+							ctx,
+							networkProvider,
+							hostChain,
+							tbtcHandle,
+							keep,
+							signer,
+							chainParams,
+							btcAddresses,
+							maxFeePerVByte,
+						)
+						if err != nil {
+							logger.Errorf(
+								"failed to build the transaction for keep [%s]: [%v]",
+								keep.ID(),
+								err,
+							)
+							return err
+						}
+
+						broadcastError := bitcoinHandle.Broadcast(recoveryTransactionHex)
+						if broadcastError != nil {
+							logger.Errorf(
+								"failed to broadcast the recovery transaction to %s, [%v]",
+								*tbtcConfig.Bitcoin.ElectrsURL,
+								broadcastError,
+							)
+
+							for i := 0; i < 5; i++ {
+								logger.Warningf("Please broadcast Bitcoin transaction %s", recoveryTransactionHex)
+							}
+						}
+
+						keepsRegistry.UnregisterKeep(keep.ID())
+						keepTerminated <- event
+
+						return nil
+					},
+				)
 				if err != nil {
 					logger.Errorf("failed to broadcast the bitcoin recovery transaction: [%v]", err)
 				}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -991,11 +991,11 @@ func monitorKeepTerminatedEvent(
 				err := tbtcConfig.Bitcoin.Validate()
 				if err != nil {
 					if (bitcoin.Config{}) == tbtcConfig.Bitcoin {
-						logger.Warnf("missing bitcoin configuration for tbtc extension: [%v]", err)
+						logger.Errorf("missing bitcoin configuration for tbtc extension: [%v]", err)
 					} else {
 						logger.Errorf("misconfigured bitcoin configured for tbtc extension: [%v]", err)
-						return
 					}
+					return
 				}
 				err = utils.DoWithDefaultRetry(
 					tbtcConfig.GetLiquidationRecoveryTimeout(),

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -988,7 +988,7 @@ func monitorKeepTerminatedEvent(
 			)
 
 			go func(event *chain.KeepTerminatedEvent) {
-				err := tbtcConfig.Bitcoin.Validate()
+				_, err := tbtcConfig.Bitcoin.Validate()
 				if err != nil {
 					logger.Errorf("failed to handle KeepTerminatedEvent due to invalid bitcoin configuration for tbtc extension: [%v]", err)
 					return

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -988,10 +988,14 @@ func monitorKeepTerminatedEvent(
 			)
 
 			go func(event *chain.KeepTerminatedEvent) {
-				_, err := tbtcConfig.Bitcoin.Validate()
+				err := tbtcConfig.Bitcoin.Validate()
 				if err != nil {
-					logger.Errorf("failed to handle KeepTerminatedEvent due to invalid bitcoin configuration for tbtc extension: [%v]", err)
-					return
+					if (bitcoin.Config{}) == tbtcConfig.Bitcoin {
+						logger.Warnf("missing bitcoin configuration for tbtc extension: [%v]", err)
+					} else {
+						logger.Errorf("misconfigured bitcoin configured for tbtc extension: [%v]", err)
+						return
+					}
 				}
 				err = utils.DoWithDefaultRetry(
 					tbtcConfig.GetLiquidationRecoveryTimeout(),

--- a/pkg/ecdsa/tss/tss_test.go
+++ b/pkg/ecdsa/tss/tss_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestGenerateKeyAndSign(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 120*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 180*time.Second)
 	defer cancel()
 
 	groupSize := 5

--- a/pkg/extensions/tbtc/recovery/resolve_address.go
+++ b/pkg/extensions/tbtc/recovery/resolve_address.go
@@ -1,0 +1,32 @@
+package recovery
+
+import (
+	"github.com/btcsuite/btcd/chaincfg"
+	"github.com/btcsuite/btcutil"
+	"github.com/keep-network/keep-ecdsa/pkg/chain/bitcoin"
+)
+
+// ResolveAddress resolves a configured beneficiaryAddress into a
+// valid bitcoin address. If the supplied address is already a valid bitcoin
+// address, we don't have to do anything. If the supplied address is an
+// extended public key of a HD wallet, attempt to derive the bitcoin address at
+// the specified index.
+func ResolveAddress(
+	beneficiaryAddress string,
+	storage *DerivationIndexStorage,
+	chainParams *chaincfg.Params,
+	handle bitcoin.Handle,
+) (string, error) {
+	// If the address decodes without error, then we have a valid bitcoin
+	// address. Otherwise, we assume that it's an extended key and we attempt to
+	// derive the address.
+	_, err := btcutil.DecodeAddress(beneficiaryAddress, chainParams)
+	if err != nil {
+		derivedAddress, err := storage.GetNextAddress(beneficiaryAddress, handle)
+		if err != nil {
+			return "", err
+		}
+		return derivedAddress, nil
+	}
+	return beneficiaryAddress, nil
+}

--- a/pkg/extensions/tbtc/recovery/resolve_address_test.go
+++ b/pkg/extensions/tbtc/recovery/resolve_address_test.go
@@ -1,0 +1,158 @@
+package recovery
+
+import (
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/btcsuite/btcd/chaincfg"
+)
+
+func ErrorContains(err error, expected string) bool {
+	return strings.Contains(err.Error(), expected)
+}
+
+var resolveAddressData = map[string]struct {
+	beneficiaryAddress string
+	usedIndexes        []uint32
+	chainParams        *chaincfg.Params
+	expectedAddress    string
+}{
+	"BIP44: xpub at m/44'/0'/0'/0/0": {
+		"xpub6Cg41S21VrxkW1WBTZJn95KNpHozP2Xc6AhG27ZcvZvH8XyNzunEqLdk9dxyXQUoy7ALWQFNn5K1me74aEMtS6pUgNDuCYTTMsJzCAk9sk1",
+		[]uint32{},
+		&chaincfg.MainNetParams,
+		"1MjCqoLqMZ6Ru64TTtP16XnpSdiE8Kpgcx",
+	},
+	"BIP44: xpub at m/44'/0'/0'/0/4": {
+		"xpub6Cg41S21VrxkW1WBTZJn95KNpHozP2Xc6AhG27ZcvZvH8XyNzunEqLdk9dxyXQUoy7ALWQFNn5K1me74aEMtS6pUgNDuCYTTMsJzCAk9sk1",
+		[]uint32{3},
+		&chaincfg.MainNetParams,
+		"1EEX8qZnTw1thadyxsueV748v3Y6tTMccc",
+	},
+
+	"Standard mainnet P2PKH btc address": {
+		"1MjCqoLqMZ6Ru64TTtP16XnpSdiE8Kpgcx",
+		[]uint32{},
+		&chaincfg.MainNetParams,
+		"1MjCqoLqMZ6Ru64TTtP16XnpSdiE8Kpgcx",
+	},
+
+	"Standard mainnet P2SH btc address": {
+		"3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy",
+		[]uint32{},
+		&chaincfg.MainNetParams,
+		"3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy",
+	},
+
+	"Standard mainnet Bech32 btc address": {
+		"bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
+		[]uint32{},
+		&chaincfg.MainNetParams,
+		"bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
+	},
+
+	"Standard testnet btc address": {
+		"mkHS9ne12qx9pS9VojpwU5xtRd4T7X7ZUt",
+		[]uint32{},
+		&chaincfg.TestNet3Params,
+		"mkHS9ne12qx9pS9VojpwU5xtRd4T7X7ZUt",
+	},
+}
+
+func TestResolveAddress(t *testing.T) {
+	for testName, testData := range resolveAddressData {
+		t.Run(testName, func(t *testing.T) {
+			dir, err := ioutil.TempDir("", "example")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.RemoveAll(dir)
+			dis, err := NewDerivationIndexStorage(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, usedIndex := range testData.usedIndexes {
+				dis.save(testData.beneficiaryAddress, usedIndex)
+			}
+
+			handle := newMockBitcoinHandle()
+
+			resolvedAddress, err := ResolveAddress(
+				testData.beneficiaryAddress,
+				dis,
+				testData.chainParams,
+				handle,
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if resolvedAddress != testData.expectedAddress {
+				t.Errorf(
+					"the resolved address does not match\nexpected: %s\nactual:   %s",
+					testData.expectedAddress,
+					resolvedAddress,
+				)
+			}
+		})
+	}
+}
+
+var resolveAddressExpectedFailureData = map[string]struct {
+	extendedAddress string
+	chainParams     *chaincfg.Params
+	failure         string
+}{
+	"WIF": {
+		"5Hwgr3u458GLafKBgxtssHSPqJnYoGrSzgQsPwLFhLNYskDPyyA",
+		&chaincfg.MainNetParams,
+		"the provided serialized extended key length is invalid",
+	},
+	"empty string": {
+		"",
+		&chaincfg.MainNetParams,
+		"insufficient length for public key",
+	},
+	"BIP32 private key": {
+		"xprv9s21ZrQH143K24Mfq5zL5MhWK9hUhhGbd45hLXo2Pq2oqzMMo63oStZzF93Y5wvzdUayhgkkFoicQZcP3y52uPPxFnfoLZB21Teqt1VvEHx",
+		&chaincfg.MainNetParams,
+		"unusable seed",
+	},
+	"complete nonsense": {
+		"lorem ipsum dolor sit amet, consec",
+		&chaincfg.MainNetParams,
+		"the provided serialized extended key length is invalid",
+	},
+}
+
+func TestResolveBeneficiaryAddress_ExpectedFailure(t *testing.T) {
+	for testName, testData := range resolveAddressExpectedFailureData {
+		t.Run(testName, func(t *testing.T) {
+			dir, err := ioutil.TempDir("", "example")
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer os.RemoveAll(dir)
+			dis, err := NewDerivationIndexStorage(dir)
+			if err != nil {
+				t.Fatal(err)
+			}
+			_, err = ResolveAddress(
+				testData.extendedAddress,
+				dis,
+				testData.chainParams,
+				nil,
+			)
+			if err == nil {
+				t.Errorf("no error found\nexpected: %s", testData.failure)
+			} else if !ErrorContains(err, testData.failure) {
+				t.Errorf(
+					"unexpected error message\nexpected: %s\nactual:   %s",
+					testData.failure,
+					err.Error(),
+				)
+			}
+		})
+	}
+}

--- a/pkg/extensions/tbtc/recovery/storage.go
+++ b/pkg/extensions/tbtc/recovery/storage.go
@@ -156,7 +156,7 @@ func (dis *DerivationIndexStorage) GetNextAddress(
 	startIndex := uint32(lastIndex + 1)
 	for i := uint32(0); true; i++ {
 		index := startIndex + i
-		derivedAddress, err := deriveAddress(strings.TrimSpace(extendedPublicKey), index)
+		derivedAddress, err := bitcoin.DeriveAddress(strings.TrimSpace(extendedPublicKey), index)
 		if err != nil {
 			return "", err
 		}

--- a/pkg/extensions/tbtc/recovery/storage_test.go
+++ b/pkg/extensions/tbtc/recovery/storage_test.go
@@ -4,6 +4,8 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+
+	"github.com/keep-network/keep-ecdsa/pkg/chain/bitcoin"
 )
 
 type mockBitcoinHandle struct {
@@ -46,7 +48,7 @@ func TestDerivationIndexStorage_GetNextAddressOnNewKey(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		expectedBtcAddress, err := deriveAddress(extendedPublicKey, i)
+		expectedBtcAddress, err := bitcoin.DeriveAddress(extendedPublicKey, i)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -316,7 +318,7 @@ func TestDerivationIndexStorage_MultipleAsyncGetNextAddresses(t *testing.T) {
 			for i := 0; i < iterations; i++ {
 				// the valid indexes should be 840, 850, 860, 870...
 				index := uint32(840) + 10*uint32(i)
-				derivedAddress, err := deriveAddress(extendedPublicKey, index)
+				derivedAddress, err := bitcoin.DeriveAddress(extendedPublicKey, index)
 				if err != nil {
 					getNextAddressResults <- pair{"", err}
 					return
@@ -337,7 +339,7 @@ func TestDerivationIndexStorage_MultipleAsyncGetNextAddresses(t *testing.T) {
 		}
 		// the valid indexes should be 840, 850, 860, 870...
 		expectedIndex := uint32(840) + 10*uint32(i)
-		expectedAddress, err := deriveAddress(extendedPublicKey, expectedIndex)
+		expectedAddress, err := bitcoin.DeriveAddress(extendedPublicKey, expectedIndex)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
If a user has not configured `Extensions.TBTC.Bitcoin` with the required fields (BeneficiaryAddress and BitcoinChainName presently), this PR changes the client behavior in the following ways:

* We warn at startup about the paths that are missing, and suggest possible values:
```
2021-06-04T11:11:26.586-0400    WARN    keep-cmd        invalid Bitcoin configuration: [a bit
coin address or extended public key (*pub) is required; configure one at [Extensions.TBTC.Bitc
oin.BeneficiaryAddress]]
2021-06-04T11:11:26.586-0400    WARN    keep-cmd        invalid Bitcoin configuration: [a valid chain name is required; choose between [mainnet, regtest, simnet, testnet3] and configure it at [Extensions.TBTC.Bitcoin.BitcoinChainName]: [unable to find chaincfg param for name: [banana]]]
```

* We error out and skip the retry loop during termination handling:
```
2021-06-04T10:29:13.005-0400    ERROR    keep-ecdsa    failed to broadcast the bitcoin recovery transaction: [a bitcoin address or extended public key (*pub) is required; configure one at [Extensions.TBTC.Bitcoin.BeneficiaryAddress]]
2021-06-04T10:29:13.005-0400    ERROR    keep-ecdsa    failed to broadcast the bitcoin recovery transaction: [a valid chain name is required; choose between [mainnet, regtest, simnet, testnet3] and configure it at [Extensions.TBTC.Bitcoin.BitcoinChainName]: [unable to find chaincfg param for name: [banana]]]
```

closes #807 

tagging @nkuba for review