### PR TITLE
Bitcoin config cleanup

### DIFF
--- a/pkg/chain/bitcoin/config.go
+++ b/pkg/chain/bitcoin/config.go
@@ -58,6 +58,10 @@ func (c Config) ChainParams() (*chaincfg.Params, error) {
 // letting a user connect to the node of their choice.
 func (c Config) ElectrsURLWithDefault() string {
 	if c.ElectrsURL == nil {
+		if c.BitcoinChainName == "testnet3" {
+			return "https://blockstream.info/testnet/api/"
+		}
+
 		return "https://blockstream.info/api/"
 	}
 	return *c.ElectrsURL

--- a/pkg/chain/config.go
+++ b/pkg/chain/config.go
@@ -1,23 +1,7 @@
 package chain
 
-import "github.com/keep-network/keep-ecdsa/pkg/chain/bitcoin"
-
 // Config stores configuration of application extension responsible for
 // executing signer actions specific for TBTC application.
 type Config struct {
 	TBTCSystem string
-	ElectrsURL *string
-	BTCRefunds bitcoin.Config
-}
-
-// ElectrsURLWithDefault dereferences ElectrsURL in the following way: if there
-// is a configured value, use it. Otherwise, default to
-// https://blockstream.info/api/. This allows us to add bitcoin connection
-// functionality to nodes that haven't made config changes yet while also
-// letting a user connect to the node of their choice.
-func (c Config) ElectrsURLWithDefault() string {
-	if c.ElectrsURL == nil {
-		return "https://blockstream.info/api/"
-	}
-	return *c.ElectrsURL
 }


### PR DESCRIPTION
In b0e7a25 we decided to move the bitcoin specific config to `bitcoin.Config, but looks like we didn't remove the old code. Here we clean it up.

We also resolve the default Bitcoin endpoint to use based on the `BitcoinChainName` property. For `testnet3` we use Blockstream's  testnet endpoint, and in other cases we use Blockstream's mainnet endpoint.