### PR TITLE
Move :icons: line to the top of the file

### DIFF
--- a/docs/infrastructure.adoc
+++ b/docs/infrastructure.adoc
@@ -1,8 +1,8 @@
 :toc: macro
+:icons: font
 
 = Infrastructure
 
-:icons: font
 :numbered:
 toc::[]
 

--- a/docs/network-troubleshooting.adoc
+++ b/docs/network-troubleshooting.adoc
@@ -1,8 +1,8 @@
 :toc: macro
+:icons: font
 
 = Network troubleshooting
 
-:icons: font
 :numbered:
 toc::[]
 
@@ -133,12 +133,3 @@ If none of the above points solve the issue you're observing, reaching out
 the https://discord.keep.network[Keep Discord] is a good next step. Describe
 the problem and provide as much details as you can. Some debug logs would be
 also appreciated.
-
-
-
-
-
-
-
-
-

--- a/docs/run-keep-ecdsa.adoc
+++ b/docs/run-keep-ecdsa.adoc
@@ -1,9 +1,9 @@
 :toc: macro
+:icons: font
 :source-highlighter: rouge
 
 = Run ECDSA Keep
 
-:icons: font
 :numbered:
 toc::[]
 

--- a/docs/tbtc-liquidation-recovery.adoc
+++ b/docs/tbtc-liquidation-recovery.adoc
@@ -1,4 +1,5 @@
 :toc: macro
+:icons: font
 :source-highlighter: rouge
 
 = tBTC Liquidation Recovery
@@ -11,7 +12,6 @@ ifdef::env-github[]
 :warning-caption: :warning:
 endif::[]
 
-:icons: font
 :numbered:
 toc::[]
 


### PR DESCRIPTION
The line should be placed on the top of the file so the icons are rendered correctly.

Please see: https://docs.keep.network/ecdsa/docs-icons/tbtc-liquidation-recovery.html