### PR TITLE
Remove contract artifact folder before copying

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ node_modules/
 # Generated files
 *.abi
 abi/
+artifacts/
 
 # Build output
 build/

--- a/scripts/install-celo.sh
+++ b/scripts/install-celo.sh
@@ -80,6 +80,7 @@ CONTRACT_OWNER_CELO_ACCOUNT_PRIVATE_KEY=$CONTRACT_OWNER_CELO_ACCOUNT_PRIVATE_KEY
   npx truffle migrate --reset --network $NETWORK
 
 printf "${LOG_START}Copying contract artifacts...${LOG_END}"
+rm -rf artifacts
 cp -r build/contracts artifacts
 npm link
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -80,6 +80,7 @@ npm run clean
 npx truffle migrate --reset --network $NETWORK
 
 printf "${LOG_START}Copying contract artifacts...${LOG_END}"
+rm -rf artifacts
 cp -r build/contracts artifacts
 npm link
 npm link @keep-network/keep-core


### PR DESCRIPTION
This PR adds a small change - remove the folder with contract artifact before copying.
Also the `artifacts/` directory is added to `.gitignore`.