### PR TITLE
Remove the Deployment Considerations Section

### DIFF
--- a/docs/infrastructure.adoc
+++ b/docs/infrastructure.adoc
@@ -1,0 +1,22 @@
+:toc: macro
+
+= Infrastructure
+
+:icons: font
+:numbered:
+toc::[]
+
+== Deployment Considerations
+
+// TODO: Flesh out this document
+
+=== Kubernetes
+
+At Keep we run on GCP + Kube. To accommodate the aforementioned system considerations we use the following pattern for each of our environments:
+
+- Regional Kube cluster.
+- 5 ECDSA clients, each running minimum stake required by the network.
+- A LoadBalancer Service for each client.
+- A StatefulSet for each client.
+
+You can see our Ropsten Kube configurations https://github.com/keep-network/keep-ecdsa/tree/master/infrastructure/kube/keep-test[here]

--- a/docs/run-keep-ecdsa.adoc
+++ b/docs/run-keep-ecdsa.adoc
@@ -297,19 +297,6 @@ docker run -d \
 keepnetwork/keep-ecdsa-client:<version> --config /mnt/keep-ecdsa/config/keep-ecdsa-config.toml start
 ----
 
-== Deployment Considerations
-
-=== Kubernetes
-
-At Keep we run on GCP + Kube. To accommodate the aforementioned system considerations we use the following pattern for each of our environments:
-
-- Regional Kube cluster.
-- 5 ECDSA clients, each running minimum stake required by the network.
-- A LoadBalancer Service for each client.
-- A StatefulSet for each client.
-
-You can see our Ropsten Kube configurations https://github.com/keep-network/keep-ecdsa/tree/master/infrastructure/kube/keep-test[here]
-
 == Logging
 
 Below are some of the key things to look out for to make sure you're booted and connected to the


### PR DESCRIPTION
This section points to an example of running multiple ecdsa nodes in a
kube cluster. While this is useful, I feel that it dilutes the message
and intent of the document, which is to get the user started running a
node. If we want to keep this information, I think we should find a
different home for it.

Tagging @pdyraga for review