### PR TITLE
Unify CI workflows

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -119,6 +119,7 @@ jobs:
           node-version: "14.x"
           cache: "npm"
           cache-dependency-path: solidity/package-lock.json
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: npm ci
@@ -180,9 +181,9 @@ jobs:
           version-tag: ${{ steps.npm-version-bump.outputs.version }}
 
       - name: Publish to npm
-        run: |
-          echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }} > .npmrc
-          npm publish --access=public --tag ${{ github.event.inputs.environment }}
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access=public --tag ${{ github.event.inputs.environment }}
 
       - name: Notify CI about completion of the workflow
         uses: keep-network/ci/actions/notify-workflow-completed@v1

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -182,7 +182,7 @@ jobs:
       - name: Publish to npm
         run: |
           echo //registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }} > .npmrc
-          npm publish --access=public
+          npm publish --access=public --tag ${{ github.event.inputs.environment }}
 
       - name: Notify CI about completion of the workflow
         uses: keep-network/ci/actions/notify-workflow-completed@v1

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
   pull_request:
+  workflow_dispatch:
 
 jobs:
   code-format:

--- a/.github/workflows/initcontainer.yml
+++ b/.github/workflows/initcontainer.yml
@@ -32,23 +32,8 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "14.x"
-
-      # In the future we could switch to using cache functionality built-in to
-      # the `setup-node` action. Right now the functionality does not support
-      # cases when package.json resides outside of the root directory, but there's
-      # an open issue (https://github.com/actions/setup-node/issues/275) in the
-      # works for that.
-      - name: Cache node modules
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-solidity-node-modules
-        with:
-          path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+          cache: "npm"
+          cache-dependency-path: infrastructure/kube/templates/keep-ecdsa/initcontainer/provision-keep-ecdsa/package-lock.json
 
       - name: Get upstream packages' versions
         uses: keep-network/ci/actions/upstream-builds-query@v1

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -22,19 +22,9 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "14.x"
+          cache: "npm"
+          cache-dependency-path: solidity/package-lock.json
           registry-url: "https://registry.npmjs.org"
-
-      - name: Cache node modules
-        uses: actions/cache@v1
-        env:
-          cache-name: cache-solidity-node-modules
-        with:
-          path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/staker-rewards.yml
+++ b/.github/workflows/staker-rewards.yml
@@ -42,18 +42,8 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: "14.x"
-
-      - name: Cache node modules
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-solidity-node-modules
-        with:
-          path: ~/.npm # npm cache files are stored in `~/.npm` on Linux/macOS
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+          cache: "npm"
+          cache-dependency-path: staker-rewards/package-lock.json
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
We have CI workflows scattered across various repositories. We try to keep their implementation as similar as possible. In this PR and the ones listed below we introduce a couple of changes which unify used solutions and fix small mistakes, such as:
* making tagging of published packages consistent
* passing `NPM_TOKEN` secret as variable instead of passing it by writing to file
* handling caching of npm/yarn dependencies via `setup-node` action
* adding `workflow_dispatch` job trigger where it's missing
* using Node.js in version 14.x instead of 12.x where possible

Related PRs in other repositories:
* https://github.com/keep-network/keep-core/pull/2776
* https://github.com/keep-network/tbtc/pull/842
* https://github.com/keep-network/tbtc.js/pull/145
* https://github.com/keep-network/sortition-pools/pull/145
* https://github.com/keep-network/local-setup/pull/124
* https://github.com/keep-network/coverage-pools/pull/204
* https://github.com/keep-network/tbtc-v2/pull/88
* https://github.com/threshold-network/solidity-contracts/pull/59