### PR TITLE
Fix passing of version in the `Notify CI...` step

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -222,4 +222,4 @@ jobs:
           environment: ${{ github.event.inputs.environment }}
           upstream_builds: ${{ github.event.inputs.upstream_builds }}
           upstream_ref: ${{ github.event.inputs.upstream_ref }}
-          version: ${{ needs.contracts-migrate-and-publish.outputs.version }}
+          version: ${{ steps.npm-version-bump.outputs.version }}


### PR DESCRIPTION
Due to a mistake during merging of branches we ended up with the
incorrect change going into `main` branch. Bringing back the correct
implementation.