### PR TITLE
Using fixed version of sortition-pools package

### DIFF
--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -134,7 +134,6 @@ jobs:
 
       - name: Resolve latest contracts
         run: |
-          npm update @keep-network/sortition-pools
           npm install --save-exact \
             @keep-network/keep-core@${{ steps.upstream-builds-query.outputs.keep-core-contracts-version }}
 

--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -32,9 +32,7 @@ jobs:
       - name: Resolve latest contracts
         working-directory: ./solidity
         run: |
-          npm update --save-exact \
-            @keep-network/keep-core \
-            @keep-network/sortition-pools
+          npm update --save-exact @keep-network/keep-core
 
       - name: Compile contracts
         run: npx truffle compile

--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -4760,10 +4760,15 @@
         }
       }
     },
+    "@keep-network/prettier-config-keep": {
+      "version": "github:keep-network/prettier-config-keep#a1a333e7ac49928a0f6ed39421906dd1e46ab0f3",
+      "from": "github:keep-network/prettier-config-keep",
+      "dev": true
+    },
     "@keep-network/sortition-pools": {
-      "version": "1.2.0-dev.0",
-      "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-1.2.0-dev.0.tgz",
-      "integrity": "sha512-HWmHrVHsVOJQc7dLm6+LFPUXrSqffoB/zAGs6lvnln/zqI0bvCv6hdxlGIVErKn6GOAx3MuwERzZkDBXlzVhaw==",
+      "version": "1.2.0-dev.1",
+      "resolved": "https://registry.npmjs.org/@keep-network/sortition-pools/-/sortition-pools-1.2.0-dev.1.tgz",
+      "integrity": "sha512-CaOsvxNWHgXRFwPThDn3C/LiCwq9pL8ICLXXkysRSLw1Hx69wLnToaXYuwyXeIEy5pGqe5+288DBIqvJ3T4+jA==",
       "requires": {
         "@openzeppelin/contracts": "^2.4.0"
       }
@@ -13890,19 +13895,22 @@
       "from": "git+https://github.com/keep-network/eslint-config-keep.git",
       "dev": true,
       "requires": {
+        "@keep-network/prettier-config-keep": "github:keep-network/prettier-config-keep",
         "eslint-config-google": "^0.13.0",
         "eslint-config-prettier": "^6.15.0",
         "eslint-plugin-no-only-tests": "^2.3.1",
         "eslint-plugin-prettier": "^3.1.2"
-      }
-    },
-    "eslint-config-prettier": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.11.0.tgz",
-      "integrity": "sha512-oB8cpLWSAjOVFEJhhyMZh6NOEOtBVziaqdDQ86+qhDHFbZXoRTM7pNSvFRfW/W/L/LrQ38C99J5CGuRBBzBsdA==",
-      "dev": true,
-      "requires": {
-        "get-stdin": "^6.0.0"
+      },
+      "dependencies": {
+        "eslint-config-prettier": {
+          "version": "6.15.0",
+          "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz",
+          "integrity": "sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==",
+          "dev": true,
+          "requires": {
+            "get-stdin": "^6.0.0"
+          }
+        }
       }
     },
     "eslint-plugin-no-only-tests": {

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/keep-network/keep-ecdsa",
   "dependencies": {
     "@keep-network/keep-core": ">1.8.0-dev <1.8.0-pre",
-    "@keep-network/sortition-pools": ">1.2.0-dev <1.2.0-pre",
+    "@keep-network/sortition-pools": "^1.2.0-dev.1",
     "@openzeppelin/upgrades": "^2.7.2",
     "openzeppelin-solidity": "2.3.0"
   },

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -29,7 +29,7 @@
   "homepage": "https://github.com/keep-network/keep-ecdsa",
   "dependencies": {
     "@keep-network/keep-core": ">1.8.0-dev <1.8.0-pre",
-    "@keep-network/sortition-pools": "^1.2.0-dev.1",
+    "@keep-network/sortition-pools": "1.2.0-dev.1",
     "@openzeppelin/upgrades": "^2.7.2",
     "openzeppelin-solidity": "2.3.0"
   },


### PR DESCRIPTION
The `keep-ecdsa` contracts depend on some `sortition-pools` contracts
which are no longer present in the latest npm packages (this is due to
transision to v2). Until we stop supporting `keep-ecdsa` repo
& contracts, we need to configure there the dependncy to the latest
`sortition-pools` package which contains the required contracts. This
is package `@keep-network/sortition-pools@1.2.0-dev.1`.