### PR TITLE
Bumping smart contracts version to v1.9.0-dev

### DIFF
--- a/solidity/package-lock.json
+++ b/solidity/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "1.8.0-dev",
+  "version": "1.9.0-dev",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@keep-network/keep-ecdsa",
-  "version": "1.8.0-dev",
+  "version": "1.9.0-dev",
   "description": "Smart contracts for ECDSA Keep",
   "repository": "ssh://git@github.com/keep-network/keep-ecdsa.git",
   "files": [


### PR DESCRIPTION
Version increased after `solidity/v1.8.0` release.

Refs #944