### PR TITLE
Add --save-exact to npm update for dev package

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-node@v2
         with:
-          node-version: "12.x"
+          node-version: "14.x"
           registry-url: "https://registry.npmjs.org"
 
       - name: Cache node modules

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -66,4 +66,4 @@ jobs:
       - name: Publish package
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public
+        run: npm publish --access public --tag development

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Resolve latest contracts
         working-directory: ./solidity
         run: |
-          npm update \
+          npm update --save-exact \
             @keep-network/keep-core \
             @keep-network/sortition-pools
 


### PR DESCRIPTION
If we run `npm update` a dependency version is resolved and changed in
`package.json` to a value prefixed with carrot e.g. `^1.8.0-dev.0` which
causes problems when resolving versions in other packages using this
package. We want to have an exact version resolved and stored for
publication.