### PR TITLE
Don't Give Up: continue with liquidation recovery when the electrs connection fails

### DIFF
--- a/pkg/chain/bitcoin/electrs.go
+++ b/pkg/chain/bitcoin/electrs.go
@@ -130,10 +130,12 @@ func (e electrsConnection) VbyteFeeFor25Blocks() (int32, error) {
 }
 
 // IsAddressUnused returns true if and only if the supplied bitcoin address has
-// no recorded transactions.
+// no recorded transactions. NOTE: IsAddressUnused will return true rather than
+// false in the case that it encounters an error. This lets processing continue
+// in the case where there is not a working electrs connection.
 func (e electrsConnection) IsAddressUnused(btcAddress string) (bool, error) {
 	if e.apiURL == "" {
-		return false, fmt.Errorf("attempted to call IsAddressUnused with no apiURL")
+		return true, fmt.Errorf("attempted to call IsAddressUnused with no apiURL")
 	}
 
 	isAddressUnused := false
@@ -169,7 +171,7 @@ func (e electrsConnection) IsAddressUnused(btcAddress string) (bool, error) {
 		return nil
 	})
 	if err != nil {
-		return false, err
+		return true, err
 	}
 	return isAddressUnused, nil
 }

--- a/pkg/chain/bitcoin/electrs.go
+++ b/pkg/chain/bitcoin/electrs.go
@@ -145,8 +145,8 @@ func (e electrsConnection) IsAddressUnused(btcAddress string) (bool, error) {
 		if resp.StatusCode != 200 {
 			responseBody, err := io.ReadAll(resp.Body)
 			if err != nil {
-				logger.Error(
-					"something went wrong trying to read error response for transactions of bitcoin address [%s]: [%w]",
+				logger.Errorf(
+					"something went wrong trying to read error response for transactions of bitcoin address [%s]: [%v]",
 					btcAddress,
 					err,
 				)

--- a/pkg/chain/bitcoin/electrs_test.go
+++ b/pkg/chain/bitcoin/electrs_test.go
@@ -186,7 +186,7 @@ func TestIsAddressUnused(t *testing.T) {
 
 func TestIsAddressUnused_EmptyApiURL(t *testing.T) {
 	expectedError := "attempted to call IsAddressUnused with no apiURL"
-	expectedUnusedFlag := false
+	expectedUnusedFlag := true
 
 	electrs := &electrsConnection{}
 
@@ -208,7 +208,7 @@ func TestIsAddressUnused_EmptyApiURL(t *testing.T) {
 }
 
 func TestIsAddressUnused_ExpectedFailures(t *testing.T) {
-	expectedUnusedFlag := false
+	expectedUnusedFlag := true
 
 	testData := map[string]struct {
 		btcAddress   string

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1095,7 +1095,7 @@ func monitorKeepTerminatedEvent(
 						vbyteFee, vbyteFeeError := bitcoinHandle.VbyteFeeFor25Blocks()
 						if vbyteFeeError != nil {
 							logger.Errorf(
-								"failed to retrieve a vbyte fee estimate, [%v]",
+								"failed to retrieve a vbyte fee estimate: [%v]",
 								vbyteFeeError,
 							)
 							// Since the electrs connection is optional, we don't return the error

--- a/pkg/extensions/tbtc/recovery/storage.go
+++ b/pkg/extensions/tbtc/recovery/storage.go
@@ -168,7 +168,11 @@ func (dis *DerivationIndexStorage) GetNextAddress(
 		}
 		ok, err := handle.IsAddressUnused(derivedAddress)
 		if err != nil {
-			return "", err
+			logger.Errorf(
+				"something went wrong checking to see if address [%s] is unused: [%v]",
+				derivedAddress,
+				err,
+			)
 		}
 
 		err = dis.save(extendedPublicKey, index)


### PR DESCRIPTION
Currently, when a user has a non-working electrs connection configured and an extended public key as their beneficiary address, we are unable to complete liquidation recovery because we error out trying to verify that a derived address is unused.

This PR changes that behavior to log the failure as an error, and then continue on with processing using the index supplied by local persistence.

Tagging @nkuba for review

closes #840 