### PR TITLE
Update `tss-lib` dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ replace (
 	github.com/btcsuite/btcd => github.com/keep-network/btcd v0.0.0-20190427004231-96897255fd17
 	github.com/btcsuite/btcutil => github.com/keep-network/btcutil v0.0.0-20210527170813-e2ba6805a890
 	github.com/urfave/cli => github.com/keep-network/cli v1.20.0
-	github.com/binance-chain/tss-lib => github.com/keep-network/tss-lib v1.3.3-0.20211215091450-8afce0f07c9f // Branch: v1.3.3.keep
+	github.com/binance-chain/tss-lib => github.com/keep-network/tss-lib v1.3.3-0.20220914135540-bf17762025bf // Branch: v1.3.4.keep
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -502,8 +502,8 @@ github.com/keep-network/tbtc v1.1.1-0.20211005102550-e0f035c575a2 h1:KUkq7+GLFoi
 github.com/keep-network/tbtc v1.1.1-0.20211005102550-e0f035c575a2/go.mod h1:POTeEzpqsuuK9Hng5tbLLJckmfGAQqtVUoCpW0PkuJU=
 github.com/keep-network/toml v0.3.0 h1:G+NJwWR/ZiORqeLBsDXDchYoL29PXHdxOPcCueA7ctE=
 github.com/keep-network/toml v0.3.0/go.mod h1:Zeyd3lxbIlMYLREho3UK1dMP2xjqt2gLkQ5E5vM6K38=
-github.com/keep-network/tss-lib v1.3.3-0.20211215091450-8afce0f07c9f h1:yeErMU/AgG7R66yo11CD5Wqwm8IYyshRjrq3XvoyJFY=
-github.com/keep-network/tss-lib v1.3.3-0.20211215091450-8afce0f07c9f/go.mod h1:y85qADlz1+q+Eo01GupDnNt68XJDmb6I/jEwAolIHtQ=
+github.com/keep-network/tss-lib v1.3.3-0.20220914135540-bf17762025bf h1:se8JiIikGGG4Et4doGIwNZwWBdNvd34X3338xya3Xmw=
+github.com/keep-network/tss-lib v1.3.3-0.20220914135540-bf17762025bf/go.mod h1:y85qADlz1+q+Eo01GupDnNt68XJDmb6I/jEwAolIHtQ=
 github.com/kilic/bls12-381 v0.0.0-20201226121925-69dacb279461/go.mod h1:vDTTHJONJ6G+P2R74EhnyotQDTliQDnFEwhdmfzw1ig=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=


### PR DESCRIPTION
Bump up the version of the forked `tss-lib` dependency from version `v1.3.3.keep` to the latest `v1.3.4.keep`.