### PR TITLE
Update queries for `keep-core-contracts-version`

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -129,7 +129,7 @@ jobs:
         with:
           upstream-builds: ${{ github.event.inputs.upstream_builds }}
           query: |
-            keep-core-contracts-version = github.com/keep-network/keep-core/solidity#version
+            keep-core-contracts-version = github.com/keep-network/keep-core/solidity-v1#version
 
       - name: Resolve latest contracts
         run: |

--- a/.github/workflows/initcontainer.yml
+++ b/.github/workflows/initcontainer.yml
@@ -56,7 +56,7 @@ jobs:
         with:
           upstream-builds: ${{ github.event.inputs.upstream_builds }}
           query: |
-            keep-core-contracts-version = github.com/keep-network/keep-core/solidity#version
+            keep-core-contracts-version = github.com/keep-network/keep-core/solidity-v1#version
             keep-ecdsa-contracts-version = github.com/keep-network/keep-ecdsa/solidity#version
             tbtc-contracts-version = github.com/keep-network/tbtc/solidity#version
 


### PR DESCRIPTION
Queries updated after change of structure in `keep-core` (renaming
`solidity` to `solidity-v1`) resulting in update of the name of the
module with `keep-core` v1 contracts.

Ref:
https://github.com/keep-network/keep-core/pull/2610
https://github.com/keep-network/ci/pull/21