### PR TITLE
Fix spelling mistake

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -162,7 +162,7 @@ func Initialize(
 
 			signer, err := keepsRegistry.GetSigner(keepID)
 			if err != nil {
-				// If there are no signer for loaded keep that something is clearly
+				// If there are no signer for loaded keep then something is clearly
 				// wrong. We don't want to continue processing for this keep.
 				logger.Errorf(
 					"no signer for keep [%s]: [%v]",

--- a/pkg/client/liquidation_recovery.go
+++ b/pkg/client/liquidation_recovery.go
@@ -114,7 +114,7 @@ func handleLiquidationRecovery(
 
 	signer, err := keepsRegistry.GetSigner(keep.ID())
 	if err != nil {
-		// If there are no signer for loaded keep that something is clearly
+		// If there are no signer for loaded keep then something is clearly
 		// wrong. We don't want to continue processing for this keep.
 		logger.Errorf(
 			"no signer for keep [%s]: [%v]",


### PR DESCRIPTION
Replaced `If there are no signer for loaded keep that `something is clearly` with `If there are no signer for loaded keep then something is clearly`.