### PR TITLE
No longer set CI_GITHUB_TOKEN for load-env-variables action

### DIFF
--- a/.github/workflows/client-celo.yml
+++ b/.github/workflows/client-celo.yml
@@ -52,8 +52,6 @@ jobs:
 
       - name: Load environment variables
         uses: keep-network/load-env-variables@v1
-        env: 
-          CI_GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:
           # TODO: Consider passing of `environment` input instead of using 
           # hardcoded value. Would require some rework in action's code or

--- a/.github/workflows/client-ethereum.yml
+++ b/.github/workflows/client-ethereum.yml
@@ -52,8 +52,6 @@ jobs:
 
       - name: Load environment variables
         uses: keep-network/load-env-variables@v1
-        env: 
-          CI_GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:
           # TODO: Consider passing of `environment` input instead of using 
           # hardcoded value. Would require some rework in action's code or

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -127,8 +127,6 @@ jobs:
 
       - name: Load environment variables
         uses: keep-network/load-env-variables@v1
-        env: 
-          CI_GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:
           # TODO: Consider passing of `environment` input instead of using 
           # hardcoded value. Would require some rework in action's code or
@@ -235,8 +233,6 @@ jobs:
 
       - name: Load environment variables
         uses: keep-network/load-env-variables@v1
-        env: 
-          CI_GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:
           # TODO: Consider passing of `environment` input instead of using 
           # hardcoded value. Would require some rework in action's code or
@@ -308,8 +304,6 @@ jobs:
 
       - name: Load environment variables
         uses: keep-network/load-env-variables@v1
-        env: 
-          CI_GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
         with:
           # TODO: Consider passing of `environment` input instead of using 
           # hardcoded value. Would require some rework in action's code or


### PR DESCRIPTION
The `keep-network/ci` repository storing the config files used by the
`load-env-variables` action is no longer private. This means that we
no longer need to authenticate curl with the token allowing access to
the repository.

See also:
https://github.com/keep-network/keep-core/pull/2490
https://github.com/keep-network/tbtc/pull/803
https://github.com/keep-network/tbtc-dapp/pull/397