### PR TITLE
Copy images to HTML output directory

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - "docs/**"
+      - "./.github/workflows/docs.yml"
   pull_request:
   workflow_dispatch:
 
@@ -24,6 +25,7 @@ jobs:
           filters: |
             path-filter:
               - './docs/**'
+              - './.github/workflows/docs.yml'
 
   # TODO: Add generation of Solidity documentation
 


### PR DESCRIPTION
asciidoctor-action generates html files to the output directory, we also
want to include images in the published folder so we need to copy the
`img` directory.

See preview: https://docs.keep.network/ecdsa/docs-img/tbtc-liquidation-recovery.html