### PR TITLE
Remove `./` from the workflow file path

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,7 +6,7 @@ on:
       - main
     paths:
       - "docs/**"
-      - "./.github/workflows/docs.yml"
+      - ".github/workflows/docs.yml"
   pull_request:
   workflow_dispatch:
 


### PR DESCRIPTION
It seems redundant. More importantly, this PR is another try to invoke the workflow on the main merge.