### PR TITLE
Add missing `TBTCSystem.json` copy

### DIFF
--- a/infrastructure/kube/templates/keep-ecdsa/initcontainer/provision-keep-ecdsa/Dockerfile
+++ b/infrastructure/kube/templates/keep-ecdsa/initcontainer/provision-keep-ecdsa/Dockerfile
@@ -15,6 +15,8 @@ COPY ./TokenStaking.json /tmp/TokenStaking.json
 
 COPY ./KeepToken.json /tmp/KeepToken.json
 
+COPY ./TBTCSystem.json /tmp/TBTCSystem.json
+
 COPY ./keep-ecdsa-config-template.toml /tmp/keep-ecdsa-config-template.toml
 
 COPY ./provision-keep-ecdsa.js /tmp/provision-keep-ecdsa.js


### PR DESCRIPTION
Since we use that artifact in the provisioning script, it must be copied in the Dockerfile as well. Follow-up to #873