### PR TITLE
Update locked sha3 version to 1.2.6

### DIFF
--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -34096,9 +34096,9 @@
       }
     },
     "sha3": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/sha3/-/sha3-1.2.3.tgz",
-      "integrity": "sha512-sOWDZi8cDBRkLfWOw18wvJyNblXDHzwMGnRWut8zNNeIeLnmMRO17bjpLc7OzMuj1ASUgx2IyohzUCAl+Kx5vA==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/sha3/-/sha3-1.2.6.tgz",
+      "integrity": "sha512-KgLGmJGrmNB4JWVsAV11Yk6KbvsAiygWJc7t5IebWva/0NukNrjJqhtKhzy3Eiv2AKuGvhZZt7dt1mDo7HkoiQ==",
       "requires": {
         "nan": "2.13.2"
       },


### PR DESCRIPTION
In this PR we updated version of `sha3` in `package-lock.json` file to `1.2.6`, as the previous version was erroring node-gyp in npm install on Node 14.