### PR TITLE
Resolve btc address based on btcutil encoding

### DIFF
--- a/pkg/extensions/tbtc/recovery/resolve_address.go
+++ b/pkg/extensions/tbtc/recovery/resolve_address.go
@@ -20,7 +20,7 @@ func ResolveAddress(
 	// If the address decodes without error, then we have a valid bitcoin
 	// address. Otherwise, we assume that it's an extended key and we attempt to
 	// derive the address.
-	_, err := btcutil.DecodeAddress(beneficiaryAddress, chainParams)
+	decodedAddress, err := btcutil.DecodeAddress(beneficiaryAddress, chainParams)
 	if err != nil {
 		derivedAddress, err := storage.GetNextAddress(beneficiaryAddress, handle)
 		if err != nil {
@@ -28,5 +28,5 @@ func ResolveAddress(
 		}
 		return derivedAddress, nil
 	}
-	return beneficiaryAddress, nil
+	return decodedAddress.EncodeAddress(), nil
 }

--- a/pkg/extensions/tbtc/recovery/resolve_address_test.go
+++ b/pkg/extensions/tbtc/recovery/resolve_address_test.go
@@ -31,33 +31,75 @@ var resolveAddressData = map[string]struct {
 		&chaincfg.MainNetParams,
 		"1EEX8qZnTw1thadyxsueV748v3Y6tTMccc",
 	},
-
+	// P2PKH
 	"Standard mainnet P2PKH btc address": {
 		"1MjCqoLqMZ6Ru64TTtP16XnpSdiE8Kpgcx",
 		[]uint32{},
 		&chaincfg.MainNetParams,
 		"1MjCqoLqMZ6Ru64TTtP16XnpSdiE8Kpgcx",
 	},
-
+	"Standard testnet P2PKH btc address": {
+		"mkHS9ne12qx9pS9VojpwU5xtRd4T7X7ZUt",
+		[]uint32{},
+		&chaincfg.TestNet3Params,
+		"mkHS9ne12qx9pS9VojpwU5xtRd4T7X7ZUt",
+	},
+	// P2SH
 	"Standard mainnet P2SH btc address": {
 		"3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy",
 		[]uint32{},
 		&chaincfg.MainNetParams,
 		"3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy",
 	},
-
-	"Standard mainnet Bech32 btc address": {
+	"Standard testnet P2SH btc address": {
+		"2NBFNJTktNa7GZusGbDbGKRZTxdK9VVez3n",
+		[]uint32{},
+		&chaincfg.TestNet3Params,
+		"2NBFNJTktNa7GZusGbDbGKRZTxdK9VVez3n",
+	},
+	// SegWit
+	"Standard mainnet Bech32 (segwit) P2WPKH btc address": {
 		"bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
 		[]uint32{},
 		&chaincfg.MainNetParams,
 		"bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq",
 	},
-
-	"Standard testnet btc address": {
-		"mkHS9ne12qx9pS9VojpwU5xtRd4T7X7ZUt",
+	"Standard mainnet Bech32 (segwit) P2WPSH btc address": {
+		"bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3",
+		[]uint32{},
+		&chaincfg.MainNetParams,
+		"bc1qrp33g0q5c5txsp9arysrx4k6zdkfs4nce4xj0gdcccefvpysxf3qccfmv3",
+	},
+	"Standard testnet Bech32 (segwit) P2WPKH btc address": {
+		"tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
 		[]uint32{},
 		&chaincfg.TestNet3Params,
-		"mkHS9ne12qx9pS9VojpwU5xtRd4T7X7ZUt",
+		"tb1qw508d6qejxtdg4y5r3zarvary0c5xw7kxpjzsx",
+	},
+	// P2PK - public keys
+	"Mainnet P2PK compressed btc public key (0x02)": {
+		"02192d74d0cb94344c9569c2e77901573d8d7903c3ebec3a957724895dca52c6b4",
+		[]uint32{},
+		&chaincfg.MainNetParams,
+		"13CG6SJ3yHUXo4Cr2RY4THLLJrNFuG3gUg",
+	},
+	"Mainnet P2PK compressed btc public key (0x03)": {
+		"03b0bd634234abbb1ba1e986e884185c61cf43e001f9137f23c2c409273eb16e65",
+		[]uint32{},
+		&chaincfg.MainNetParams,
+		"15sHANNUBSh6nDp8XkDPmQcW6n3EFwmvE6",
+	},
+	"Mainnet P2PK uncompressed btc public key (0x04)": {
+		"0411db93e1dcdb8a016b49840f8c53bc1eb68a382e97b1482ecad7b148a6909a5cb2e0eaddfb84ccf9744464f82e160bfa9b8b64f9d4c03f999b8643f656b412a3",
+		[]uint32{},
+		&chaincfg.MainNetParams,
+		"12cbQLTFMXRnSzktFkuoG3eHoMeFtpTu3S",
+	},
+	"Testnet P2PK compressed btc public key (0x02)": {
+		"02192d74d0cb94344c9569c2e77901573d8d7903c3ebec3a957724895dca52c6b4",
+		[]uint32{},
+		&chaincfg.TestNet3Params,
+		"mhiDPVP2nJunaAgTjzWSHCYfAqxxrxzjmo",
 	},
 }
 


### PR DESCRIPTION
An address provided as a beneficiary address can match one of many bitcoin address formats. One of which is P2PK where a public key is provided.

Previously we would return the same public key that was supplied by the user, but `btcutil.DecodeAddress` resolves a correct address for this public key, so we want to use the address resolved by the `btcutil`.

Here we updated unit tests to cover the scenario described above but also enhanced the tests a little bit with some test cases taken from: https://github.com/btcsuite/btcutil/blob/e2ba6805a89060647fa22ec61b799acff6a4f6fd/address_test.go

Depends on: https://github.com/keep-network/keep-ecdsa/pull/815