### PR TITLE
Updated hasAnnounced function to lowercase ID before matching

### DIFF
--- a/pkg/ecdsa/tss/protocol_announce.go
+++ b/pkg/ecdsa/tss/protocol_announce.go
@@ -46,7 +46,7 @@ func AnnounceProtocol(
 		receivedMemberIDs[strings.ToLower(operatorID.String())] = memberID
 	}
 	hasAnnounced := func(keepMemberID chain.ID) bool {
-		_, ok := receivedMemberIDs[keepMemberID.String()]
+		_, ok := receivedMemberIDs[strings.ToLower(keepMemberID.String())]
 		return ok
 	}
 


### PR DESCRIPTION
In `receivedMemberIDs` map we're storing IDs that are previously converted to lower case. In `hasAnnounced` function we should lowercase the ID when looking for matching entries.

Before this change, we weren't correctly matching operators that already announced their presence and logged errors for all operators in the group.