### PR TITLE
Cleanup of v1-related GH Actions workflows

### DIFF
--- a/.github/workflows/client.yml
+++ b/.github/workflows/client.yml
@@ -1,8 +1,6 @@
 name: Go
 
 on:
-  schedule:
-    - cron: "0 0 * * *"
   push:
     branches:
       - main

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -1,8 +1,6 @@
 name: Solidity
 
 on:
-  schedule:
-    - cron: "0 0 * * *"
   push:
     branches:
       - main

--- a/.github/workflows/staker-rewards.yml
+++ b/.github/workflows/staker-rewards.yml
@@ -1,8 +1,6 @@
 name: Staker Rewards
 
 on:
-  schedule:
-    - cron: "0 0 * * *"
   push:
     branches:
       - main


### PR DESCRIPTION
We're no longer adding new functionalities to the `keep-ecdsa` code, as this repository is related to the `v1` of the system and is no longer used in `v2`. There is no need to run the code-checking workflows every night.