### PR TITLE
Upgraded Golang to 1.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.8-alpine3.10 AS gobuild
+FROM golang:1.16.5-alpine3.12 AS gobuild
 
 # HOST_CHAIN argument defines the chain implementation which should be used
 # during image build process.
@@ -27,7 +27,7 @@ RUN apk add --update --no-cache \
 	make \
 	nodejs \
 	npm \
-	python \
+	python3 \
 	git \
 	protobuf && \
 	rm -rf /var/cache/apk/ && mkdir /var/cache/apk/ && \
@@ -92,7 +92,7 @@ RUN GOOS=linux go build -tags "$APP_BUILD_TAGS" -ldflags "-X main.version=$VERSI
 	mv $APP_NAME $BIN_PATH
 
 # Configure runtime container.
-FROM alpine:3.10
+FROM alpine:3.12
 
 ENV APP_NAME=keep-ecdsa \
 	BIN_PATH=/usr/local/bin

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/keep-network/keep-ecdsa
 
-go 1.13
+go 1.16
 
 replace (
 	github.com/BurntSushi/toml => github.com/keep-network/toml v0.3.0


### PR DESCRIPTION
We upgraded Golang to the latest version 1.16.

For the docker image, we use alpine 3.12, while the latest available source image is based on 3.13. We use an older alpine version as it comes with Node 12 which is required by the solidity package. Alpine 3.13 comes with Node 14 which doesn't work well for us yet.

We also install `python3`, as `python` is no longer available in the package registry.

