### PR TITLE
Don't use unathenticated git protocol

### DIFF
--- a/staker-rewards/package-lock.json
+++ b/staker-rewards/package-lock.json
@@ -779,7 +779,7 @@
       "resolved": "https://registry.npmjs.org/@celo/utils/-/utils-0.1.11.tgz",
       "integrity": "sha512-i3oK1guBxH89AEBaVA1d5CHnANehL36gPIcSpPBWiYZrKTGGVvbwNmVoaDwaKFXih0N22vXQAf2Rul8w5VzC3w==",
       "requires": {
-        "@umpirsky/country-list": "git://github.com/umpirsky/country-list.git#05fda51",
+        "@umpirsky/country-list": "git+https://github.com/umpirsky/country-list.git#05fda51",
         "bigi": "^1.1.0",
         "bignumber.js": "^9.0.0",
         "bip32": "2.0.5",
@@ -1142,8 +1142,8 @@
       }
     },
     "@keep-network/tbtc.js": {
-      "version": "git://github.com/keep-network/tbtc.js.git#4da9d668f589310c2b5ff985143f27d29a7f7e61",
-      "from": "git://github.com/keep-network/tbtc.js.git#4da9d668f589310c2b5ff985143f27d29a7f7e61",
+      "version": "git+https://github.com/keep-network/tbtc.js.git#4da9d668f589310c2b5ff985143f27d29a7f7e61",
+      "from": "git:/git+https://github.com/keep-network/tbtc.js.git#4da9d668f589310c2b5ff985143f27d29a7f7e61",
       "requires": {
         "@keep-network/keep-ecdsa": "1.2.1",
         "@keep-network/tbtc": "1.1.0",
@@ -1638,8 +1638,8 @@
       }
     },
     "@umpirsky/country-list": {
-      "version": "git://github.com/umpirsky/country-list.git#05fda51cd97b3294e8175ffed06104c44b3c71d7",
-      "from": "git://github.com/umpirsky/country-list.git#05fda51"
+      "version": "git+https://github.com/umpirsky/country-list.git#05fda51cd97b3294e8175ffed06104c44b3c71d7",
+      "from": "git+https://github.com/umpirsky/country-list.git#05fda51"
     },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",

--- a/staker-rewards/package.json
+++ b/staker-rewards/package.json
@@ -18,7 +18,7 @@
     "@0x/subproviders": "^6.2.0",
     "@keep-network/keep-core": "^1.4.1",
     "@keep-network/keep-ecdsa": "1.3.1",
-    "@keep-network/tbtc.js": "git://github.com/keep-network/tbtc.js.git#4da9d668f589310c2b5ff985143f27d29a7f7e61",
+    "@keep-network/tbtc.js": "git+https://github.com/keep-network/tbtc.js.git#4da9d668f589310c2b5ff985143f27d29a7f7e61",
     "bignumber.js": "^9.0.1",
     "cli-color": "^2.0.0",
     "lowdb": "^1.0.0",


### PR DESCRIPTION
GitHub is no longer allowing for referencing the dependencies using
`git://` protocol. Instead `git@` should be used.
Without the change, `npm ci` executed in GitHub Actions workflows
results with ` The unauthenticated git protocol on port 9418 is no
longer supported.` error.
More info:
https://github.blog/2021-09-01-improving-git-protocol-security-github/.

Ref:
https://github.com/keep-network/tbtc/pull/839
https://github.com/keep-network/tbtc.js/pull/144