### PR TITLE
Liquidation recovery:  Compare estimated transaction fee with 5% utxo value 

### DIFF
--- a/pkg/chain/local/tbtc.go
+++ b/pkg/chain/local/tbtc.go
@@ -3,7 +3,6 @@ package local
 import (
 	"bytes"
 	"context"
-	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"math/big"
@@ -17,9 +16,8 @@ import (
 )
 
 const (
-	defaultUTXOValue            = 10000000
 	defaultInitialRedemptionFee = 10
-	defaultUtxoValueHex         = "8096980000000000"
+	defaultUtxoValueHex         = "8096980000000000" // 10000000
 	defaultFundedAt             = "1615172517"
 	previousTransactionHashHex  = "c27c3bfa8293ac6b303b9f7455ae23b7c24b8814915a6511976027064efc4d51"
 	previousTransactionIndex    = 1
@@ -190,9 +188,9 @@ func (tlc *TBTCLocalChain) CreateDeposit(
 	tlc.deposits[depositAddress] = &localDeposit{
 		keepAddress: keepAddress.Hex(),
 		state:       chain.AwaitingSignerSetup,
-		utxoValue:   big.NewInt(defaultUTXOValue),
+		utxoValue:   big.NewInt(int64(chain.UtxoValueBytesToUint32(utxoValueBytes))),
 		fundingInfo: &chain.FundingInfo{
-			UtxoValueBytes:  utxoValueBytes, // 0x0065cd1d00000000
+			UtxoValueBytes:  utxoValueBytes,
 			FundedAt:        fundedAt,
 			TransactionHash: previousTransactionHashHex,
 			OutputIndex:     previousTransactionIndex,
@@ -773,5 +771,5 @@ func (tlc *TBTCLocalChain) Logger() *ChainLogger {
 }
 
 func fromLittleEndianBytes(bytes [8]byte) *big.Int {
-	return new(big.Int).SetUint64(binary.LittleEndian.Uint64(bytes[:]))
+	return new(big.Int).SetUint64(uint64(chain.UtxoValueBytesToUint32(bytes)))
 }

--- a/pkg/chain/tbtc.go
+++ b/pkg/chain/tbtc.go
@@ -175,3 +175,9 @@ func ParseUtxoOutpoint(utxoOutpoint []uint8) (string, uint32) {
 	outputIndex := binary.LittleEndian.Uint32(utxoOutpoint[32:])
 	return transactionHash, outputIndex
 }
+
+// UtxoValueBytesToUint32 converts utxo value from little endian bytes8 that is
+// returned from chain to uin32.
+func UtxoValueBytesToUint32(utxoValueBytes [8]uint8) uint32 {
+	return binary.LittleEndian.Uint32(utxoValueBytes[:])
+}

--- a/pkg/chain/tbtc_test.go
+++ b/pkg/chain/tbtc_test.go
@@ -73,3 +73,47 @@ func TestParseUtxoOutpoint(t *testing.T) {
 		})
 	}
 }
+
+func TestUtxoValueBytesToUint32(t *testing.T) {
+	testData := map[string]struct {
+		utxoValueBytes [8]uint8
+		expectedValue  uint32
+	}{
+		"0": {
+			[8]uint8{0, 0, 0, 0}, // 0x00000000
+			uint32(0),
+		},
+		"1": {
+			[8]uint8{1, 0, 0, 0}, // 0x01000000
+			uint32(1),
+		},
+		"16777216": {
+			[8]uint8{0, 0, 0, 1}, // 0x00000001
+			uint32(16777216),
+		},
+		"1000000": {
+			[8]uint8{64, 66, 15, 0}, // 0x40420f00
+			uint32(1000000),
+		},
+		"500000000": {
+			[8]uint8{0, 101, 205, 29}, // 0x0065cd1d
+			uint32(500000000),
+		},
+		"1000000000": {
+			[8]uint8{0, 202, 154, 59}, // 0x00ca9a3b
+			uint32(1000000000),
+		},
+		"4294967295": {
+			[8]uint8{255, 255, 255, 255}, // 0xffffffff
+			uint32(4294967295),
+		},
+	}
+	for testName, testData := range testData {
+		t.Run(testName, func(t *testing.T) {
+			actualValue := UtxoValueBytesToUint32(testData.utxoValueBytes)
+			if actualValue != testData.expectedValue {
+				t.Errorf("unexpected result\nexpected: %d\nactual:   %d", testData.expectedValue, actualValue)
+			}
+		})
+	}
+}

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1049,6 +1049,11 @@ func monitorKeepTerminatedEvent(
 							keepsRegistry,
 							derivationIndexStorage,
 						); err != nil {
+							logger.Errorf(
+								"failed to handle liquidation recovery for keep [%s]: [%w]",
+								keep.ID(),
+								err,
+							)
 							return err
 						}
 

--- a/pkg/client/liquidation_recovery.go
+++ b/pkg/client/liquidation_recovery.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/keep-network/keep-core/pkg/net"
 	"github.com/keep-network/keep-core/pkg/operator"
@@ -40,12 +41,11 @@ func handleLiquidationRecovery(
 
 	members, err := keep.GetMembers()
 	if err != nil {
-		logger.Errorf(
-			"failed to retrieve members from keep [%s]: [%v]",
+		return fmt.Errorf(
+			"failed to retrieve members from keep [%s]: [%w]",
 			keep.ID(),
 			err,
 		)
-		return err
 	}
 
 	memberID := tss.MemberIDFromPublicKey(operatorPublicKey)
@@ -57,21 +57,19 @@ func handleLiquidationRecovery(
 		members,
 	)
 	if err != nil {
-		logger.Errorf(
-			"failed to announce signer presence on keep [%s] termination: [%v]",
+		return fmt.Errorf(
+			"failed to announce signer presence on keep [%s] termination: [%w]",
 			keep.ID(),
 			err,
 		)
-		return err
 	}
 
 	chainParams, err := tbtcConfig.Bitcoin.ChainParams()
 	if err != nil {
-		logger.Errorf(
-			"failed to parse the configured net params: [%v]",
+		return fmt.Errorf(
+			"failed to parse the configured net params: [%w]",
 			err,
 		)
-		return err
 	}
 
 	beneficiaryAddress, err := recovery.ResolveAddress(
@@ -81,8 +79,8 @@ func handleLiquidationRecovery(
 		bitcoinHandle,
 	)
 	if err != nil {
-		logger.Errorf(
-			"failed to resolve a btc address for keep: [%s] address: [%s] err: [%v]",
+		return fmt.Errorf(
+			"failed to resolve a btc address for keep [%s] address: [%s]: [%w]",
 			keep.ID(),
 			tbtcConfig.Bitcoin.BeneficiaryAddress,
 			err,
@@ -124,24 +122,18 @@ func handleLiquidationRecovery(
 		chainParams,
 	)
 	if err != nil {
-		logger.Errorf(
-			"failed to communicate recovery details for keep [%s]: [%v]",
+		return fmt.Errorf(
+			"failed to communicate recovery details for keep [%s]: [%w]",
 			keep.ID(),
 			err,
 		)
-		return err
 	}
 
 	signer, err := keepsRegistry.GetSigner(keep.ID())
 	if err != nil {
 		// If there are no signer for loaded keep then something is clearly
 		// wrong. We don't want to continue processing for this keep.
-		logger.Errorf(
-			"no signer for keep [%s]: [%v]",
-			keep.ID(),
-			err,
-		)
-		return err
+		return fmt.Errorf("no signer for keep [%s]: [%w]", keep.ID(), err)
 	}
 
 	logger.Infof(
@@ -157,19 +149,17 @@ func handleLiquidationRecovery(
 		networkProvider,
 		hostChain,
 		fundingInfo,
-		keep,
 		signer,
 		chainParams,
 		btcAddresses,
 		maxFeePerVByte,
 	)
 	if err != nil {
-		logger.Errorf(
-			"failed to build the transaction for keep [%s]: [%v]",
+		return fmt.Errorf(
+			"failed to build the transaction for keep [%s]: [%w]",
 			keep.ID(),
 			err,
 		)
-		return err
 	}
 
 	logger.Debugf(

--- a/pkg/client/liquidation_recovery.go
+++ b/pkg/client/liquidation_recovery.go
@@ -156,7 +156,7 @@ func handleLiquidationRecovery(
 		ctx,
 		networkProvider,
 		hostChain,
-		tbtcHandle,
+		fundingInfo,
 		keep,
 		signer,
 		chainParams,

--- a/pkg/extensions/tbtc/recovery/recovery.go
+++ b/pkg/extensions/tbtc/recovery/recovery.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	cecdsa "crypto/ecdsa"
-	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"strings"
@@ -140,6 +139,14 @@ func constructUnsignedTransaction(
 	perRecipientValue := (previousOutputValue - fee) / int64(len(recipientAddresses))
 	for _, txOut := range tx.TxOut {
 		txOut.Value = perRecipientValue
+	}
+
+	if fee > previousOutputValue/20 {
+		logger.Warnf(
+			"transaction fee [%d] is greater than 5%% of the UTXO value [%d]",
+			fee,
+			previousOutputValue,
+		)
 	}
 
 	return tx, nil

--- a/pkg/extensions/tbtc/recovery/recovery.go
+++ b/pkg/extensions/tbtc/recovery/recovery.go
@@ -200,7 +200,6 @@ func BuildBitcoinTransaction(
 	networkProvider net.Provider,
 	hostChain chain.Handle,
 	fundingInfo *chain.FundingInfo,
-	keep chain.BondedECDSAKeepHandle,
 	signer *tss.ThresholdSigner,
 	chainParams *chaincfg.Params,
 	retrievalAddresses []string,
@@ -208,12 +207,7 @@ func BuildBitcoinTransaction(
 ) (string, error) {
 	scriptCodeBytes, err := publicKeyToP2WPKHScriptCode(signer.PublicKey(), chainParams)
 	if err != nil {
-		logger.Errorf(
-			"failed to retrieve the script code for keep [%s]: [%v]",
-			keep.ID(),
-			err,
-		)
-		return "", err
+		return "", fmt.Errorf("failed to retrieve the script code: [%v]", err)
 	}
 
 	previousOutputValue := int64(chain.UtxoValueBytesToUint32(fundingInfo.UtxoValueBytes))
@@ -227,17 +221,11 @@ func BuildBitcoinTransaction(
 		chainParams,
 	)
 	if err != nil {
-		logger.Errorf(
-			"failed to construct the unsigned transaction for keep [%s]: [%v]",
-			keep.ID(),
-			err,
-		)
-		return "", err
+		return "", fmt.Errorf("failed to construct the unsigned transaction: [%w]", err)
 	}
 
 	logger.Debugf(
-		"constructed unsigned liquidation recovery transcation for keep [%s]: [%+v]",
-		keep.ID(),
+		"constructed unsigned liquidation recovery transcation: [%+v]",
 		unsignedTransaction,
 	)
 
@@ -250,17 +238,11 @@ func BuildBitcoinTransaction(
 		previousOutputValue,
 	)
 	if err != nil {
-		logger.Errorf(
-			"failed to calculate the sighash bytes for keep [%s]: [%v]",
-			keep.ID(),
-			err,
-		)
-		return "", err
+		return "", fmt.Errorf("failed to calculate the sighash bytes: [%w]", err)
 	}
 
 	logger.Debugf(
-		"calculated liquidation recovery transcation sighash for keep [%s]: [%x]",
-		keep.ID(),
+		"calculated liquidation recovery transcation sighash: [%x]",
 		sighashBytes,
 	)
 
@@ -271,17 +253,11 @@ func BuildBitcoinTransaction(
 		hostChain.Signing().PublicKeyToAddress,
 	)
 	if err != nil {
-		logger.Errorf(
-			"failed to calculate signature for keep [%s]: [%v]",
-			keep.ID(),
-			err,
-		)
-		return "", err
+		return "", fmt.Errorf("failed to calculate signature: [%w]", err)
 	}
 
 	logger.Debugf(
-		"calculated liquidation recovery transcation signature for keep [%s]: [%v]",
-		keep.ID(),
+		"calculated liquidation recovery transcation signature: [%v]",
 		signature,
 	)
 

--- a/pkg/extensions/tbtc/recovery/recovery.go
+++ b/pkg/extensions/tbtc/recovery/recovery.go
@@ -199,7 +199,7 @@ func BuildBitcoinTransaction(
 	ctx context.Context,
 	networkProvider net.Provider,
 	hostChain chain.Handle,
-	tbtcHandle chain.TBTCHandle,
+	fundingInfo *chain.FundingInfo,
 	keep chain.BondedECDSAKeepHandle,
 	signer *tss.ThresholdSigner,
 	chainParams *chaincfg.Params,
@@ -210,26 +210,6 @@ func BuildBitcoinTransaction(
 	if err != nil {
 		logger.Errorf(
 			"failed to retrieve the script code for keep [%s]: [%v]",
-			keep.ID(),
-			err,
-		)
-		return "", err
-	}
-	depositAddress, err := keep.GetOwner()
-	if err != nil {
-		logger.Errorf(
-			"failed to retrieve the owner for keep [%s]: [%v]",
-			keep.ID(),
-			err,
-		)
-		return "", err
-	}
-
-	fundingInfo, err := tbtcHandle.FundingInfo(depositAddress.String())
-	if err != nil {
-		logger.Errorf(
-			"failed to retrieve the funding info of deposit [%s] for keep [%s]: [%v]",
-			depositAddress,
 			keep.ID(),
 			err,
 		)

--- a/pkg/extensions/tbtc/recovery/recovery.go
+++ b/pkg/extensions/tbtc/recovery/recovery.go
@@ -229,7 +229,7 @@ func BuildBitcoinTransaction(
 		return "", err
 	}
 
-	previousOutputValue := int64(binary.LittleEndian.Uint32(fundingInfo.UtxoValueBytes[:]))
+	previousOutputValue := int64(chain.UtxoValueBytesToUint32(fundingInfo.UtxoValueBytes))
 
 	unsignedTransaction, err := constructUnsignedTransaction(
 		fundingInfo.TransactionHash,

--- a/pkg/extensions/tbtc/recovery/recovery_test.go
+++ b/pkg/extensions/tbtc/recovery/recovery_test.go
@@ -173,6 +173,11 @@ func TestBuildBitcoinTransaction(t *testing.T) {
 	tbtcHandle.CreateDeposit(depositAddressString, memberAddresses)
 	keep := tbtcHandle.OpenKeep(keepAddress, depositAddress, memberAddresses)
 
+	fundingInfo, err := tbtcHandle.FundingInfo(depositAddress.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	btcAddresses := []string{
 		"1MjCqoLqMZ6Ru64TTtP16XnpSdiE8Kpgcx",
 		"3EktnHQD7RiAE6uzMj2ZifT9YgRrkSgzQX",
@@ -224,7 +229,7 @@ func TestBuildBitcoinTransaction(t *testing.T) {
 				ctx,
 				networkProvider,
 				localChain,
-				tbtcHandle,
+				fundingInfo,
 				keep,
 				signer,
 				&chaincfg.MainNetParams,

--- a/pkg/extensions/tbtc/recovery/recovery_test.go
+++ b/pkg/extensions/tbtc/recovery/recovery_test.go
@@ -230,7 +230,6 @@ func TestBuildBitcoinTransaction(t *testing.T) {
 				networkProvider,
 				localChain,
 				fundingInfo,
-				keep,
 				signer,
 				&chaincfg.MainNetParams,
 				btcAddresses,


### PR DESCRIPTION
According to [RFC-2](https://github.com/keep-network/keep-ecdsa/blob/master/docs/rfc/rfc-2.adoc#dealing-with-the-bitcoin-fee) fee suggested by Bitcoin handle should be compared with max fee configured by the operator:

> There is one exception to the rule that the 25-block suggested fee should be used in the presence of a Bitcoin connection. If this suggested fee would result in a fee consuming more than 5% of the UTXO value that is being split, then the lesser of the 25-block suggested fee and MaxFeePerVByte configured fee should be used. Because the true fee computation requires that the full transaction be assembled, the transaction fee should be estimated by assuming the final transaction will be 175 vBytes, which should be very close to accurate given the regular structure of liquidation refund transactions.
If the final fee is computed as being >5% of UTXO value, the client should log a WARN message so that the operator can be aware of this and revise their max fee per vByte if desired.

This PR has couple more improvements that are described in the commits.

Closes: https://github.com/keep-network/keep-ecdsa/issues/857