### PR TITLE
Rename logger for bitcoin package

### DIFF
--- a/pkg/chain/bitcoin/electrs.go
+++ b/pkg/chain/bitcoin/electrs.go
@@ -13,7 +13,7 @@ import (
 	"github.com/keep-network/keep-ecdsa/pkg/utils"
 )
 
-var logger = log.Logger("bitcoin")
+var logger = log.Logger("keep-bitcoin")
 
 const (
 	defaultTimeout = 2 * time.Minute


### PR DESCRIPTION
Here we align the logger name with the convention we have across the
repo. We prefix all our loggers with `keep-` prefix so the log messages
are easily filtered.