### PR TITLE
Reference the chain in the container image name

### DIFF
--- a/infrastructure/kube/keep-test/ethereum/keep-ecdsa-0-statefulset.yaml
+++ b/infrastructure/kube/keep-test/ethereum/keep-ecdsa-0-statefulset.yaml
@@ -47,7 +47,7 @@ spec:
     spec:
       containers:
         - name: keep-ecdsa
-          image: gcr.io/keep-test-f3e0/keep-ecdsa
+          image: gcr.io/keep-test-f3e0/keep-ecdsa-ethereum
           imagePullPolicy: Always
           ports:
             - containerPort: 3919

--- a/infrastructure/kube/keep-test/ethereum/keep-ecdsa-1-statefulset.yaml
+++ b/infrastructure/kube/keep-test/ethereum/keep-ecdsa-1-statefulset.yaml
@@ -47,7 +47,7 @@ spec:
     spec:
       containers:
         - name: keep-ecdsa
-          image: gcr.io/keep-test-f3e0/keep-ecdsa
+          image: gcr.io/keep-test-f3e0/keep-ecdsa-ethereum
           imagePullPolicy: Always
           ports:
             - containerPort: 3919

--- a/infrastructure/kube/keep-test/ethereum/keep-ecdsa-2-statefulset.yaml
+++ b/infrastructure/kube/keep-test/ethereum/keep-ecdsa-2-statefulset.yaml
@@ -47,7 +47,7 @@ spec:
     spec:
       containers:
         - name: keep-ecdsa
-          image: gcr.io/keep-test-f3e0/keep-ecdsa
+          image: gcr.io/keep-test-f3e0/keep-ecdsa-ethereum
           imagePullPolicy: Always
           ports:
             - containerPort: 3919

--- a/infrastructure/kube/keep-test/ethereum/keep-ecdsa-3-statefulset.yaml
+++ b/infrastructure/kube/keep-test/ethereum/keep-ecdsa-3-statefulset.yaml
@@ -47,7 +47,7 @@ spec:
     spec:
       containers:
         - name: keep-ecdsa
-          image: gcr.io/keep-test-f3e0/keep-ecdsa
+          image: gcr.io/keep-test-f3e0/keep-ecdsa-ethereum
           imagePullPolicy: Always
           ports:
             - containerPort: 3919

--- a/infrastructure/kube/keep-test/ethereum/keep-ecdsa-4-statefulset.yaml
+++ b/infrastructure/kube/keep-test/ethereum/keep-ecdsa-4-statefulset.yaml
@@ -47,7 +47,7 @@ spec:
     spec:
       containers:
         - name: keep-ecdsa
-          image: gcr.io/keep-test-f3e0/keep-ecdsa
+          image: gcr.io/keep-test-f3e0/keep-ecdsa-ethereum
           imagePullPolicy: Always
           ports:
             - containerPort: 3919

--- a/infrastructure/kube/keep-test/ethereum/keep-ecdsa-5-statefulset.yaml
+++ b/infrastructure/kube/keep-test/ethereum/keep-ecdsa-5-statefulset.yaml
@@ -47,7 +47,7 @@ spec:
     spec:
       containers:
         - name: keep-ecdsa
-          image: gcr.io/keep-test-f3e0/keep-ecdsa
+          image: gcr.io/keep-test-f3e0/keep-ecdsa-ethereum
           imagePullPolicy: Always
           ports:
             - containerPort: 3919

--- a/infrastructure/kube/keep-test/ethereum/keep-ecdsa-6-statefulset.yaml
+++ b/infrastructure/kube/keep-test/ethereum/keep-ecdsa-6-statefulset.yaml
@@ -47,7 +47,7 @@ spec:
     spec:
       containers:
         - name: keep-ecdsa
-          image: gcr.io/keep-test-f3e0/keep-ecdsa
+          image: gcr.io/keep-test-f3e0/keep-ecdsa-ethereum
           imagePullPolicy: Always
           ports:
             - containerPort: 3919

--- a/infrastructure/kube/keep-test/ethereum/keep-ecdsa-7-statefulset.yaml
+++ b/infrastructure/kube/keep-test/ethereum/keep-ecdsa-7-statefulset.yaml
@@ -47,7 +47,7 @@ spec:
     spec:
       containers:
         - name: keep-ecdsa
-          image: gcr.io/keep-test-f3e0/keep-ecdsa
+          image: gcr.io/keep-test-f3e0/keep-ecdsa-ethereum
           imagePullPolicy: Always
           ports:
             - containerPort: 3919

--- a/infrastructure/kube/keep-test/ethereum/keep-ecdsa-8-statefulset.yaml
+++ b/infrastructure/kube/keep-test/ethereum/keep-ecdsa-8-statefulset.yaml
@@ -47,7 +47,7 @@ spec:
     spec:
       containers:
         - name: keep-ecdsa
-          image: gcr.io/keep-test-f3e0/keep-ecdsa
+          image: gcr.io/keep-test-f3e0/keep-ecdsa-ethereum
           imagePullPolicy: Always
           ports:
             - containerPort: 3919

--- a/infrastructure/kube/keep-test/ethereum/keep-ecdsa-9-statefulset.yaml
+++ b/infrastructure/kube/keep-test/ethereum/keep-ecdsa-9-statefulset.yaml
@@ -47,7 +47,7 @@ spec:
     spec:
       containers:
         - name: keep-ecdsa
-          image: gcr.io/keep-test-f3e0/keep-ecdsa
+          image: gcr.io/keep-test-f3e0/keep-ecdsa-ethereum
           imagePullPolicy: Always
           ports:
             - containerPort: 3919


### PR DESCRIPTION
Since the merge of PR #823 the container image name contains a suffix
reflecting the chain for which it's configured. We need to update the
kubernetes configs to reflect that change.