### PR TITLE
Fix ignore comment for PasswordEnvVariable gosec

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -15,10 +15,7 @@ import (
 )
 
 // PasswordEnvVariable environment variable name for ethereum key password.
-// #nosec G101 (look for hardcoded credentials)
-// This line doesn't contain any credentials.
-// It's just the name of the environment variable.
-const PasswordEnvVariable = "KEEP_ETHEREUM_PASSWORD"
+const PasswordEnvVariable = "KEEP_ETHEREUM_PASSWORD" // #nosec G101 -- it's just env variable name
 
 // Config is the top level config structure.
 type Config struct {


### PR DESCRIPTION
gosec command doesn't ignore the line if `// #nosec` is not in the first
comment line. So what would work is:
```
// #nosec G101 (look for hardcoded credentials)
// This line doesn't contain any credentials.
// It's just the name of the environment variable.
// PasswordEnvVariable environment variable name for ethereum key password.
const PasswordEnvVariable = "KEEP_ETHEREUM_PASSWORD"
```
But this makes go lint fail with `exported const PasswordEnvVariable
should have a comment or be unexported`.

The solution in this PR makes both golint and gosec work.