### PR TITLE
Link to documentation in sample toml configuration file

### DIFF
--- a/configs/config.toml.SAMPLE
+++ b/configs/config.toml.SAMPLE
@@ -1,4 +1,7 @@
 # This is a TOML configuration file.
+#
+# For detailed information please see the documentation at:
+# https://github.com/keep-network/keep-ecdsa/blob/master/docs/run-keep-ecdsa.adoc#32-application
 
 # Connection details of ethereum blockchain.
 [ethereum]


### PR DESCRIPTION
The docs contain more detailed information and properties description so it may be a good idea to point the user to them from a config file.