### PR TITLE
Align timeouts for electrs connection and liquidation recovery protocol

### DIFF
--- a/pkg/chain/bitcoin/electrs.go
+++ b/pkg/chain/bitcoin/electrs.go
@@ -16,7 +16,13 @@ import (
 var logger = log.Logger("keep-bitcoin")
 
 const (
-	defaultTimeout = 2 * time.Minute
+	// defaultTimeout defines a period within which the member tries to call Electrs
+	// API. If the time is reached an error will be returned.
+	//
+	// It is important that this value is less than the timeout used for a
+	// liquidation recovery protocol (recoveryProtocolReadyTimeout), so the nodes
+	// can correctly synchronize liquidation protocol execution.
+	defaultTimeout = 1 * time.Minute
 )
 
 type httpClient interface {

--- a/pkg/ecdsa/tss/protocol_recovery.go
+++ b/pkg/ecdsa/tss/protocol_recovery.go
@@ -12,6 +12,18 @@ import (
 	"github.com/keep-network/keep-ecdsa/pkg/chain/bitcoin"
 )
 
+const (
+	// recoveryProtocolReadyTimeout defines a period within which the member sends
+	// and receives notifications from peer members about their readiness to begin
+	// the broadcast recovery address protocol execution. If the time limit is
+	// reached the ready protocol stage fails.
+	//
+	// It is important that this value is greater than the timeout defined for
+	// Electrs connection, so the nodes/ can correctly synchronize liquidation
+	// protocol execution.
+	recoveryProtocolReadyTimeout = 2 * time.Minute
+)
+
 // recoveryInfo represents the broadcasted information needed from the other
 // signers to complete liquidation recovery.
 type recoveryInfo struct {
@@ -34,7 +46,7 @@ func BroadcastRecoveryAddress(
 	pubKeyToAddressFn func(cecdsa.PublicKey) []byte,
 	chainParams *chaincfg.Params,
 ) ([]string, int32, error) {
-	const protocolReadyTimeout = 2 * time.Minute
+	protocolReadyTimeout := recoveryProtocolReadyTimeout
 
 	group := &groupInfo{
 		groupID:            groupID,


### PR DESCRIPTION
A timeout for electrs connection retries has to be less than the timeout
used for the liquidation protocol execution, so the nodes can correctly
sychronize.

Currently electrs connection timeout is the same as default retry timeout
for liquidation recovery (2 minutes). So it’s hard for the nodes to sync
in the same time frame to execute the complete protocol. They all announce
presence so node 1 which has non-working electrs connection retries for 2 minutes,
and once it aborts electrs retries and proceed to next protocol step the other
nodes hit the 2 minutes timeout waiting for the node 1 and start again
from the begining.

Depends on https://github.com/keep-network/keep-ecdsa/pull/841