### PR TITLE
Verify `LPRewardsTBTCv2Saddle` on Etherscan

### DIFF
--- a/solidity/scripts/etherscan-verify.sh
+++ b/solidity/scripts/etherscan-verify.sh
@@ -23,6 +23,8 @@ npx truffle run verify \
     LPRewardsKEEPTBTC \
     LPRewardsTBTCETH \
     LPRewardsTBTCSaddle \
+    LPRewardsTBTCv2Saddle \
+    LPRewardsTBTCv2SaddleV2 \
     Migrations \
     Position \
     StackLib \


### PR DESCRIPTION
As part of deployment process of `keep-ecdsa` contracts via execution of
`.github/workflows/contracts.yml` workflow we run a script which
verifies deployed contracts on Etherscan
(`solidity/scripts/etherscan-verify.sh`).
We recently added new contracts (`LPRewardsTBTCv2Saddle`,
`LPRewardsTBTCv2SaddleV2`) to the set of `keep-ecdsa` contracts that can
be deployed and we're now adding it to the `etherscan-verify.sh` script.