### PR TITLE
Deploy LPRewardsTBTCv2SaddleV2 contract to the network

### DIFF
--- a/solidity/migrations/2_deploy_contracts.js
+++ b/solidity/migrations/2_deploy_contracts.js
@@ -27,6 +27,7 @@ const LPRewardsKEEPETH = artifacts.require("LPRewardsKEEPETH")
 const LPRewardsKEEPTBTC = artifacts.require("LPRewardsKEEPTBTC")
 const LPRewardsTBTCSaddle = artifacts.require("LPRewardsTBTCSaddle")
 const LPRewardsTBTCv2Saddle = artifacts.require("LPRewardsTBTCv2Saddle")
+const LPRewardsTBTCv2SaddleV2 = artifacts.require("LPRewardsTBTCv2SaddleV2")
 const TestToken = artifacts.require("./test/TestToken")
 const ECDSARewards = artifacts.require("ECDSARewards")
 const ECDSARewardsDistributor = artifacts.require("ECDSARewardsDistributor")
@@ -171,6 +172,13 @@ module.exports = async function (deployer, network) {
     LPRewardsTBTCv2Saddle,
     KeepTokenAddress,
     WrappedTokenTBTCv2Saddle.address
+  )
+
+  const WrappedTokenTBTCv2SaddleV2 = await deployer.deploy(TestToken)
+  await deployer.deploy(
+    LPRewardsTBTCv2SaddleV2,
+    KeepTokenAddress,
+    WrappedTokenTBTCv2SaddleV2.address
   )
 
   // ECDSA Rewards

--- a/solidity/scripts/liquidity-rewards-starter.js
+++ b/solidity/scripts/liquidity-rewards-starter.js
@@ -3,6 +3,7 @@ const LPRewardsKEEPETH = artifacts.require("LPRewardsKEEPETH")
 const LPRewardsKEEPTBTC = artifacts.require("LPRewardsKEEPTBTC")
 const LPRewardsTBTCSaddle = artifacts.require("LPRewardsTBTCSaddle")
 const LPRewardsTBTCv2Saddle = artifacts.require("LPRewardsTBTCv2Saddle")
+const LPRewardsTBTCv2SaddleV2 = artifacts.require("LPRewardsTBTCv2SaddleV2")
 
 const TestToken = artifacts.require("./test/TestToken")
 const KeepToken = artifacts.require(
@@ -67,6 +68,7 @@ module.exports = async function () {
       LPRewardsKEEPTBTC,
       LPRewardsTBTCSaddle,
       LPRewardsTBTCv2Saddle,
+      LPRewardsTBTCv2SaddleV2,
     ]
 
     for (const LPRewardsContract of LPRewardsContracts) {


### PR DESCRIPTION
Ref: https://github.com/keep-network/keep-core/pull/2781

Deploys `LPRewardsTBTCv2SaddleV2` contract via trffle migration script and
updates `liquidity-rewards-starter.js` script.