### PR TITLE
Update btcutil

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ replace (
 	github.com/BurntSushi/toml => github.com/keep-network/toml v0.3.0
 	github.com/blockcypher/gobcy => github.com/keep-network/gobcy v1.3.1
 	github.com/btcsuite/btcd => github.com/keep-network/btcd v0.0.0-20190427004231-96897255fd17
-	github.com/btcsuite/btcutil => github.com/keep-network/btcutil v0.0.0-20190425235716-9e5f4b9a998d
+	github.com/btcsuite/btcutil => github.com/keep-network/btcutil v0.0.0-20210527170813-e2ba6805a890
 	github.com/urfave/cli => github.com/keep-network/cli v1.20.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -435,6 +435,8 @@ github.com/keep-network/btcd v0.0.0-20190427004231-96897255fd17 h1:YvkAWRGnwLdNn
 github.com/keep-network/btcd v0.0.0-20190427004231-96897255fd17/go.mod h1:3J08xEfcugPacsc34/LKRU2yO7YmuT8yt28J8k2+rrI=
 github.com/keep-network/btcutil v0.0.0-20190425235716-9e5f4b9a998d h1:ZUxpxggD2RooBEU6QqojffSxMK/njPSZchBiwBFoPWQ=
 github.com/keep-network/btcutil v0.0.0-20190425235716-9e5f4b9a998d/go.mod h1:vhMoS7zlQpjHWB/xCYPYcnoDvRMJWhSGTsSWw5Pj4zE=
+github.com/keep-network/btcutil v0.0.0-20210527170813-e2ba6805a890 h1:TVICLiY+rt/+C9pmI1z5a+9p6k7GjwranMVNIDOuaqc=
+github.com/keep-network/btcutil v0.0.0-20210527170813-e2ba6805a890/go.mod h1:0DVlHczLPewLcPGEIeUEzfOJhqGPQ0mJJRDBtD307+o=
 github.com/keep-network/cli v1.20.0 h1:mEufpPsovOVdduTTkk+a2CxS3crIrGFqUsvs58gSik8=
 github.com/keep-network/cli v1.20.0/go.mod h1:nzsst4JjU+rGE8Q5J839fYxectxWHpLhxKNohQWtQhA=
 github.com/keep-network/go-libp2p-bootstrap v0.0.0-20200423153828-ed815bc50aec h1:2pXAsi4OUUjZKr5ds5UOF2IxXN+jVW0WetVO+czkf+A=
@@ -1049,6 +1051,7 @@ golang.org/x/crypto v0.0.0-20190611184440-5c40567a22f8/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20190618222545-ea8f1a30c443/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20190909091759-094676da4a83/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
 golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8UmvKecakEJjdnWj3jj499lnFckfCI=
+golang.org/x/crypto v0.0.0-20200115085410-6d4e4cb37c7d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200221231518-2aa609cf4a9d/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200423211502-4bdfaf469ed5/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9 h1:psW17arqaxU48Z5kZ0CQnkZWQJsqcURM6tKiBApRjXI=

--- a/pkg/chain/bitcoin/derive_address.go
+++ b/pkg/chain/bitcoin/derive_address.go
@@ -51,7 +51,7 @@ func DeriveAddress(extendedPublicKey string, addressIndex uint32) (string, error
 	for externalChain.Depth() < 4 {
 		// Descend the hierarchy at /0 until the external chain path, `m/*/*/*/0`.
 		// ex: If we get a `m/32'/5` extended key, we descend to `m/32'/5/0/0`.
-		externalChain, err = externalChain.Child(0)
+		externalChain, err = externalChain.Derive(0)
 		if err != nil {
 			return "", fmt.Errorf(
 				"error deriving external chain path /0 from extended key: [%s]",
@@ -60,7 +60,7 @@ func DeriveAddress(extendedPublicKey string, addressIndex uint32) (string, error
 		}
 	}
 
-	requestedPublicKey, err := externalChain.Child(addressIndex)
+	requestedPublicKey, err := externalChain.Derive(addressIndex)
 	if err != nil {
 		return "", fmt.Errorf(
 			"error deriving requested address index /0/%v from extended key: [%s]",


### PR DESCRIPTION
Sometime between 2019 (the last time we updated) and now, btcutil
removed `ExtendedKey.Child` and replaced it with `ExtendedKey.Derive`,
so we do the same.

Tagging @nkuba for review